### PR TITLE
Continuous integration using github actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,20 @@
+name: Run tests
+on:
+  # Allow manually running from Github UI or API.
+  workflow_dispatch:
+  # to re-run status checks, mark as draft then ready_for_review.
+  pull_request:
+    types: [ready_for_review]
+jobs:
+  pytest-ubuntu-22.04:
+    # Ships with python 3.10. Using it saves time installing it.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+#         pip install -e ".[dev]"
+          pip install fiftyone-db-ubuntu2204
+#     - name: Test with pytest
+#       run: |
+#         pytest


### PR DESCRIPTION
The proposed continuous integration workflow runs tests for pull requests, and requires tests to pass before checking in to main (though this can be bypassed). We do not do any recurring builds or deployments.

There are three pieces needed to enable this workflow.
1. A branch protection rule (AKA Rules in repo settings).
2. A Github Action (this PR)
3. A GPU Runner (we need to first upgrade the paninski org to Teams tier).

### Branch protection rule

I added a branch protection rule that requires tests to pass before merging a commit. This rule is disabled right now since the github action is not yet checked in. Please take a look at the settings:
https://github.com/paninski-lab/lightning-pose/settings/rules/2377592

Writers to this repository may bypass the rule - this setting is required to allow us to push to main via command line.  Additionally in Pull requests we will see a checkbox to bypass the check - I don't forsee us needing this but it might be useful while tweaking the CI to get it working.

### Github action

The github action in this PR does not yet run tests since they will fail on the default CPU runner. It will, however, run for free for 2,000 min per month because lightning-pose is a public repo.

The strategy to keep costs down is to only run tests when a PR is marked Ready for Review. This differs from the default which runs tests on PR open, reopen, and change to HEAD. Thus if additional commits are added after the PR opens, tests will not automatically re-run every time. In order to trigger a re-run, mark the PR as Draft and then mark it as Ready for Review. This is required before the PR can be merged.

Ideally there would be a "Run tests" button in the PR, but no such functionality exists. Github provides a way to manually run a github action, `workflow_dispatch`, but it does not work on Pull Requests. It only runs actions on existing branches of the repo.