### PR TITLE
Added scale augmentation

### DIFF
--- a/lightning_pose/data/augmentations.py
+++ b/lightning_pose/data/augmentations.py
@@ -125,7 +125,7 @@ def imgaug_transform(cfg: DictConfig) -> iaa.Sequential:
         ))
 
     else:
-        raise NotImplementedError("must choose imgaug kind from 'default', 'dlc', 'dlc-top-down', 'dlc-scale', 'dlc-top-down-scale'")
+        raise NotImplementedError("must choose imgaug kind from 'default', 'dlc','dlc-lr', 'dlc-top-down', 'dlc-scale', 'dlc-top-down-scale'")
 
     # do not resize when using dynamic crop pipeline
     if not cfg.data.get('dynamic_crop', False):

--- a/lightning_pose/data/augmentations.py
+++ b/lightning_pose/data/augmentations.py
@@ -36,12 +36,19 @@ def imgaug_transform(cfg: DictConfig) -> iaa.Sequential:
         # resizing happens below
         print("using default image augmentation pipeline (resizing only)")
 
-    elif kind == "dlc" or kind == "dlc-top-down":
+    elif kind == "dlc" or kind == "dlc-top-down" or kind == "dlc-top-down-scale" or kind == "dlc-scale":
 
         print(f"using {kind} image augmentation pipeline")
 
+        if kind == "dlc-top-down-scale" or kind == "dlc-scale":
+            data_transform.append(
+                iaa.Affine(
+                    scale=(0.5, 1.5),
+                )
+            )
+        
         # flip around horizontal/vertical axes first
-        if kind == "dlc-top-down":
+        if kind == "dlc-top-down" or kind == "dlc-top-down-scale":
             # vertical axis
             data_transform.append(iaa.Fliplr(p=0.5))
             # horizontal axis
@@ -117,7 +124,7 @@ def imgaug_transform(cfg: DictConfig) -> iaa.Sequential:
         ))
 
     else:
-        raise NotImplementedError("must choose imgaug kind from 'default', 'dlc', 'dlc-top-down'")
+        raise NotImplementedError("must choose imgaug kind from 'default', 'dlc', 'dlc-top-down', 'dlc-scale', 'dlc-top-down-scale'")
 
     # do not resize when using dynamic crop pipeline
     if not cfg.data.get('dynamic_crop', False):


### PR DESCRIPTION
So, I did some testing and adding the scale augmentation improved all the models that include images from different sources (where the animals have different sizes). 

I will post a more quantitative analysis when everything is done, but visually things are better *and* the switches are gone! 

I implemented two options. Scaling + DLC and scaling + DLC + horizontal/vertical flips. 

It is getting a bit wild with all the options. I wondered if it makes sense to let the user pass multiple augmentation building blocks and then build the logic around that. So the user passes a list like so: [dlc, topdown, lr, scale]. 

I also noticed that currently the exact settings of the augmentation can't be changed in the config. Maybe it's a bit overkill for now, but I could imagine augmentations being its own part of the config in the future. 
