### PR TITLE
Replace relative paths with absolute paths in demo config

### DIFF
--- a/lightning_pose/__init__.py
+++ b/lightning_pose/__init__.py
@@ -1,1 +1,7 @@
 __version__ = "1.5.1"
+
+from pathlib import Path
+from omegaconf import OmegaConf
+
+LP_ROOT_PATH = (Path(__file__).parent.parent).absolute()
+OmegaConf.register_new_resolver("LP_ROOT_PATH", lambda: LP_ROOT_PATH)

--- a/scripts/configs/config_default.yaml
+++ b/scripts/configs/config_default.yaml
@@ -4,9 +4,9 @@ data:
     height: null
     width: null
   # ABSOLUTE path to data directory
-  data_dir: null
+  data_dir: /replace/with/your/path
   # ABSOLUTE path to unlabeled videos' directory
-  video_dir: null
+  video_dir: /replace/with/your/path
   # location of labels; this should be relative to `data_dir`
   csv_file: CollectedData.csv
   # downsample heatmaps - 2 | 3
@@ -151,9 +151,7 @@ eval:
   # predict? used in scripts/train_hydra.py
   predict_vids_after_training: true
   # str with an absolute path to a directory containing videos for prediction.
-  # set to null to skip automatic video prediction from train_hydra.py script
-  # used in scripts/train_hydra.py and scripts/predict_new_vids.py
-  test_videos_directory: null
+  test_videos_directory: ${data.video_dir}
   # save labeled .mp4? used in scripts/train_hydra.py and scripts/predict_new_vids.py
   save_vids_after_training: false
   # matplotlib sequential or diverging colormap name for prediction visualization

--- a/scripts/configs/config_mirror-mouse-example.yaml
+++ b/scripts/configs/config_mirror-mouse-example.yaml
@@ -3,10 +3,12 @@ data:
   image_resize_dims:
     width: 256
     height: 256
-  # ABSOLUTE path to data directory. the below is just a toy example for running Getting Started scripts
-  data_dir: data/mirror-mouse-example
-  # ABSOLUTE path to unlabeled videos' directory. the below is just a toy example for running Getting Started scripts
-  video_dir: videos
+  # ABSOLUTE path to data directory.
+  #   Demo data resides in the git repo. LP_ROOT_PATH resolves to the absolute
+  #   path of the lightning-pose git repo.
+  data_dir: ${LP_ROOT_PATH:}/data/mirror-mouse-example
+  # ABSOLUTE path to unlabeled videos' directory.
+  video_dir: ${data.data_dir}/videos
   # location of labels; for example script, this should be relative to `data_dir`
   csv_file: CollectedData.csv
   # downsample heatmaps: 2 | 3
@@ -191,8 +193,7 @@ eval:
     address: 127.0.0.1 # ip to launch the app on.
     port: 5151 # port to launch the app on.
   # str with an absolute path to a directory containing videos for prediction.
-  # (it's not absolute just for the toy example)
-  test_videos_directory: data/mirror-mouse-example/videos
+  test_videos_directory: ${data.video_dir}
   # confidence threshold for plotting a vid
   confidence_thresh_for_vid: 0.9
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def cfg_multiview() -> dict:
     cfg.training.imgaug = "dlc"
     cfg.dali.base.train.sequence_length = 6
     cfg.dali.base.predict.sequence_length = 16
-    cfg.data.data_dir = "data/mirror-mouse-example_split"
+    cfg.data.data_dir = "${LP_ROOT_PATH:}/data/mirror-mouse-example_split"
     cfg.data.csv_file = ["top.csv", "bot.csv"]
     cfg.data.view_names = ["bot", "top"]
     cfg.data.num_keypoints = 7

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -102,7 +102,7 @@ def test_train_multiview(cfg_multiview, tmp_path):
 # https://github.com/Lightning-AI/pytorch-lightning/issues/4397#issuecomment-722743582
 # Our multi-GPU tests currently just ensure the train script finishes with status code 0.
 def _execute_multi_gpu_test(cfg, tmp_path, pytestconfig):
-    # set output directory to {tmp_path}/output. Hydra will chdir to here.
+    # set output directory to {tmp_path}/output.
     cfg = OmegaConf.merge(
         cfg, OmegaConf.create({"hydra": {"run": {"dir": tmp_path / "output"}}})
     )
@@ -114,12 +114,10 @@ def _execute_multi_gpu_test(cfg, tmp_path, pytestconfig):
     process = subprocess.run(
         [
             "python",
-            os.path.join("scripts", "train_hydra.py"),
+            pytestconfig.rootpath / "scripts" / "train_hydra.py",
             f"--config-path={tmp_path}",
             f"--config-name=config",
         ],
-        # We need to run this from the lightning-pose package root.
-        cwd=pytestconfig.rootpath,
     )
     assert process.returncode == 0
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -25,8 +25,6 @@ def _test_cfg(cfg):
     pwd = os.getcwd()
     # copy config and update paths
     cfg_tmp = copy.deepcopy(cfg)
-    cfg_tmp.data.data_dir = os.path.join(pwd, cfg_tmp.data.data_dir)
-    cfg_tmp.data.video_dir = os.path.join(cfg_tmp.data.data_dir, "videos")
     cfg_tmp.eval.test_videos_directory = cfg_tmp.data.video_dir
 
     # don't train for long


### PR DESCRIPTION
Out of the box, train_hydra only works when run from the repo root. This was due to the use of relative paths. These are replaced with absolute paths and the config now adheres to the public spec.

Prevents issues like #195 from being encountered on the mirror mouse example.

Additionally tweaked the default config. If you don't change data_dir, it will error with 
`OSError: /replace/with/your/path is not a valid path`. Also `test_videos_directory` defaults to `data.video_dir.`
