### PR TITLE
Change backbone finetuning strategy to allow for DDP

### DIFF
--- a/lightning_pose/callbacks.py
+++ b/lightning_pose/callbacks.py
@@ -42,3 +42,73 @@ class AnnealWeight(Callback):
             # Dan: removed buffer; seems to complicate checkpoint loading
             # pl_module.register_buffer(self.attr_name, torch.tensor(value))
             setattr(pl_module, self.attr_name, torch.tensor(value))
+
+
+class UnfreezeBackbone(Callback):
+    """Callback that ramps up the backbone learning rate from 0 to `upsampling_lr` on
+    `unfreeze_epoch`.
+
+    Starts LR at `initial_ratio * upsampling_lr`. Grows lr by a factor of `epoch_ratio` per
+    epoch. Once LR reaches `upsampling_lr`, keeps it in sync with `upsampling_lr`.
+
+    Use instead of pl.callbacks.BackboneFinetuning in order to use multi-GPU (DDP). See
+    lightning-ai/pytorch-lightning#20340 for context.
+    """
+
+    def __init__(
+        self,
+        unfreeze_epoch,
+        initial_ratio=0.1,
+        epoch_ratio=1.5,
+    ):
+        self.unfreeze_epoch = unfreeze_epoch
+        self.initial_ratio = initial_ratio
+        self.epoch_ratio = epoch_ratio
+        self._warmed_up = False
+
+    def on_train_epoch_start(self, trainer, pl_module):
+        # This callback is only applicable to heatmap models but we
+        # might encounter a RegressionModel.
+        if not hasattr(pl_module, "upsampling_layers"):
+            return
+        
+        # Once backbone_lr warms up to upsampling_lr, this callback does nothing.
+        # Control of backbone lr is then the sole job of the main lr scheduler.
+        if self._warmed_up:
+            return
+
+        optimizer = pl_module.optimizers()
+        # Check our assumptions about param group indices
+        assert optimizer.param_groups[0]["name"] == "backbone"
+        assert optimizer.param_groups[1]["name"].startswith("upsampling")
+
+        upsampling_lr = optimizer.param_groups[1]["lr"]
+
+        optimizer.param_groups[0]["lr"] = self._get_backbone_lr(
+            pl_module.current_epoch, upsampling_lr
+        )
+
+    def _get_backbone_lr(self, current_epoch, upsampling_lr):
+        assert not self._warmed_up
+
+        # Before unfreeze, learning_rate is 0.
+        if current_epoch < self.unfreeze_epoch:
+            return 0.0
+
+        # On unfreeze, initialize learning rate.
+        # Remember this initial value for warm up.
+        if current_epoch == self.unfreeze_epoch:
+            self._initial_lr = self.initial_ratio * upsampling_lr
+            return self._initial_lr
+
+        # Warm up: compute inital_ratio * epoch_ratio ** epochs_since_thaw.
+        # Use stored initial_ratio rather than recomputing it since
+        # upsampling_lr is subject to change via the scheduler.
+        if current_epoch > self.unfreeze_epoch:
+            epochs_since_thaw = current_epoch - self.unfreeze_epoch
+            next_lr = min(
+                self._initial_lr * self.epoch_ratio**epochs_since_thaw, upsampling_lr
+            )
+            if next_lr == upsampling_lr:
+                self._warmed_up = True
+            return next_lr

--- a/lightning_pose/models/heatmap_tracker_mhcrnn.py
+++ b/lightning_pose/models/heatmap_tracker_mhcrnn.py
@@ -251,12 +251,12 @@ class HeatmapTrackerMHCRNN(HeatmapTracker):
 
     def get_parameters(self):
         params = [
-            # don't uncomment line below
-            # the BackboneFinetuning callback should add backbone to the params.
-            # {"params": self.backbone.parameters()},
-            # important this is the 0th element, for BackboneFinetuning callback
-            {"params": self.upsampling_layers_rnn.parameters()},
-            {"params": self.upsampling_layers_sf.parameters()},
+            {"params": self.backbone.parameters(), "name": "backbone", "lr": 0.0},
+            {
+                "params": self.upsampling_layers_rnn.parameters(),
+                "name": "upsampling_rnn",
+            },
+            {"params": self.upsampling_layers_sf.parameters(), "name": "upsampling_sf"},
         ]
         return params
 
@@ -360,17 +360,6 @@ class SemiSupervisedHeatmapTrackerMHCRNN(SemiSupervisedTrackerMixin, HeatmapTrac
             "keypoints_pred": torch.cat([pred_keypoints_crnn, pred_keypoints_sf], dim=0),
             "confidences": torch.cat([confidence_crnn, confidence_sf], dim=0),
         }
-
-    def get_parameters(self):
-        params = [
-            # don't uncomment line below
-            # the BackboneFinetuning callback should add backbone to the params.
-            # {"params": self.backbone.parameters()},
-            # important this is the 0th element, for BackboneFinetuning callback
-            {"params": self.upsampling_layers_rnn.parameters()},
-            {"params": self.upsampling_layers_sf.parameters()},
-        ]
-        return params
 
 
 class UpsamplingCRNN(torch.nn.Module):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -528,7 +528,7 @@ def video_dataloader(cfg, base_dataset, video_list) -> LitDaliWrapper:
 def trainer(cfg) -> pl.Trainer:
     """Create a basic pytorch lightning trainer for testing models."""
 
-    cfg.training.unfreezing_epoch = 10  # force no unfreezing to keep memory reqs of tests down
+    cfg.training.unfreezing_epoch = 1 # exercise unfreezing
     callbacks = get_callbacks(cfg, early_stopping=False, lr_monitor=False, backbone_unfreeze=True)
 
     trainer = pl.Trainer(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,29 @@
+from lightning_pose.callbacks import UnfreezeBackbone
+
+
+def test_unfreeze_backbone():
+    unfreeze_backbone = UnfreezeBackbone(2, initial_ratio=0.1, epoch_ratio=1.5)
+
+    # Test unfreezing at epoch 2.
+    assert unfreeze_backbone._get_backbone_lr(0, 1e-3) == 0.0
+    assert unfreeze_backbone._get_backbone_lr(1, 1e-3) == 0.0
+    assert (
+        unfreeze_backbone._get_backbone_lr(2, 1e-3) == 1e-3 * 0.1
+    )  # upsampling_lr * initial_ratio
+
+    # Test warming up.
+    # We thawed at upsampling_lr = 1e-3. Henceforth, backbone_lr should be
+    # agnostic to changes in upsampling_lr so long as we are not fully
+    # "warmed up".
+    assert unfreeze_backbone._get_backbone_lr(3, 1e-3) == 1e-3 * 0.1 * 1.5
+    assert unfreeze_backbone._get_backbone_lr(3, 1.5e-3) == 1e-3 * 0.1 * 1.5
+
+    assert unfreeze_backbone._get_backbone_lr(4, 1e-3) == 1e-4 * 1.5 * 1.5
+    assert unfreeze_backbone._get_backbone_lr(4, 1.5e-3) == 1e-4 * 1.5 * 1.5
+
+    # Once we hit upsampling_lr, set the _warmed_up bit to stop this callback
+    # from setting backbone lr in the future, allowing the normal scheduler to take over.
+    assert not unfreeze_backbone._warmed_up
+    # current_epoch set to some high value to trigger "warmed up" condition
+    assert unfreeze_backbone._get_backbone_lr(15, 1e-3) == 1e-3
+    assert unfreeze_backbone._warmed_up


### PR DESCRIPTION
See lightning-ai/pytorch-lightning#20340 for the original issue. The implemented workaround no longer freezes/unfreezes layers via require_grad, instead we only modulate the learning rate of the backbone layer.

Unblocks #138 
