### PR TITLE
Fix doc build failure

### DIFF
--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -1,5 +1,7 @@
 """Dataset objects store images, labels, and functions for manipulation."""
 
+from __future__ import annotations  # python 3.8 compatibility for sphinx
+
 import os
 import re
 from pathlib import Path


### PR DESCRIPTION
Using `list[Path]` in type annotation is supported in python 3.10 but not 3.8 used by sphinx.

Doc build failure: https://readthedocs.org/projects/lightning-pose/builds/26240407/
Stack overflow: https://stackoverflow.com/a/75317316

