### PR TITLE
Added option to choose colormap for labelled videos

### DIFF
--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -736,7 +736,7 @@ def load_model_from_checkpoint(
 
 
 @typechecked
-def make_cmap(number_colors: int, cmap: str = "cool"):
+def make_cmap(number_colors: int, cmap: str):
     color_class = plt.cm.ScalarMappable(cmap=cmap)
     C = color_class.to_rgba(np.linspace(0, 1, number_colors))
     colors = (C[:, :3] * 255).astype(np.uint8)
@@ -750,7 +750,7 @@ def create_labeled_video(
     ys_arr: np.ndarray,
     mask_array: Optional[np.ndarray] = None,
     dotsize: int = 4,
-    colormap: str = "cool",
+    colormap: Optional[str] = "cool",
     fps: Optional[float] = None,
     filename: str = "movie.mp4",
     start_time: float = 0.0,

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -756,4 +756,5 @@ def export_predictions_and_labeled_video(
             ys_arr=ys_arr,
             mask_array=mask_array,
             filename=labeled_mp4_file,
+            colormap=cfg.eval.colormap
         )

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -756,5 +756,5 @@ def export_predictions_and_labeled_video(
             ys_arr=ys_arr,
             mask_array=mask_array,
             filename=labeled_mp4_file,
-            colormap=cfg.eval.colormap
+            colormap=colormap=cfg.eval.get("colormap", "cool")
         )

--- a/scripts/configs/config_default.yaml
+++ b/scripts/configs/config_default.yaml
@@ -168,6 +168,10 @@ eval:
   # set to null to skip automatic video prediction from train_hydra.py script
   # used in scripts/train_hydra.py and scripts/predict_new_vids.py
   test_videos_directory: null
+  # matplotlib sequential or diverging colormap name for prediction visualization
+  # sequential options: viridis, plasma, magma, inferno, cool, etc.
+  # diverging options: RdBu, coolwarm, Spectral, etc.
+  colormap: "cool"
   # confidence threshold for plotting a vid
   confidence_thresh_for_vid: 0.90
 


### PR DESCRIPTION
I wanted to change the standard colormap for the labelled videos ("cool") is it is harder to differentiate keypoints when the number is larger. So I added the option to choose the colormap in the yaml file.