### PR TITLE
Log hydra job config to tensorboard

### DIFF
--- a/lightning_pose/train.py
+++ b/lightning_pose/train.py
@@ -80,6 +80,11 @@ def train(cfg: DictConfig) -> None:
 
     # logger
     logger = pl.loggers.TensorBoardLogger("tb_logs", name=cfg.model.model_name)
+    # Log hydra config to tensorboard as helpful metadata.
+    for key, value in cfg.items():
+        logger.experiment.add_text(
+            "hydra_config_%s" % key, "```\n%s```" % OmegaConf.to_yaml(value)
+        )
 
     # early stopping, learning rate monitoring, model checkpointing, backbone unfreezing
     callbacks = get_callbacks(


### PR DESCRIPTION
This allows you to see what config was associated with a run in tensorboard. 
To access the new logged data, you have to go to the text tab. 
Screenshots:
![image](https://github.com/user-attachments/assets/cdfd6ca3-6c8a-4251-9b09-68fc23841260)
![image](https://github.com/user-attachments/assets/1f4cdfbc-640e-49c6-babd-b89a90777a4d)
