### PR TITLE
Save out detector artifacts on detector training

### DIFF
--- a/docs/api/lightning_pose.models.backbones.vit_img_encoder.ImageEncoderViT.rst
+++ b/docs/api/lightning_pose.models.backbones.vit_img_encoder.ImageEncoderViT.rst
@@ -1,0 +1,17 @@
+ImageEncoderViT
+===============
+
+.. currentmodule:: lightning_pose.models.backbones.vit_img_encoder
+
+.. autoclass:: ImageEncoderViT
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~ImageEncoderViT.forward
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: forward

--- a/docs/api/lightning_pose.models.base.BaseSupervisedTracker.rst
+++ b/docs/api/lightning_pose.models.base.BaseSupervisedTracker.rst
@@ -12,7 +12,6 @@ BaseSupervisedTracker
 
       ~BaseSupervisedTracker.evaluate_labeled
       ~BaseSupervisedTracker.get_loss_inputs_labeled
-      ~BaseSupervisedTracker.get_parameters
       ~BaseSupervisedTracker.test_step
       ~BaseSupervisedTracker.training_step
       ~BaseSupervisedTracker.validation_step
@@ -21,7 +20,6 @@ BaseSupervisedTracker
 
    .. automethod:: evaluate_labeled
    .. automethod:: get_loss_inputs_labeled
-   .. automethod:: get_parameters
    .. automethod:: test_step
    .. automethod:: training_step
    .. automethod:: validation_step

--- a/docs/api/lightning_pose.models.base.SemiSupervisedTrackerMixin.rst
+++ b/docs/api/lightning_pose.models.base.SemiSupervisedTrackerMixin.rst
@@ -12,12 +12,10 @@ SemiSupervisedTrackerMixin
 
       ~SemiSupervisedTrackerMixin.evaluate_unlabeled
       ~SemiSupervisedTrackerMixin.get_loss_inputs_unlabeled
-      ~SemiSupervisedTrackerMixin.get_parameters
       ~SemiSupervisedTrackerMixin.training_step
 
    .. rubric:: Methods Documentation
 
    .. automethod:: evaluate_unlabeled
    .. automethod:: get_loss_inputs_unlabeled
-   .. automethod:: get_parameters
    .. automethod:: training_step

--- a/docs/api/lightning_pose.models.heatmap_tracker_mhcrnn.SemiSupervisedHeatmapTrackerMHCRNN.rst
+++ b/docs/api/lightning_pose.models.heatmap_tracker_mhcrnn.SemiSupervisedHeatmapTrackerMHCRNN.rst
@@ -11,9 +11,7 @@ SemiSupervisedHeatmapTrackerMHCRNN
    .. autosummary::
 
       ~SemiSupervisedHeatmapTrackerMHCRNN.get_loss_inputs_unlabeled
-      ~SemiSupervisedHeatmapTrackerMHCRNN.get_parameters
 
    .. rubric:: Methods Documentation
 
    .. automethod:: get_loss_inputs_unlabeled
-   .. automethod:: get_parameters

--- a/docs/api/lightning_pose.utils.cropzoom.generate_cropped_labeled_frames.rst
+++ b/docs/api/lightning_pose.utils.cropzoom.generate_cropped_labeled_frames.rst
@@ -1,0 +1,6 @@
+generate_cropped_labeled_frames
+===============================
+
+.. currentmodule:: lightning_pose.utils.cropzoom
+
+.. autofunction:: generate_cropped_labeled_frames

--- a/docs/api/lightning_pose.utils.cropzoom.generate_cropped_video.rst
+++ b/docs/api/lightning_pose.utils.cropzoom.generate_cropped_video.rst
@@ -1,0 +1,6 @@
+generate_cropped_video
+======================
+
+.. currentmodule:: lightning_pose.utils.cropzoom
+
+.. autofunction:: generate_cropped_video

--- a/docs/api/lightning_pose.utils.io.get_context_img_paths.rst
+++ b/docs/api/lightning_pose.utils.io.get_context_img_paths.rst
@@ -1,0 +1,6 @@
+get_context_img_paths
+=====================
+
+.. currentmodule:: lightning_pose.utils.io
+
+.. autofunction:: get_context_img_paths

--- a/docs/api/lightning_pose.utils.io.load_label_csv_from_cfg.rst
+++ b/docs/api/lightning_pose.utils.io.load_label_csv_from_cfg.rst
@@ -1,6 +1,0 @@
-load_label_csv_from_cfg
-=======================
-
-.. currentmodule:: lightning_pose.utils.io
-
-.. autofunction:: load_label_csv_from_cfg

--- a/docs/api/lightning_pose.utils.predictions.export_predictions_and_labeled_video.rst
+++ b/docs/api/lightning_pose.utils.predictions.export_predictions_and_labeled_video.rst
@@ -1,6 +1,6 @@
 export_predictions_and_labeled_video
 ====================================
 
-.. currentmodule:: lightning_pose.utils.scripts
+.. currentmodule:: lightning_pose.utils.predictions
 
 .. autofunction:: export_predictions_and_labeled_video

--- a/docs/api/lightning_pose.utils.predictions.get_cfg_file.rst
+++ b/docs/api/lightning_pose.utils.predictions.get_cfg_file.rst
@@ -1,6 +1,0 @@
-get_cfg_file
-============
-
-.. currentmodule:: lightning_pose.utils.predictions
-
-.. autofunction:: get_cfg_file

--- a/docs/api/lightning_pose.utils.predictions.make_cmap.rst
+++ b/docs/api/lightning_pose.utils.predictions.make_cmap.rst
@@ -1,6 +1,0 @@
-make_cmap
-=========
-
-.. currentmodule:: lightning_pose.utils.predictions
-
-.. autofunction:: make_cmap

--- a/docs/modules/lightning_pose.utils.rst
+++ b/docs/modules/lightning_pose.utils.rst
@@ -3,6 +3,9 @@
 lightning\_pose.utils
 =====================
 
+.. automodapi:: lightning_pose.utils.cropzoom
+   :no-inheritance-diagram:
+
 .. automodapi:: lightning_pose.utils.fiftyone
    :no-inheritance-diagram:
 

--- a/lightning_pose/utils/cropzoom.py
+++ b/lightning_pose/utils/cropzoom.py
@@ -11,6 +11,8 @@ from typeguard import typechecked
 
 from lightning_pose.utils.io import get_context_img_paths
 
+__all__ = ["generate_cropped_labeled_frames", "generate_cropped_video"]
+
 
 @typechecked
 def _calculate_bbox_size(

--- a/lightning_pose/utils/cropzoom.py
+++ b/lightning_pose/utils/cropzoom.py
@@ -1,0 +1,210 @@
+from collections.abc import Collection
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+from moviepy.editor import VideoFileClip
+from omegaconf import DictConfig
+from PIL import Image
+from typeguard import typechecked
+
+from lightning_pose.utils.io import get_context_img_paths
+
+
+@typechecked
+def _calculate_bbox_size(
+    keypoints_per_frame: np.ndarray, crop_ratio: float = 1.0
+) -> int:
+    """Given all labeled keypoints, computes the bounding box square size as
+    the length of one side in pixels.
+    First we compute the maximum bounding box that would always encompass
+    the animal (maximum difference of all x's and y's per frame, max over all frames).
+    Then we take the larger dimension of the bbox (x or y). Finally we scale by `crop_ratio`.
+
+    Arguments:
+        keypoints_per_frame: np array of all labeled frames. Shape of (frames, keypoints, x|y).
+        crop_ratio:
+    """
+    # Extract x and y coordinates
+    x_coords = keypoints_per_frame[:, :, 0]  # All rows, all columns, first element (x)
+    y_coords = keypoints_per_frame[:, :, 1]  # All rows, all columns, second element (y)
+    max_x_diff_per_frame = np.max(x_coords, axis=1) - np.min(x_coords, axis=1)
+    max_y_diff_per_frame = np.max(y_coords, axis=1) - np.min(y_coords, axis=1)
+
+    # Max of all x_diff and y_diff over all frames. A scalar.
+    max_bbox_size = np.max([max_x_diff_per_frame, max_y_diff_per_frame], axis=(0, 1))
+
+    # Scale by crop_ratio, and take ceiling.
+    bbox_size = int(np.ceil(max_bbox_size * crop_ratio))
+
+    # Many video players don't like odd dimensions.
+    # Make sure the bbox has even dimensions.
+    bbox_size = bbox_size if bbox_size % 2 == 0 else bbox_size + 1
+
+    return bbox_size
+
+
+@typechecked
+def _compute_bbox_df(
+    pred_df: pd.DataFrame, anchor_keypoints: Collection[str], crop_ratio: float = 1.0
+) -> pd.DataFrame:
+    # Get x,y columns for anchor_keypoints (or all keypoints if anchor_keypoints is empty)
+    coord_mask = pred_df.columns.get_level_values("coords").isin(["x", "y"])
+    if len(anchor_keypoints) > 0:
+        coord_mask &= pred_df.columns.get_level_values("bodyparts").isin(
+            anchor_keypoints
+        )
+
+    # Shape: (frames, keypoints, x|y)
+    keypoints_per_frame = (
+        pred_df.loc[:, coord_mask].to_numpy().reshape(pred_df.shape[0], -1, 2)
+    )
+
+    bbox_size = _calculate_bbox_size(keypoints_per_frame, crop_ratio=crop_ratio)
+
+    # Shape: (frames, keypoints, x|y) -> (frames, x|y)
+    centroids = keypoints_per_frame.mean(axis=1)
+
+    # Instead of storing centroid, we'll store bbox top-left.
+    # Shape: (frames, x|y)
+    bbox_toplefts = centroids - bbox_size // 2
+    # Floor and store ints.
+    bbox_toplefts = np.int64(bbox_toplefts)
+
+    # Store bbox size as (h,w). Note that h=w since bbox is a square for now.
+    # Shape: (frames, h|w)
+    bbox_hws = np.full_like(bbox_toplefts, bbox_size)
+
+    # Shape: (frames, x|y) -> (frames, x|y|h|w)
+    bboxes = np.concatenate([bbox_toplefts, bbox_hws], axis=1)
+
+    index = pred_df.index
+
+    return pd.DataFrame(bboxes, index=index, columns=["x", "y", "h", "w"])
+
+
+@typechecked
+def _crop_images(
+    bbox_df: pd.DataFrame, root_directory: Path, output_directory: Path
+) -> None:
+    """Crops images according to their bboxes in `bbox_df`.
+
+    root_directory: root of img paths in bbox_df.
+    output_directory: where to save cropped images."""
+    for center_img_path, row in bbox_df.iterrows():
+        for img_path in get_context_img_paths(Path(center_img_path)):
+            # Silently skip non-existent context frames.
+            if not (root_directory / img_path).exists() and img_path != center_img_path:
+                continue
+            img = Image.open(root_directory / img_path)
+            img = img.crop((row.x, row.y, row.x + row.h, row.y + row.w))
+
+            # preserve directory structure of img_path
+            # (e.g. labeled-data/x.png will create a labeled-data dir)
+            cropped_img_path = output_directory / img_path
+            cropped_img_path.parent.mkdir(parents=True, exist_ok=True)
+            img.save(cropped_img_path)
+
+
+@typechecked
+def _crop_video_moviepy(
+    video_file: Path, bbox_df: pd.DataFrame, output_directory: Path
+):
+    clip = VideoFileClip(str(video_file))
+
+    b = bbox_df.iloc[0]
+    h = b.h
+    w = b.w
+
+    def crop_frame(get_frame, t):
+        frame = get_frame(t)
+
+        frame_index = int(t * clip.fps)  # Calculate frame index based on time
+        if frame_index >= len(bbox_df):
+            print(f"crop_frame: Skipped frame {frame_index}")
+            return np.zeros((h, w, frame.shape[2]), dtype=np.uint8)
+
+        b = bbox_df.iloc[frame_index]
+        x1, x2 = b.x, b.x + b.w
+        y1, y2 = b.y, b.y + b.h
+        assert b.h == h
+        assert b.w == w
+        cropped_frame = np.zeros((h, w, frame.shape[2]), dtype=np.uint8)
+
+        # Calculate valid crop boundaries within the original frame
+        x1_valid = max(0, x1)
+        x2_valid = min(clip.w - 1, x2)
+        y1_valid = max(0, y1)
+        y2_valid = min(clip.h - 1, y2)
+
+        # Calculate corresponding coordinates in the cropped frame
+        crop_x1 = abs(min(0, x1))  # Offset in the cropped frame if x1 is negative
+        crop_x2 = crop_x1 + (x2_valid - x1_valid)
+        crop_y1 = abs(min(0, y1))  # Offset in the cropped frame if y1 is negative
+        crop_y2 = crop_y1 + (y2_valid - y1_valid)
+
+        # Copy the valid region to the cropped frame
+        cropped_frame[crop_y1:crop_y2, crop_x1:crop_x2] = frame[
+            y1_valid:y2_valid, x1_valid:x2_valid
+        ]
+
+        return cropped_frame
+
+    # renamed image_transform in 2.0.0
+    cropped_clip = clip.fl(crop_frame, apply_to="mask")
+
+    cropped_clip.write_videofile(
+        str(output_directory / video_file.name), codec="libx264"
+    )
+
+
+@typechecked
+def generate_cropped_labeled_frames(
+    root_directory: Path,
+    output_directory: Path,
+    detector_cfg: DictConfig,
+    preds_file: Optional[Path] = None,
+) -> None:
+    # Use predictions rather than CollectedData.csv because collected data can sometimes have NaNs.
+    preds_file = preds_file or output_directory / "predictions.csv"
+    # load predictions
+    pred_df = pd.read_csv(preds_file, header=[0, 1, 2], index_col=0)
+
+    # compute and save bbox_df
+    bbox_df = _compute_bbox_df(
+        pred_df, detector_cfg.anchor_keypoints, crop_ratio=detector_cfg.crop_ratio
+    )
+
+    bbox_csv_path = output_directory / "cropped_images" / "bbox.csv"
+    bbox_csv_path.parent.mkdir(parents=True, exist_ok=True)
+    bbox_df.to_csv(bbox_csv_path)
+
+    _crop_images(bbox_df, root_directory, output_directory / "cropped_images")
+
+
+@typechecked
+def generate_cropped_video(
+    video_path: Path, detector_model_dir: Path, detector_cfg: DictConfig
+) -> None:
+    video_path = Path(video_path)
+
+    # Given the predictions, compute cropping bboxes
+    preds_file = detector_model_dir / "video_preds" / (video_path.stem + ".csv")
+
+    # load predictions
+    # TODO If predictions do not exist, predict with detector model
+    pred_df = pd.read_csv(preds_file, header=[0, 1, 2], index_col=0)
+
+    # Save cropping bboxes
+    bbox_df = _compute_bbox_df(
+        pred_df, detector_cfg.anchor_keypoints, crop_ratio=detector_cfg.crop_ratio
+    )
+    output_bbox_path = (
+        detector_model_dir / "cropped_videos" / (video_path.stem + "_bbox.csv")
+    )
+    output_bbox_path.parent.mkdir(parents=True, exist_ok=True)
+    bbox_df.to_csv(output_bbox_path)
+
+    # Generate a cropped video for debugging purposes.
+    _crop_video_moviepy(video_path, bbox_df, detector_model_dir / "cropped_videos")

--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -19,6 +19,7 @@ __all__ = [
     "return_absolute_data_paths",
     "get_videos_in_dir",
     "check_video_paths",
+    "get_context_img_paths",
 ]
 
 

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -26,20 +26,19 @@ from lightning_pose.utils import pretty_print_str
 
 # to ignore imports for sphix-autoapidoc
 __all__ = [
-    "get_cfg_file",
     "PredictionHandler",
     "predict_dataset",
     "predict_single_video",
     "make_dlc_pandas_index",
     "get_model_class",
     "load_model_from_checkpoint",
-    "make_cmap",
     "create_labeled_video",
+    "export_predictions_and_labeled_video",
 ]
 
 
 @typechecked
-def get_cfg_file(cfg_file: Union[str, DictConfig]):
+def _get_cfg_file(cfg_file: Union[str, DictConfig]):
     """Load yaml configuration files."""
     if isinstance(cfg_file, str):
         # load configuration file
@@ -390,7 +389,7 @@ def predict_single_video(
 
     """
 
-    cfg = get_cfg_file(cfg_file=cfg_file).copy()  # copy because we update imgaug field below
+    cfg = _get_cfg_file(cfg_file=cfg_file).copy()  # copy because we update imgaug field below
 
     delete_model = False
     if model is None:
@@ -736,7 +735,7 @@ def load_model_from_checkpoint(
 
 
 @typechecked
-def make_cmap(number_colors: int, cmap: str):
+def _make_cmap(number_colors: int, cmap: str):
     color_class = plt.cm.ScalarMappable(cmap=cmap)
     C = color_class.to_rgba(np.linspace(0, 1, number_colors))
     colors = (C[:, :3] * 255).astype(np.uint8)
@@ -752,11 +751,10 @@ def create_labeled_video(
     dotsize: int = 4,
     colormap: Optional[str] = "cool",
     fps: Optional[float] = None,
-    filename: str = "movie.mp4",
+    output_video_path: str = "movie.mp4",
     start_time: float = 0.0,
 ) -> None:
     """Helper function for creating annotated videos.
-
     Args
         clip
         xs_arr: shape T x n_joints
@@ -765,9 +763,8 @@ def create_labeled_video(
         dotsize: size of marker dot on labeled video
         colormap: matplotlib color map for markers
         fps: None to default to fps of original video
-        filename: video file name
+        output_video_path: video file name
         start_time: time (in seconds) of video start
-
     """
 
     if mask_array is None:
@@ -776,7 +773,7 @@ def create_labeled_video(
     n_frames, n_keypoints = xs_arr.shape
 
     # set colormap for each color
-    colors = make_cmap(n_keypoints, cmap=colormap)
+    colors = _make_cmap(n_keypoints, cmap=colormap)
 
     # extract info from clip
     nx, ny = clip.size
@@ -813,34 +810,34 @@ def create_labeled_video(
 
     # add marker to each frame t, where t is in sec
     def add_marker_and_timestamps(get_frame, t):
-        image = get_frame(t * 1.0)
+        image = get_frame(t)
         # frame [ny x ny x 3]
         frame = image.copy()
         # convert from sec to indices
-        index = int(np.round(t * 1.0 * fps_og))
+        index = int(np.round(t * fps_og))
         # ----------------
         # markers
         # ----------------
-        for bpindex in range(n_keypoints):
-            if index >= n_frames:
-                print("Skipped frame {}, marker {}".format(index, bpindex))
-                continue
-            if mask_array[index, bpindex]:
-                xc = min(int(upsample_factor * xs_arr[index, bpindex]), nx - 1)
-                yc = min(int(upsample_factor * ys_arr[index, bpindex]), ny - 1)
-                frame = cv2.circle(
-                    frame,
-                    center=(xc, yc),
-                    radius=dotsize,
-                    color=colors[bpindex].tolist(),
-                    thickness=-1,
-                )
+        if index >= n_frames:
+            print(f"add_marker_and_timestamps: Skipped frame {index}")
+        else:
+            for bpindex in range(n_keypoints):
+                if mask_array[index, bpindex]:
+                    xc = min(int(upsample_factor * xs_arr[index, bpindex]), nx - 1)
+                    yc = min(int(upsample_factor * ys_arr[index, bpindex]), ny - 1)
+                    frame = cv2.circle(
+                        frame,
+                        center=(xc, yc),
+                        radius=dotsize,
+                        color=colors[bpindex].tolist(),
+                        thickness=-1,
+                    )
         # ----------------
         # timestamps
         # ----------------
         seconds_from_start = t + start_time
         time_from_start = seconds_to_hms(seconds_from_start)
-        idx_from_start = int(np.round(seconds_from_start * 1.0 * fps_og))
+        idx_from_start = int(np.round(seconds_from_start * fps_og))
         text = f"t={time_from_start}, frame={idx_from_start}"
         # define text info
         font = cv2.FONT_HERSHEY_SIMPLEX
@@ -873,5 +870,56 @@ def create_labeled_video(
         return frame
 
     clip_marked = clip.fl(add_marker_and_timestamps)
-    clip_marked.write_videofile(filename, codec="libx264", fps=fps or fps_og or 20.0)
+    clip_marked.write_videofile(
+        output_video_path, codec="libx264", fps=fps or fps_og or 20.0
+    )
     clip_marked.close()
+
+
+@typechecked
+def export_predictions_and_labeled_video(
+    video_file: str,
+    cfg: DictConfig,
+    prediction_csv_file: str,
+    ckpt_file: Optional[str] = None,
+    trainer: Optional[pl.Trainer] = None,
+    model: Optional[ALLOWED_MODELS] = None,
+    data_module: Optional[Union[BaseDataModule, UnlabeledDataModule]] = None,
+    labeled_mp4_file: Optional[str] = None,
+    save_heatmaps: Optional[bool] = False,
+) -> None:
+    """Export predictions csv and a labeled video for a single video file."""
+
+    if ckpt_file is None and model is None:
+        raise ValueError("either 'ckpt_file' or 'model' must be passed")
+
+    # compute predictions
+    preds_df = predict_single_video(
+        video_file=video_file,
+        ckpt_file=ckpt_file,
+        cfg_file=cfg,
+        preds_file=prediction_csv_file,
+        trainer=trainer,
+        model=model,
+        data_module=data_module,
+        save_heatmaps=save_heatmaps,
+    )
+
+    # create labeled video
+    if labeled_mp4_file is not None:
+        os.makedirs(os.path.dirname(labeled_mp4_file), exist_ok=True)
+        # transform df to numpy array
+        keypoints_arr = np.reshape(preds_df.to_numpy(), [preds_df.shape[0], -1, 3])
+        xs_arr = keypoints_arr[:, :, 0]
+        ys_arr = keypoints_arr[:, :, 1]
+        mask_array = keypoints_arr[:, :, 2] > cfg.eval.confidence_thresh_for_vid
+        # video generation
+        video_clip = VideoFileClip(video_file)
+        create_labeled_video(
+            clip=video_clip,
+            xs_arr=xs_arr,
+            ys_arr=ys_arr,
+            mask_array=mask_array,
+            output_video_path=labeled_mp4_file,
+            colormap=cfg.eval.get("colormap", "cool")
+        )

--- a/scripts/predict_new_vids.py
+++ b/scripts/predict_new_vids.py
@@ -12,10 +12,12 @@ from lightning_pose.utils.io import (
     return_absolute_data_paths,
     return_absolute_path,
 )
-from lightning_pose.utils.predictions import load_model_from_checkpoint
+from lightning_pose.utils.predictions import (
+    export_predictions_and_labeled_video,
+    load_model_from_checkpoint,
+)
 from lightning_pose.utils.scripts import (
     compute_metrics,
-    export_predictions_and_labeled_video,
     get_data_module,
     get_dataset,
     get_imgaug_transform,

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ install_requires = [
     "kornia",
     "lightning",
     "matplotlib",
-    "moviepy",
+    "moviepy<2.0.0", # update is to be tested
     "numpy<2.0.0",  # several bugs related to numpy updates as of 2024/07/05
     "opencv-python-headless",
     "pandas>=2.0.0",

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1,10 +1,6 @@
 """Test basic dataset functionality."""
 
-from pathlib import Path
-
 import torch
-
-from lightning_pose.data.datasets import _get_context_img_paths
 
 
 def test_base_dataset(cfg, base_dataset):
@@ -110,30 +106,3 @@ def test_multiview_heatmap_dataset_context(
 def test_equal_return_sizes(base_dataset, heatmap_dataset):
     # can only assert the batches are the same if not using imgaug pipeline
     assert base_dataset[0]["images"].shape == heatmap_dataset[0]["images"].shape
-
-
-def test_get_context_img_paths():
-    assert _get_context_img_paths(Path("a/b/c/img_2.png")) == [
-        Path("a/b/c/img_0.png"),
-        Path("a/b/c/img_1.png"),
-        Path("a/b/c/img_2.png"),
-        Path("a/b/c/img_3.png"),
-        Path("a/b/c/img_4.png"),
-    ]
-
-    assert _get_context_img_paths(Path("a/b/c/img_0200.png")) == [
-        Path("a/b/c/img_0198.png"),
-        Path("a/b/c/img_0199.png"),
-        Path("a/b/c/img_0200.png"),
-        Path("a/b/c/img_0201.png"),
-        Path("a/b/c/img_0202.png"),
-    ]
-
-    # Test negative indices floored to 0.
-    assert _get_context_img_paths(Path("a/b/c/img_1.png")) == [
-        Path("a/b/c/img_0.png"),
-        Path("a/b/c/img_0.png"),
-        Path("a/b/c/img_1.png"),
-        Path("a/b/c/img_2.png"),
-        Path("a/b/c/img_3.png"),
-    ]

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -1,0 +1,173 @@
+import copy
+import filecmp
+import io
+import shutil
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+from omegaconf import OmegaConf
+
+from lightning_pose.utils.cropzoom import generate_cropped_labeled_frames, generate_cropped_video
+
+
+# TODO: Move to utils.
+def compare_directories(dir1: Path, dir2: Path) -> int | dict:
+    """
+    Compares files in two directories recursively.
+
+    Args:
+      dir1: Path to the first directory.
+      dir2: Path to the second directory.
+
+    Returns:
+      Number of matched files if the directories are identical, or
+      a dictionary with the following keys if the directories are different:
+        'mismatch': List of files that differ between the directories.
+        'errors': List of files that couldn't be compared (e.g., due to permissions).
+        'left_only': List of files that exist only in the first directory.
+        'right_only': List of files that exist only in the second directory.
+    """
+    num_matches = 0
+    empty_results = {
+        "mismatch": [],
+        "errors": [],
+        "left_only": [],
+        "right_only": [],
+    }
+    results = copy.deepcopy(empty_results)
+
+    dircmp_result = filecmp.dircmp(dir1, dir2)
+
+    # Compare common files
+    for common_file in dircmp_result.common_files:
+        if filecmp.cmp(dir1 / common_file, dir2 / common_file, shallow=False):
+            num_matches += 1
+        else:
+            results["mismatch"].append(common_file)
+
+    # Recursively compare subdirectories
+    for sub_dir in dircmp_result.common_dirs:
+        sub_results = compare_directories(dir1 / sub_dir, dir2 / sub_dir)
+        if isinstance(sub_results, int):
+            num_matches += sub_results
+        else:
+            results["mismatch"].extend(sub_results["mismatch"])
+            results["errors"].extend(sub_results["errors"])
+            results["left_only"].extend(sub_results["left_only"])
+            results["right_only"].extend(sub_results["right_only"])
+
+    # Add files unique to each directory and any errors
+    results["errors"].extend(dircmp_result.common_funny)
+    results["left_only"].extend(dircmp_result.left_only)
+    results["right_only"].extend(dircmp_result.right_only)
+
+    if results == empty_results:
+        return num_matches
+    return results
+
+
+# TODO Move to utils
+def fetch_test_data_if_needed(dir: Path, dataset_name: str) -> None:
+    datasets_url_dict = {
+        "test_cropzoom_data": "https://figshare.com/ndownloader/files/51015435"
+    }
+    # check if data exists
+    dataset_dir = dir / dataset_name
+    # TODO Add a way to force download fresh data.
+    # Maybe compare file size of stored dataset and figshare dataset?
+    # Figshare filesize can be gotten with HEAD request, and stored
+    # in the dataset directory.
+    if dataset_dir.exists():
+        return
+
+    url = datasets_url_dict[dataset_name]
+    print(f"Fetching {dataset_name} from {url}")
+    with requests.get(url, stream=True) as r:
+        r.raise_for_status()  # Check for download errors
+        with zipfile.ZipFile(io.BytesIO(r.raw.read())) as z:
+            # Extract assuming there is only one directory in the zip file.
+            file_list = z.namelist()
+            top_level_file_list = [name for name in file_list if name.count("/") <= 1]
+            if (
+                len(top_level_file_list) > 1
+                or top_level_file_list[0] != f"{dataset_name}/"
+            ):
+                raise ValueError(
+                    f"Zip file must have only one dir called {dataset_dir}\n"
+                    f"Instead found {file_list}."
+                )
+            else:
+                z.extractall(dir)
+
+    print("Done")
+
+
+def test_generate_cropped_labeled_frames(tmp_path, request):
+    # Fetch a dataset and a fully trained model's predictions on it.
+    fetch_test_data_if_needed(request.path.parent, "test_cropzoom_data")
+
+    # Copy the model predictions to a temporary model directory.
+    tmp_model_directory = tmp_path / "test_model"
+    shutil.copytree(
+        request.path.parent / "test_cropzoom_data" / "test_model_output",
+        tmp_model_directory,
+        dirs_exist_ok=True,
+    )
+
+    # Run cropzoom on the test data in the temporary model directory.
+    root_directory = request.path.parent / "test_cropzoom_data" / "test_data"
+    detector_cfg = OmegaConf.create(
+        {"crop_ratio": 1.5, "anchor_keypoints": ["A_head", "D_tailtip"]}
+    )
+    generate_cropped_labeled_frames(
+        root_directory, tmp_model_directory, detector_cfg=detector_cfg
+    )
+
+    # Assert cropzoom output matches expected output.
+    comparison = compare_directories(
+        tmp_model_directory / "cropped_images",
+        request.path.parent
+        / "test_cropzoom_data"
+        / "expected_model_output"
+        / "cropped_images",
+    )
+    # Successfully compared 23 objects.
+    assert comparison == 23
+
+
+def test_generate_cropped_video(tmp_path, request):
+    # Fetch a dataset and a fully trained model's predictions on it.
+    fetch_test_data_if_needed(request.path.parent, "test_cropzoom_data")
+
+    # Copy the model predictions to a temporary model directory.
+    tmp_model_directory = tmp_path / "test_model"
+    shutil.copytree(
+        request.path.parent / "test_cropzoom_data" / "test_model_output",
+        tmp_model_directory,
+        dirs_exist_ok=True,
+    )
+
+    # Run cropzoom on the test data in the temporary model directory.
+    video_directory = (
+        request.path.parent / "test_cropzoom_data" / "test_data" / "videos"
+    )
+    detector_cfg = OmegaConf.create(
+        {"crop_ratio": 1.5, "anchor_keypoints": ["A_head", "D_tailtip"]}
+    )
+    for video_path in video_directory.iterdir():
+        generate_cropped_video(
+            video_path, tmp_model_directory, detector_cfg=detector_cfg
+        )
+
+    # Assert cropzoom output matches expected output.
+    comparison = compare_directories(
+        tmp_model_directory / "cropped_videos",
+        request.path.parent
+        / "test_cropzoom_data"
+        / "expected_model_output"
+        / "cropped_videos",
+    )
+    # Successfully compared 4 objects.
+    assert comparison == 4

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -2,14 +2,19 @@
 
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 
+from lightning_pose.utils.io import (
+    check_if_semi_supervised,
+    check_video_paths,
+    get_context_img_paths,
+    get_videos_in_dir,
+)
+
 
 def test_check_if_semisupervised():
-
-    from lightning_pose.utils.io import check_if_semi_supervised
-
     flag = check_if_semi_supervised(losses_to_use=None)
     assert not flag
 
@@ -27,9 +32,6 @@ def test_check_if_semisupervised():
 
 
 def test_get_videos_in_dir(toy_data_dir, tmpdir):
-
-    from lightning_pose.utils.io import get_videos_in_dir
-
     videos_dir = os.path.join(toy_data_dir, "videos")
 
     # --------------------
@@ -90,9 +92,6 @@ def test_get_videos_in_dir(toy_data_dir, tmpdir):
 
 
 def test_check_video_paths(toy_data_dir, tmpdir):
-
-    from lightning_pose.utils.io import check_video_paths
-
     videos_dir = os.path.join(toy_data_dir, "videos")
 
     # --------------------
@@ -136,3 +135,30 @@ def test_check_video_paths(toy_data_dir, tmpdir):
     for v_list in video_list_5:
         assert isinstance(v_list, list)
         assert len(v_list) == 1
+
+
+def test_get_context_img_paths():
+    assert get_context_img_paths(Path("a/b/c/img_2.png")) == [
+        Path("a/b/c/img_0.png"),
+        Path("a/b/c/img_1.png"),
+        Path("a/b/c/img_2.png"),
+        Path("a/b/c/img_3.png"),
+        Path("a/b/c/img_4.png"),
+    ]
+
+    assert get_context_img_paths(Path("a/b/c/img_0200.png")) == [
+        Path("a/b/c/img_0198.png"),
+        Path("a/b/c/img_0199.png"),
+        Path("a/b/c/img_0200.png"),
+        Path("a/b/c/img_0201.png"),
+        Path("a/b/c/img_0202.png"),
+    ]
+
+    # Test negative indices floored to 0.
+    assert get_context_img_paths(Path("a/b/c/img_1.png")) == [
+        Path("a/b/c/img_0.png"),
+        Path("a/b/c/img_0.png"),
+        Path("a/b/c/img_1.png"),
+        Path("a/b/c/img_2.png"),
+        Path("a/b/c/img_3.png"),
+    ]

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -2,11 +2,13 @@
 
 import copy
 import gc
+import os
 
 import lightning.pytorch as pl
 import torch
 
 from lightning_pose.utils.scripts import get_loss_factories, get_model
+from lightning_pose.utils.predictions import predict_dataset, predict_single_video, export_predictions_and_labeled_video
 
 
 def test_predict_dataset(cfg, heatmap_data_module, remove_logs, tmpdir):
@@ -15,9 +17,6 @@ def test_predict_dataset(cfg, heatmap_data_module, remove_logs, tmpdir):
     NOTE: this only tests a heatmap tracker
 
     """
-
-    from lightning_pose.utils.predictions import predict_dataset
-
     # make a basic heatmap tracker
     cfg_tmp = copy.deepcopy(cfg)
     cfg_tmp.model.model_type = "heatmap"
@@ -89,9 +88,6 @@ def test_predict_single_video(cfg, heatmap_data_module, video_list, remove_logs,
     NOTE: this only tests a heatmap tracker
 
     """
-
-    from lightning_pose.utils.predictions import predict_single_video
-
     # make a basic heatmap tracker
     cfg_tmp = copy.deepcopy(cfg)
     cfg_tmp.model.model_type = "heatmap"
@@ -163,6 +159,117 @@ def test_predict_single_video(cfg, heatmap_data_module, video_list, remove_logs,
         model=model,
         save_heatmaps=True,
     )
+
+    # remove tensors from gpu
+    del loss_factories
+    del model
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    # clean up logging
+    remove_logs()
+
+
+def test_export_predictions_and_labeled_video(
+        cfg, heatmap_data_module, video_list, remove_logs, tmpdir):
+    """Test helper function that predicts videos then makes a labeled movie."""
+    # make a basic heatmap tracker
+    cfg_tmp = copy.deepcopy(cfg)
+    cfg_tmp.model.model_type = "heatmap"
+    cfg_tmp.model.losses_to_use = []
+
+    # build loss factory which orchestrates different losses
+    loss_factories = get_loss_factories(cfg=cfg_tmp, data_module=heatmap_data_module)
+
+    # build model
+    model = get_model(cfg=cfg_tmp, data_module=heatmap_data_module, loss_factories=loss_factories)
+
+    # make a checkpoint callback so we know where model is saved
+    ckpt_callback = pl.callbacks.model_checkpoint.ModelCheckpoint(dirpath=str(tmpdir))
+
+    # train model for a couple epochs
+    trainer = pl.Trainer(
+        accelerator="gpu",
+        devices=1,
+        max_epochs=2,
+        min_epochs=2,
+        check_val_every_n_epoch=1,
+        log_every_n_steps=1,
+        callbacks=[ckpt_callback],
+        limit_train_batches=2,
+    )
+    trainer.fit(model=model, datamodule=heatmap_data_module)
+
+    # test 1: all available inputs
+    csv_file = str(tmpdir.join("test1.csv"))
+    mp4_file = str(tmpdir.join("test1.mp4"))
+    npy_file = csv_file.replace(".csv", "_heatmaps.npy")
+    export_predictions_and_labeled_video(
+        video_file=video_list[0],
+        cfg=cfg_tmp,
+        prediction_csv_file=csv_file,
+        ckpt_file=None,
+        trainer=trainer,
+        model=model,
+        data_module=heatmap_data_module,
+        labeled_mp4_file=mp4_file,
+        save_heatmaps=False,
+    )
+    assert os.path.exists(csv_file)
+    assert os.path.exists(mp4_file)
+    assert not os.path.exists(npy_file)
+
+    # test 2: no trainer
+    csv_file = str(tmpdir.join("test2.csv"))
+    mp4_file = str(tmpdir.join("test2.mp4"))
+    npy_file = csv_file.replace(".csv", "_heatmaps.npy")
+    export_predictions_and_labeled_video(
+        video_file=video_list[0],
+        cfg=cfg_tmp,
+        prediction_csv_file=csv_file,
+        ckpt_file=None,
+        trainer=None,
+        model=model,
+        data_module=heatmap_data_module,
+        labeled_mp4_file=mp4_file,
+        save_heatmaps=False,
+    )
+    assert os.path.exists(csv_file)
+    assert os.path.exists(mp4_file)
+    assert not os.path.exists(npy_file)
+
+    # test 3: no trainer, no model, save heatmaps
+    csv_file = str(tmpdir.join("test3.csv"))
+    mp4_file = str(tmpdir.join("test3.mp4"))
+    npy_file = csv_file.replace(".csv", "_heatmaps.npy")
+    export_predictions_and_labeled_video(
+        video_file=video_list[0],
+        cfg=cfg_tmp,
+        prediction_csv_file=csv_file,
+        ckpt_file=ckpt_callback.best_model_path,
+        trainer=None,
+        model=None,
+        data_module=heatmap_data_module,
+        labeled_mp4_file=mp4_file,
+        save_heatmaps=True,
+    )
+    assert os.path.exists(csv_file)
+    assert os.path.exists(mp4_file)
+    assert os.path.exists(npy_file)
+
+    # test 4: raise proper error
+    with pytest.raises(ValueError):
+        export_predictions_and_labeled_video(
+            video_file=video_list[0],
+            cfg=cfg_tmp,
+            prediction_csv_file=str(tmpdir.join("test4.csv")),
+            ckpt_file=None,
+            trainer=trainer,
+            model=None,
+            data_module=heatmap_data_module,
+            labeled_mp4_file=str(tmpdir.join("test3.mp4")),
+            save_heatmaps=False,
+        )
 
     # remove tensors from gpu
     del loss_factories

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -5,10 +5,15 @@ import gc
 import os
 
 import lightning.pytorch as pl
+import pytest
 import torch
 
+from lightning_pose.utils.predictions import (
+    export_predictions_and_labeled_video,
+    predict_dataset,
+    predict_single_video,
+)
 from lightning_pose.utils.scripts import get_loss_factories, get_model
-from lightning_pose.utils.predictions import predict_dataset, predict_single_video, export_predictions_and_labeled_video
 
 
 def test_predict_dataset(cfg, heatmap_data_module, remove_logs, tmpdir):

--- a/tests/utils/test_scripts.py
+++ b/tests/utils/test_scripts.py
@@ -6,24 +6,19 @@ tested) in conftest.py
 """
 
 import copy
-import gc
 import os
 from unittest.mock import Mock
 
 import lightning.pytorch as pl
 import numpy as np
 import pytest
-import torch
 from omegaconf import OmegaConf
 from omegaconf.errors import ValidationError
 
 from lightning_pose.data.datasets import BaseTrackingDataset
 from lightning_pose.utils.scripts import (
     calculate_train_batches,
-    export_predictions_and_labeled_video,
     get_data_module,
-    get_loss_factories,
-    get_model,
 )
 
 
@@ -50,117 +45,6 @@ def test_calculate_train_batches(cfg, base_dataset):
     cfg_tmp.training.train_batch_size = 1
     n_batches = calculate_train_batches(cfg_tmp, base_dataset)
     assert n_batches == n
-
-
-def test_export_predictions_and_labeled_video(
-        cfg, heatmap_data_module, video_list, remove_logs, tmpdir):
-    """Test helper function that predicts videos then makes a labeled movie."""
-    # make a basic heatmap tracker
-    cfg_tmp = copy.deepcopy(cfg)
-    cfg_tmp.model.model_type = "heatmap"
-    cfg_tmp.model.losses_to_use = []
-
-    # build loss factory which orchestrates different losses
-    loss_factories = get_loss_factories(cfg=cfg_tmp, data_module=heatmap_data_module)
-
-    # build model
-    model = get_model(cfg=cfg_tmp, data_module=heatmap_data_module, loss_factories=loss_factories)
-
-    # make a checkpoint callback so we know where model is saved
-    ckpt_callback = pl.callbacks.model_checkpoint.ModelCheckpoint(dirpath=str(tmpdir))
-
-    # train model for a couple epochs
-    trainer = pl.Trainer(
-        accelerator="gpu",
-        devices=1,
-        max_epochs=2,
-        min_epochs=2,
-        check_val_every_n_epoch=1,
-        log_every_n_steps=1,
-        callbacks=[ckpt_callback],
-        limit_train_batches=2,
-    )
-    trainer.fit(model=model, datamodule=heatmap_data_module)
-
-    # test 1: all available inputs
-    csv_file = str(tmpdir.join("test1.csv"))
-    mp4_file = str(tmpdir.join("test1.mp4"))
-    npy_file = csv_file.replace(".csv", "_heatmaps.npy")
-    export_predictions_and_labeled_video(
-        video_file=video_list[0],
-        cfg=cfg_tmp,
-        prediction_csv_file=csv_file,
-        ckpt_file=None,
-        trainer=trainer,
-        model=model,
-        data_module=heatmap_data_module,
-        labeled_mp4_file=mp4_file,
-        save_heatmaps=False,
-    )
-    assert os.path.exists(csv_file)
-    assert os.path.exists(mp4_file)
-    assert not os.path.exists(npy_file)
-
-    # test 2: no trainer
-    csv_file = str(tmpdir.join("test2.csv"))
-    mp4_file = str(tmpdir.join("test2.mp4"))
-    npy_file = csv_file.replace(".csv", "_heatmaps.npy")
-    export_predictions_and_labeled_video(
-        video_file=video_list[0],
-        cfg=cfg_tmp,
-        prediction_csv_file=csv_file,
-        ckpt_file=None,
-        trainer=None,
-        model=model,
-        data_module=heatmap_data_module,
-        labeled_mp4_file=mp4_file,
-        save_heatmaps=False,
-    )
-    assert os.path.exists(csv_file)
-    assert os.path.exists(mp4_file)
-    assert not os.path.exists(npy_file)
-
-    # test 3: no trainer, no model, save heatmaps
-    csv_file = str(tmpdir.join("test3.csv"))
-    mp4_file = str(tmpdir.join("test3.mp4"))
-    npy_file = csv_file.replace(".csv", "_heatmaps.npy")
-    export_predictions_and_labeled_video(
-        video_file=video_list[0],
-        cfg=cfg_tmp,
-        prediction_csv_file=csv_file,
-        ckpt_file=ckpt_callback.best_model_path,
-        trainer=None,
-        model=None,
-        data_module=heatmap_data_module,
-        labeled_mp4_file=mp4_file,
-        save_heatmaps=True,
-    )
-    assert os.path.exists(csv_file)
-    assert os.path.exists(mp4_file)
-    assert os.path.exists(npy_file)
-
-    # test 4: raise proper error
-    with pytest.raises(ValueError):
-        export_predictions_and_labeled_video(
-            video_file=video_list[0],
-            cfg=cfg_tmp,
-            prediction_csv_file=str(tmpdir.join("test4.csv")),
-            ckpt_file=None,
-            trainer=trainer,
-            model=None,
-            data_module=heatmap_data_module,
-            labeled_mp4_file=str(tmpdir.join("test3.mp4")),
-            save_heatmaps=False,
-        )
-
-    # remove tensors from gpu
-    del loss_factories
-    del model
-    gc.collect()
-    torch.cuda.empty_cache()
-
-    # clean up logging
-    remove_logs()
 
 
 def _supervised_multi_gpu_cfg(cfg):


### PR DESCRIPTION
It's a lot of diffs, 1. because I moved some things around.
* export_predictions_and_labeled_video method moved from scripts.py to predictions.py.
* get_context_img_paths moved to io.py
* regenerated api docs.

2. Because of the tests. I checked in some input files, and the cropzoom expected output files. This way we can visually see the cropping. If we make any intentional changes, all we have to do is copy the test output to the expected_model_output directory.