### PR TITLE
Add support for cropzoom pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,12 +143,14 @@ data/mirror-mouse-example_split/
 data/Chickadee
 
 # random other outputs that might end up in the repo
+lightning_logs/
 grid_artifacts/
 .vscode/
 outputs/
 multirun/
 preds/
 scripts/.ipynb_checkpoints
+tb_logs
 tests/utils/test_cropzoom_data/
 tests/test_model_mirror_mouse/
 tests/test_model_mirror_mouse_multiview/

--- a/.gitignore
+++ b/.gitignore
@@ -143,14 +143,12 @@ data/mirror-mouse-example_split/
 data/Chickadee
 
 # random other outputs that might end up in the repo
-lightning_logs/
 grid_artifacts/
 .vscode/
 outputs/
 multirun/
 preds/
 scripts/.ipynb_checkpoints
-tb_logs
 tests/utils/test_cropzoom_data/
 tests/test_model_mirror_mouse/
 tests/test_model_mirror_mouse_multiview/

--- a/cli/main.py
+++ b/cli/main.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 
 from omegaconf import OmegaConf
 
+# Don't import anything from torch or lightning_pose until needed.
+# These imports are slow and delay CLI help text outputs.
 if TYPE_CHECKING:
     from lightning_pose.model import Model
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -5,7 +5,10 @@ import datetime
 import os
 import sys
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
+
+from omegaconf import OmegaConf
 
 if TYPE_CHECKING:
     from lightning_pose.model import Model
@@ -44,6 +47,11 @@ def _build_parser():
         help="explicitly specifies the output model directory.\n"
         "If not specified, defaults to "
         "./outputs/{YYYY-MM-DD}/{HH:MM:SS}/",
+    )
+    train_parser.add_argument(
+        "--detector_model",
+        type=types.existing_model_dir,
+        help="If specified, uses cropped training data in the detector model's directory.",
     )
     train_parser.add_argument(
         "--overrides",
@@ -94,6 +102,13 @@ def _build_parser():
         "              uses the labels to compute pixel error.\n"
         "              saves outputs to `image_preds/<csv_file_name>`\n",
     )
+    predict_parser.add_argument(
+        "--overrides",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="overrides attributes of the config file. Uses hydra syntax:\n"
+        "https://hydra.cc/docs/advanced/override_grammar/basic/",
+    )
 
     post_prediction_args = predict_parser.add_argument_group("post-prediction")
     post_prediction_args.add_argument(
@@ -101,6 +116,72 @@ def _build_parser():
         action="store_true",
         help="skip generating prediction-annotated images/videos",
     )
+
+    # Crop command
+    crop_parser = subparsers.add_parser(
+        "crop",
+        description=dedent(
+            """\
+            Crops a video or labeled frames based on model predictions.
+            Requires model predictions to already have been generated using `litpose predict`.
+    
+            Cropped videos are saved to:
+                <model_dir>/
+                └── video_preds/
+                    ├── <video_filename>.csv              (predictions)
+                    ├── <video_filename>_bbox.csv         (bbox)
+                    └── remapped_<video_filename>.csv     (TODO move to remap command)
+                └── cropped_videos/
+                    └── cropped_<video_filename>.mp4      (cropped video)
+
+            Cropped images are saved to:
+                <model_dir>/
+                └── image_preds/
+                    └── <csv_file_name>/
+                        ├── predictions.csv
+                        ├── bbox.csv                      (bbox)
+                        └── cropped_<csv_file_name>.csv   (cropped labels)
+                └── cropped_images/
+                        └── a/b/c/<image_name>.png        (cropped images)\
+            """
+        ),
+        usage="litpose crop <model_dir> <input_path:video|csv>... --crop_ratio=CROP_RATIO --anchor_keypoints=x,y,z",
+    )
+    crop_parser.add_argument(
+        "model_dir", type=types.existing_model_dir, help="path to a model directory"
+    )
+
+    crop_parser.add_argument(
+        "input_path", type=Path, nargs="+", help="one or more files"
+    )
+    crop_parser.add_argument(
+        "--crop_ratio",
+        type=float,
+        default=2.0,
+        help="Crop a bounding box this much larger than the animal. Default is 2.",
+    )
+    crop_parser.add_argument(
+        "--anchor_keypoints",
+        type=str,
+        default="",  # Or a reasonable default like "0,0,0" if appropriate
+        help="Comma-separated list of anchor keypoint names, defaults to all keypoints",
+    )
+
+    remap_parser = subparsers.add_parser(
+        "remap",
+        description=dedent(
+            """\
+            Remaps predictions from cropped to original coordinate space.
+            Requires model predictions to already have been generated using `litpose predict`.
+
+            Remapped predictions are saved as "remapped_{preds_file}" in the same folder as preds_file.
+            """
+        ),
+        usage="litpose remap <preds_file> <bbox_file>",
+    )
+    remap_parser.add_argument("preds_file", type=Path, help="path to a prediction file")
+    remap_parser.add_argument("bbox_file", type=Path, help="path to a bbox file")
+
     return parser
 
 
@@ -119,6 +200,84 @@ def main():
 
     elif args.command == "predict":
         _predict(args)
+
+    elif args.command == "crop":
+        _crop(args)
+
+    elif args.command == "remap":
+        _remap_preds(args)
+
+
+def _crop(args: argparse.Namespace):
+    import lightning_pose.utils.cropzoom as cz
+    from lightning_pose.model import Model
+
+    model_dir = args.model_dir
+    model = Model.from_dir(model_dir)
+
+    # Make both cropped_images and cropped_videos dirs. Reason: After this, the user
+    # will train a pose model, and current code in io utils checks that both
+    # data_dir and videos_dir are present. if we just create one or the other,
+    # the check will fail.
+    model.cropped_data_dir().mkdir(parents=True, exist_ok=True)
+    model.cropped_videos_dir().mkdir(parents=True, exist_ok=True)
+
+    input_paths = [Path(p) for p in args.input_path]
+
+    detector_cfg = OmegaConf.create(
+        {
+            "crop_ratio": args.crop_ratio,
+            "anchor_keypoints": args.anchor_keypoints.split(",") if args.anchor_keypoints else [],
+        }
+    )
+    assert detector_cfg.crop_ratio > 1
+
+    for input_path in input_paths:
+        if input_path.suffix == ".mp4":
+            input_preds_file = model.video_preds_dir() / (input_path.stem + ".csv")
+            output_bbox_file = model.video_preds_dir() / (
+                input_path.stem + "_bbox.csv"
+            )
+            output_file = model.cropped_videos_dir() / ("cropped_" + input_path.name)
+
+            cz.generate_cropped_video(
+                input_video_file=input_path,
+                input_preds_file=input_preds_file,
+                detector_cfg=detector_cfg,
+                output_bbox_file=output_bbox_file,
+                output_file=output_file,
+            )
+        elif input_path.suffix == ".csv":
+            preds_dir = model.image_preds_dir() / input_path.name
+            input_data_dir = Path(model.config.cfg.data.data_dir)
+            cropped_data_dir = model.cropped_data_dir()
+
+            output_bbox_file = preds_dir / "bbox.csv"
+            output_csv_file_path = preds_dir / ("cropped_" + input_path.name)
+            input_preds_file = preds_dir / "predictions.csv"
+            cz.generate_cropped_labeled_frames(
+                input_data_dir=input_data_dir,
+                input_csv_file=input_path,
+                input_preds_file=input_preds_file,
+                detector_cfg=detector_cfg,
+                output_data_dir=cropped_data_dir,
+                output_bbox_file=output_bbox_file,
+                output_csv_file=output_csv_file_path,
+            )
+        else:
+            raise NotImplementedError("Only mp4 and csv files are supported.")
+
+
+def _remap_preds(args: argparse.Namespace):
+    import lightning_pose.utils.cropzoom as cz
+
+    output_file = args.preds_file.with_name("remapped_" + args.preds_file.name)
+
+    cz.generate_cropped_csv_file(
+        input_csv_file=args.preds_file,
+        input_bbox_file=args.bbox_file,
+        output_csv_file=output_file,
+    )
 
 
 def _train(args: argparse.Namespace):
@@ -142,11 +301,32 @@ def _train(args: argparse.Namespace):
         cfg = hydra.compose(config_name=args.config_file.stem, overrides=args.overrides)
 
         # Delay this import because it's slow.
+        from lightning_pose.model import Model
         from lightning_pose.train import train
 
         # TODO: Move some aspects of directory mgmt to the train function.
         output_dir.mkdir(parents=True, exist_ok=True)
         # Maintain legacy hydra chdir until downstream no longer depends on it.
+
+        if args.detector_model:
+            # create detector model object before chdir so that relative path is resolved correctly
+            detector_model = Model.from_dir(args.detector_model)
+            import copy
+
+            cfg = copy.deepcopy(cfg)
+            cfg.data.data_dir = str(detector_model.cropped_data_dir())
+            cfg.data.video_dir = str(detector_model.cropped_videos_dir())
+            if isinstance(cfg.data.csv_file, str):
+                cfg.data.csv_file = str(
+                    detector_model.cropped_csv_file_path(cfg.data.csv_file)
+                )
+            else:
+                cfg.data.csv_file = [
+                    str(detector_model.cropped_csv_file_path(f))
+                    for f in cfg.data.csv_file
+                ]
+            cfg.eval.test_videos_directory = cfg.data.video_dir
+
         os.chdir(output_dir)
         train(cfg)
 
@@ -155,7 +335,7 @@ def _predict(args: argparse.Namespace):
     # Delay this import because it's slow.
     from lightning_pose.model import Model
 
-    model = Model.from_dir(args.model_dir)
+    model = Model.from_dir2(args.model_dir, hydra_overrides=args.overrides)
     input_paths = [Path(p) for p in args.input_path]
 
     for p in input_paths:

--- a/cli/main.py
+++ b/cli/main.py
@@ -12,6 +12,8 @@ from omegaconf import OmegaConf
 
 # Don't import anything from torch or lightning_pose until needed.
 # These imports are slow and delay CLI help text outputs.
+# if TYPE_CHECKING allows use of imports for type annotations, without
+# actually invoking the import at runtime.
 if TYPE_CHECKING:
     from lightning_pose.model import Model
 

--- a/docs/api/lightning_pose.utils.cropzoom.generate_cropped_csv_file.rst
+++ b/docs/api/lightning_pose.utils.cropzoom.generate_cropped_csv_file.rst
@@ -1,0 +1,6 @@
+generate_cropped_csv_file
+=========================
+
+.. currentmodule:: lightning_pose.utils.cropzoom
+
+.. autofunction:: generate_cropped_csv_file

--- a/docs/api/lightning_pose.utils.scripts.calculate_steps_per_epoch.rst
+++ b/docs/api/lightning_pose.utils.scripts.calculate_steps_per_epoch.rst
@@ -1,0 +1,6 @@
+calculate_steps_per_epoch
+=========================
+
+.. currentmodule:: lightning_pose.utils.scripts
+
+.. autofunction:: calculate_steps_per_epoch

--- a/docs/api/lightning_pose.utils.scripts.calculate_train_batches.rst
+++ b/docs/api/lightning_pose.utils.scripts.calculate_train_batches.rst
@@ -1,6 +1,0 @@
-calculate_train_batches
-=======================
-
-.. currentmodule:: lightning_pose.utils.scripts
-
-.. autofunction:: calculate_train_batches

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -67,7 +67,7 @@ API Reference:
 
 .. autoclass:: lightning_pose.model.Model
     :members:
-    :exclude-members: __init__, PredictionResult, predict_on_label_csv_internal
+    :exclude-members: __init__, PredictionResult, from_dir2
 
 
 Lightning Pose Internal API

--- a/docs/source/user_guide_advanced/cropzoom_pipeline.rst
+++ b/docs/source/user_guide_advanced/cropzoom_pipeline.rst
@@ -1,0 +1,123 @@
+########################
+Cropzoom pipeline
+########################
+
+For setups where an animal is freely moving in a large arena,
+it's advantageous to crop around the animal before running pose estimation.
+Lightning-pose calls this technique "cropzoom". This document describes how
+to set up a such a pipeline.
+
+Conceptual overview
+===================
+
+A cropzoom pipeline consists of two lightning-pose models:
+a "detector model" and a "pose model".
+
+* The detector model operates on the full image of the arena.
+* The pose model operates on the cropped animal.
+
+These two models are trained and predicted like any other
+lightning pose model. We provide additional tools that help you compose these models:
+
+* ``litpose crop``: Given the detector model's predictions, crops around the animal.
+* ``litpose remap``: Given the pose model's predictions and the crop bounding boxes,
+  remaps the predictions to the original coordinate space.
+
+Training
+--------
+
+Training involves:
+
+1. Train a "detector model"
+2. Crop training data for the pose model.
+3. Train a "pose model".
+
+Inference
+---------
+
+Inference involves:
+
+1. Predict using the "detector model"
+2. Crop the data using the above predictions
+3. Predict on the cropped data using the "pose model".
+4. Remap the pose model's predictions to the original coordinate space.
+
+
+Example
+=======
+
+This is a basic example of how you can setup a cropzoom pipeline.
+Paths to CSV and MP4 files below should be replaced with your files.
+The example is illustrative only. In reality you might be interested in
+making modifications to this such as:
+
+1. Using different model type, backbone, image_resize_dims for
+   your detector model and pose model. This can be accomplished using
+   different config files for the detector and pose model.
+2. Limiting ``train_frames`` and ``max_epochs`` for testing purposes.
+
+We'll use some bash variables to avoid repeating paths below:
+
+.. code-block:: bash
+
+    MODEL_DIR=outputs/chickadee/cropzoom
+    DETECTOR_MODEL=detector_0
+    POSE_MODEL=pose_supervised_0
+
+Training script
+---------------
+
+.. code-block:: bash
+
+    #!/bin/bash
+
+    # Train the detector model.
+    litpose train config.yaml --output_dir $MODEL_DIR/$DETECTOR_MODEL
+
+    # Crop data for pose model training.
+    litpose crop $MODEL_DIR/$DETECTOR_MODEL data/CollectedData.csv
+
+    # Train the pose model.
+    litpose train config.yaml --output_dir $MODEL_DIR/$POSE_MODEL \
+        --detector_model=$MODEL_DIR/$DETECTOR_MODEL
+
+Prediction on videos script
+---------------------------
+
+.. code-block:: bash
+
+    #!/bin/bash
+
+    litpose predict $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4
+
+    litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4
+
+    litpose predict $MODEL_DIR/$POSE_MODEL $MODEL_DIR/$DETECTOR_MODEL/cropped_videos/cropped_test_vid.short.mp4
+
+    litpose remap $MODEL_DIR/$POSE_MODEL/video_preds/cropped_TRQ177_200624_112234_lBack.short.csv \
+        $MODEL_DIR/$DETECTOR_MODEL/video_preds/test_vid.short_bbox.csv
+
+Prediction on OOD Labeled Data
+------------------------------
+
+Say you have new labeled data for OoD animals, at `data/CollectedData_new.csv`,
+and you want to predict on these frames as well as compute pixel error.
+
+.. code-block:: bash
+
+    #!/bin/bash
+
+    litpose predict $MODEL_DIR/$DETECTOR_MODEL data/CollectedData_new.csv
+
+    litpose crop $MODEL_DIR/$DETECTOR_MODEL data/CollectedData_new.csv
+
+    litpose predict $MODEL_DIR/$POSE_MODEL \
+      $MODEL_DIR/$DETECTOR_MODEL/image_preds/CollectedData_new.csv/cropped_CollectedData_new.csv
+
+    litpose remap $MODEL_DIR/$POSE_MODEL/image_preds/cropped_CollectedData_new.csv/predictions.csv \
+      $MODEL_DIR/$DETECTOR_MODEL/image_preds/CollectedData_new.csv/bbox.csv
+
+Limitations
+===========
+
+* Pose models do not yet support PCA Multiview loss.

--- a/docs/source/user_guide_advanced/index.rst
+++ b/docs/source/user_guide_advanced/index.rst
@@ -15,3 +15,4 @@ For each feature, we point out necessary modifications and useful information re
    multiview_fused
    multiview_separate
    multi_gpu_training
+   cropzoom_pipeline

--- a/lightning_pose/__init__.py
+++ b/lightning_pose/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 from pathlib import Path
 

--- a/lightning_pose/model.py
+++ b/lightning_pose/model.py
@@ -16,9 +16,8 @@ from lightning_pose.utils.predictions import (
     predict_dataset,
 )
 
-# Import as different name to avoid naming conflict with the kwarg `compute_metrics`.
-from lightning_pose.utils.scripts import compute_metrics as compute_metrics_fn
 from lightning_pose.utils.scripts import (
+    compute_metrics_single,
     get_data_module,
     get_dataset,
     get_imgaug_transform,
@@ -46,8 +45,26 @@ class Model:
     @staticmethod
     def from_dir(model_dir: str | Path):
         """Create a `Model` instance for a model stored at `model_dir`."""
-        model_dir = Path(model_dir)
-        config = ModelConfig.from_yaml_file(model_dir / "config.yaml")
+        return Model.from_dir2(model_dir)
+
+    @staticmethod
+    def from_dir2(model_dir: str | Path, hydra_overrides: list[str] = None):
+        """Internal version of from_dir that supports hydra_overrides. Not sure whether to
+        promote this to public API yet."""
+
+        model_dir = Path(model_dir).absolute()
+
+        if hydra_overrides is not None:
+            import hydra
+
+            with hydra.initialize_config_dir(
+                version_base="1.1", config_dir=str(model_dir)
+            ):
+                cfg = hydra.compose(config_name="config", overrides=hydra_overrides)
+                config = ModelConfig(cfg)
+        else:
+            config = ModelConfig.from_yaml_file(model_dir / "config.yaml")
+
         return Model(model_dir, config)
 
     def __init__(self, model_dir: str | Path, config: ModelConfig):
@@ -80,6 +97,21 @@ class Model:
     def labeled_videos_dir(self) -> Path:
         return self.model_dir / "video_preds" / "labeled_videos"
 
+    def cropped_data_dir(self):
+        return self.model_dir / "cropped_images"
+
+    def cropped_videos_dir(self):
+        return self.model_dir / "cropped_videos"
+
+    def cropped_csv_file_path(self, csv_file_path: str | Path):
+        csv_file_path = Path(csv_file_path)
+        return (
+            self.model_dir
+            / "image_preds"
+            / csv_file_path.name
+            / ("cropped_" + csv_file_path.name)
+        )
+
     class PredictionResult(TypedDict):
         predictions: pd.DataFrame
         metrics: pd.DataFrame
@@ -91,6 +123,7 @@ class Model:
         compute_metrics: bool = True,
         generate_labeled_images: bool = False,
         output_dir: str | Path | None = UNSPECIFIED,
+        add_train_val_test_set: bool = False,
     ) -> PredictionResult:
         """Predicts on a labeled dataset and computes error/loss metrics if applicable.
 
@@ -103,40 +136,11 @@ class Model:
             generate_labeled_images (bool, optional): Whether to save labeled images. Defaults to False.
             output_dir (str | Path, optional): The directory to save outputs to.
                 Defaults to `{model_dir}/image_preds/{csv_file_name}`. If set to None, outputs are not saved.
+            add_train_val_test_set (bool): When predicting on training dataset, set to true to add the `set`
+                column to the prediction output.
         Returns:
             PredictionResult: A PredictionResult object containing the predictions and metrics.
         """
-        return self.predict_on_label_csv_internal(
-            csv_file=csv_file,
-            data_dir=data_dir,
-            compute_metrics=compute_metrics,
-            generate_labeled_images=generate_labeled_images,
-            output_dir=output_dir,
-            output_filename_stem="predictions",
-            add_train_val_test_set=False,
-        )
-
-    def predict_on_label_csv_internal(
-        self,
-        csv_file: str | Path,
-        data_dir: str | Path | None = None,
-        compute_metrics: bool = True,
-        generate_labeled_images: bool = False,
-        output_dir: str | Path | None = UNSPECIFIED,
-        output_filename_stem: str = "predictions",
-        add_train_val_test_set: bool = False,
-    ) -> PredictionResult:
-        """
-        See predict_on_label_csv for the rest of the arguments. The following are the
-        arguments specific to the internal function.
-        Args:
-            output_filename_stem (str): The stem of the output filename. Defaults to 'predictions'.
-                Used to generate predictions_new for OOD, and predictions_{view_name} for multi-view, in the
-                model_dir.
-            add_train_val_test_set (bool): When predicting on training dataset, set to true to add the `set`
-                column to the prediction output.
-        """
-
         self._load()
         # Convert this to absolute, because if relative, downstream will
         # assume incorrectly assume its relative to the data_dir.
@@ -157,6 +161,8 @@ class Model:
             raise NotImplementedError()
 
         # Point predict_dataset to the csv_file and data_dir.
+        # HACK: For true multi-view model, trick predict_dataset and compute_metrics
+        # into thinking this is a single-view model.
         cfg_overrides = {
             "data": {
                 "data_dir": str(data_dir),
@@ -180,7 +186,7 @@ class Model:
 
         data_module_pred = _build_datamodule_pred(cfg_pred)
 
-        preds_file_path = output_dir / (output_filename_stem + ".csv")
+        preds_file_path = output_dir / "predictions.csv"
         preds_file = str(preds_file_path)
 
         df = predict_dataset(
@@ -188,15 +194,12 @@ class Model:
         )
 
         if compute_metrics:
-            # HACK: True multi-view model treated as single-view model, so preds_file is
-            # a string, not a list per-view. This means we can't yet compute pca_multiview.
-            compute_metrics_fn(
+            compute_metrics_single(
                 cfg=cfg_pred,
+                labels_file=str(csv_file),
                 preds_file=preds_file,
                 data_module=data_module_pred,
             )
-
-        # TODO: Generate detector outputs.
 
         return self.PredictionResult(predictions=df)
 
@@ -254,9 +257,14 @@ class Model:
         )
 
         if compute_metrics:
-            # FIXME: This is only used for computing PCA metrics.
+            # FIXME: Data module is only used for computing PCA metrics.
             data_module = _build_datamodule_pred(self.cfg)
-            compute_metrics_fn(self.cfg, str(prediction_csv_file), data_module)
+            compute_metrics_single(
+                cfg=self.cfg,
+                labels_file=None,
+                preds_file=str(prediction_csv_file),
+                data_module=data_module,
+            )
 
         return self.PredictionResult(predictions=df)
 

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -452,6 +452,7 @@ def get_model(
 def get_callbacks(
     cfg: DictConfig,
     early_stopping=False,
+    checkpointing=True,
     lr_monitor=True,
     ckpt_every_n_epochs=None,
     backbone_unfreeze=True,
@@ -481,13 +482,14 @@ def get_callbacks(
         callbacks.append(lr_monitor)
 
     # always save out best model
-    ckpt_best_callback = pl.callbacks.model_checkpoint.ModelCheckpoint(
-        monitor="val_supervised_loss",
-        mode="min",
-        filename="{epoch}-{step}-best",
-        enable_version_counter=False,
-    )
-    callbacks.append(ckpt_best_callback)
+    if checkpointing:
+        ckpt_best_callback = pl.callbacks.model_checkpoint.ModelCheckpoint(
+            monitor="val_supervised_loss",
+            mode="min",
+            filename="{epoch}-{step}-best",
+            enable_version_counter=False,
+        )
+        callbacks.append(ckpt_best_callback)
 
     if ckpt_every_n_epochs:
         # if ckpt_every_n_epochs is not None, save separate checkpoint files
@@ -533,20 +535,13 @@ def compute_metrics(
         cfg: the config used to determine whether single or multiview and which metrics
             to compute
         preds_file: Path to model predictions used to compute metrics.
-            For multiview, a list of paths.
+            For multiview, a list of prediction files corresponding to the csv_files.
 
-        """
-    if (
-        cfg.data.get("view_names", None)
-        and len(cfg.data.view_names) > 1
-        and isinstance(preds_file, list)
-    ):
-        for view_name, csv_file, preds_file_ in zip(
-                sorted(cfg.data.view_names),
-                sorted(cfg.data.csv_file),
-                sorted(preds_file)
-        ):
-            assert view_name in preds_file_
+    """
+    if not isinstance(cfg.data.csv_file, str):
+        assert isinstance(preds_file, list)
+        assert len(preds_file) == len(cfg.data.csv_file)
+        for csv_file, preds_file_ in zip(cfg.data.csv_file, preds_file):
             labels_file = Path(csv_file)
             if not labels_file.is_absolute():
                 labels_file = Path(cfg.data.data_dir) / labels_file
@@ -558,48 +553,43 @@ def compute_metrics(
                 data_module=data_module,
             )
     else:
-        if isinstance(cfg.data.csv_file, str):
-            labels_file = io_utils.return_absolute_path(
-                os.path.join(cfg.data.data_dir, cfg.data.csv_file)
-            )
-        else:
-            labels_file = io_utils.return_absolute_path(
-                os.path.join(cfg.data.data_dir, cfg.data.csv_file[0])
-            )
+        assert isinstance(cfg.data.csv_file, str)
+        labels_file = Path(cfg.data.csv_file)
+        if not labels_file.is_absolute():
+            labels_file = Path(cfg.data.data_dir) / labels_file
+        labels_file = io_utils.return_absolute_path(labels_file)
         compute_metrics_single(
-            cfg=cfg, labels_file=labels_file, preds_file=preds_file, data_module=data_module,
+            cfg=cfg,
+            labels_file=labels_file,
+            preds_file=preds_file,
+            data_module=data_module,
         )
 
 
 @typechecked
 def compute_metrics_single(
     cfg: DictConfig,
-    labels_file: str,
+    labels_file: str | None,
     preds_file: str,
     data_module: BaseDataModule | UnlabeledDataModule | None = None,
 ) -> None:
     """Compute various metrics on a predictions csv file from a single view."""
-
-    # get keypoint names
-    labels_df = pd.read_csv(labels_file, header=[0, 1, 2], index_col=0)
-    labels_df = io_utils.fix_empty_first_row(labels_df)
-    keypoint_names = io_utils.get_keypoint_names(
-        cfg, csv_file=labels_file, header_rows=[0, 1, 2])
     # load predictions
     pred_df = pd.read_csv(preds_file, header=[0, 1, 2], index_col=0)
+    keypoint_names = io_utils.get_keypoint_names(
+        cfg, csv_file=preds_file, header_rows=[0, 1, 2])
     xyl_mask = pred_df.columns.get_level_values("coords").isin(["x", "y", "likelihood"])
     tmp = pred_df.loc[:, xyl_mask].to_numpy().reshape(pred_df.shape[0], -1, 3)
 
+    index = pred_df.index
     if pred_df.keys()[-1][0] == "set":
         # these are predictions on labeled data
         # get rid of last column that contains info about train/val/test set
         is_video = False
-        index = labels_df.index
         set = pred_df.iloc[:, -1].to_numpy()
     else:
         # these are predictions on video data
         is_video = True
-        index = pred_df.index
         set = None
 
     keypoints_pred = tmp[:, :, :2]  # shape (samples, n_keypoints, 2)
@@ -609,9 +599,11 @@ def compute_metrics_single(
     if is_video:
         metrics_to_compute = ["temporal"]
     else:  # labeled data
+        assert labels_file is not None
         metrics_to_compute = ["pixel_error"]
     # for either labeled and unlabeled data, if a pca loss is specified in config, we compute the
     # associated metric
+
     if (
         data_module is not None
         and cfg.data.get("columns_for_singleview_pca", None) is not None
@@ -630,6 +622,11 @@ def compute_metrics_single(
     preds_file_path = Path(preds_file)
     # compute metrics; csv files will be saved to the same directory the prdictions are stored in
     if "pixel_error" in metrics_to_compute:
+        # Read labeled data
+        labels_df = pd.read_csv(labels_file, header=[0, 1, 2], index_col=0)
+        labels_df = io_utils.fix_empty_first_row(labels_df)
+        assert labels_df.index.equals(index)
+
         keypoints_true = labels_df.to_numpy().reshape(labels_df.shape[0], -1, 2)
         error_per_keypoint = pixel_error(keypoints_true, keypoints_pred)
         error_df = pd.DataFrame(error_per_keypoint, index=index, columns=keypoint_names)

--- a/tests/fetch_test_data.py
+++ b/tests/fetch_test_data.py
@@ -7,7 +7,7 @@ import requests
 
 def fetch_test_data_if_needed(dir: Path, dataset_name: str) -> None:
     datasets_url_dict = {
-        "test_cropzoom_data": "https://figshare.com/ndownloader/files/51015435",
+        "test_cropzoom_data": "https://figshare.com/ndownloader/files/52544084",
         "test_model_mirror_mouse": "https://figshare.com/ndownloader/files/51726884",
         "test_model_mirror_mouse_multiview": "https://figshare.com/ndownloader/files/51727520",
     }

--- a/tests/models/test_heatmap_tracker.py
+++ b/tests/models/test_heatmap_tracker.py
@@ -8,7 +8,6 @@ def test_supervised_heatmap(
     heatmap_data_module,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a supervised heatmap model."""
@@ -22,7 +21,6 @@ def test_supervised_heatmap(
         data_module=heatmap_data_module,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )
 
 
@@ -31,7 +29,6 @@ def test_supervised_multiview_heatmap(
     multiview_heatmap_data_module,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a supervised heatmap model."""
@@ -45,7 +42,6 @@ def test_supervised_multiview_heatmap(
         data_module=multiview_heatmap_data_module,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )
 
 
@@ -54,7 +50,6 @@ def test_semisupervised_heatmap_temporal_pcasingleview(
     heatmap_data_module_combined,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a semi-supervised heatmap model."""
@@ -68,7 +63,6 @@ def test_semisupervised_heatmap_temporal_pcasingleview(
         data_module=heatmap_data_module_combined,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )
 
 
@@ -77,7 +71,6 @@ def test_semisupervised_multiview_heatmap_multiview(
     multiview_heatmap_data_module_combined,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a semi-supervised multiview heatmap model."""
@@ -91,5 +84,4 @@ def test_semisupervised_multiview_heatmap_multiview(
         data_module=multiview_heatmap_data_module_combined,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )

--- a/tests/models/test_heatmap_tracker_mhcrnn.py
+++ b/tests/models/test_heatmap_tracker_mhcrnn.py
@@ -8,7 +8,6 @@ def test_supervised_heatmap_mhcrnn(
     heatmap_data_module_context,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a supervised heatmap mhcrnn model."""
@@ -22,7 +21,6 @@ def test_supervised_heatmap_mhcrnn(
         data_module=heatmap_data_module_context,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )
 
 
@@ -31,7 +29,6 @@ def test_supervised_multiview_heatmap_mhcrnn(
     multiview_heatmap_data_module_context,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a supervised heatmap mhcrnn model."""
@@ -45,7 +42,6 @@ def test_supervised_multiview_heatmap_mhcrnn(
         data_module=multiview_heatmap_data_module_context,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )
 
 
@@ -54,7 +50,6 @@ def test_semisupervised_heatmap_mhcrnn_pcasingleview(
     heatmap_data_module_combined_context,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a semi-supervised heatmap mhcrnn model.
@@ -72,7 +67,6 @@ def test_semisupervised_heatmap_mhcrnn_pcasingleview(
         data_module=heatmap_data_module_combined_context,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )
 
 
@@ -81,7 +75,6 @@ def test_semisupervised_heatmap_mhcrnn_pcasingleview_vit(
     heatmap_data_module_combined_context,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a semi-supervised heatmap mhcrnn model ViT backbone.
@@ -100,7 +93,6 @@ def test_semisupervised_heatmap_mhcrnn_pcasingleview_vit(
         data_module=heatmap_data_module_combined_context,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )
 
 
@@ -109,7 +101,6 @@ def test_semisupervised_multiview_heatmap_mhcrnn_multiview(
     multiview_heatmap_data_module_combined_context,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a semi-supervised multiview heatmap model."""
@@ -123,5 +114,4 @@ def test_semisupervised_multiview_heatmap_mhcrnn_multiview(
         data_module=multiview_heatmap_data_module_combined_context,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )

--- a/tests/models/test_regression_tracker.py
+++ b/tests/models/test_regression_tracker.py
@@ -8,7 +8,6 @@ def test_supervised_regression(
     base_data_module,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a supervised regression model."""
@@ -21,7 +20,6 @@ def test_supervised_regression(
         data_module=base_data_module,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )
 
 
@@ -30,7 +28,6 @@ def test_semisupervised_regression_temporal_pcasingleview(
     base_data_module_combined,
     video_dataloader,
     trainer,
-    remove_logs,
     run_model_test,
 ):
     """Test the initialization and training of a semi-supervised regression model."""
@@ -43,5 +40,4 @@ def test_semisupervised_regression_temporal_pcasingleview(
         data_module=base_data_module_combined,
         video_dataloader=video_dataloader,
         trainer=trainer,
-        remove_logs_fn=remove_logs,
     )

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -88,7 +88,13 @@ def test_generate_cropped_labeled_frames(tmp_path, request):
         {"crop_ratio": 1.5, "anchor_keypoints": ["A_head", "D_tailtip"]}
     )
     generate_cropped_labeled_frames(
-        root_directory, tmp_model_directory, detector_cfg=detector_cfg
+        input_data_dir=root_directory,
+        input_csv_file=root_directory / "CollectedData.csv",
+        input_preds_file=tmp_model_directory / "predictions.csv",
+        detector_cfg=detector_cfg,
+        output_data_dir=tmp_model_directory / "cropped_images",
+        output_bbox_file=tmp_model_directory / "cropped_images" / "bbox.csv",
+        output_csv_file=tmp_model_directory / "cropped_images" / "cropped_labels.csv",
     )
 
     # Assert cropzoom output matches expected output.
@@ -99,8 +105,8 @@ def test_generate_cropped_labeled_frames(tmp_path, request):
         / "expected_model_output"
         / "cropped_images",
     )
-    # Successfully compared 23 objects.
-    assert comparison == 23
+    # Successfully compared 24 objects.
+    assert comparison == 24
 
 
 @pytest.mark.skip(reason="Failing on axon, TODO FIXME.")
@@ -124,7 +130,15 @@ def test_generate_cropped_video(tmp_path, request):
     )
     for video_path in video_directory.iterdir():
         generate_cropped_video(
-            video_path, tmp_model_directory, detector_cfg=detector_cfg
+            input_video_file=video_path,
+            input_preds_file=tmp_model_directory
+            / "video_preds"
+            / (video_path.stem + ".csv"),
+            detector_cfg=detector_cfg,
+            output_bbox_file=tmp_model_directory
+            / "cropped_videos"
+            / (video_path.stem + "_bbox.csv"),
+            output_file=tmp_model_directory / "cropped_videos" / video_path.name,
         )
 
     # Assert cropzoom output matches expected output.

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -109,7 +109,7 @@ def test_generate_cropped_labeled_frames(tmp_path, request):
     assert comparison == 24
 
 
-@pytest.mark.skip(reason="Failing on axon, TODO FIXME.")
+#@pytest.mark.skip(reason="Failing on axon, TODO FIXME.")
 def test_generate_cropped_video(tmp_path, request):
     # Fetch a dataset and a fully trained model's predictions on it.
     fetch_test_data_if_needed(request.path.parent, "test_cropzoom_data")

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -109,7 +109,7 @@ def test_generate_cropped_labeled_frames(tmp_path, request):
     assert comparison == 24
 
 
-#@pytest.mark.skip(reason="Failing on axon, TODO FIXME.")
+@pytest.mark.skip(reason="Failing on axon, TODO FIXME.")
 def test_generate_cropped_video(tmp_path, request):
     # Fetch a dataset and a fully trained model's predictions on it.
     fetch_test_data_if_needed(request.path.parent, "test_cropzoom_data")

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -16,7 +16,7 @@ from lightning_pose.utils.predictions import (
 from lightning_pose.utils.scripts import get_loss_factories, get_model
 
 
-def test_predict_dataset(cfg, heatmap_data_module, remove_logs, tmpdir):
+def test_predict_dataset(cfg, heatmap_data_module, tmpdir):
     """Test the prediction of a dataset after model training.
 
     NOTE: this only tests a heatmap tracker
@@ -45,6 +45,7 @@ def test_predict_dataset(cfg, heatmap_data_module, remove_logs, tmpdir):
         check_val_every_n_epoch=1,
         log_every_n_steps=1,
         callbacks=[ckpt_callback],
+        logger=False,
         limit_train_batches=2,
     )
     trainer.fit(model=model, datamodule=heatmap_data_module)
@@ -83,11 +84,8 @@ def test_predict_dataset(cfg, heatmap_data_module, remove_logs, tmpdir):
     gc.collect()
     torch.cuda.empty_cache()
 
-    # clean up logging
-    remove_logs()
 
-
-def test_predict_single_video(cfg, heatmap_data_module, video_list, remove_logs, tmpdir):
+def test_predict_single_video(cfg, heatmap_data_module, video_list, tmpdir):
     """Test the prediction of a video after model training.
 
     NOTE: this only tests a heatmap tracker
@@ -116,6 +114,7 @@ def test_predict_single_video(cfg, heatmap_data_module, video_list, remove_logs,
         check_val_every_n_epoch=1,
         log_every_n_steps=1,
         callbacks=[ckpt_callback],
+        logger=False,
         limit_train_batches=2,
     )
     trainer.fit(model=model, datamodule=heatmap_data_module)
@@ -171,12 +170,10 @@ def test_predict_single_video(cfg, heatmap_data_module, video_list, remove_logs,
     gc.collect()
     torch.cuda.empty_cache()
 
-    # clean up logging
-    remove_logs()
-
 
 def test_export_predictions_and_labeled_video(
-        cfg, heatmap_data_module, video_list, remove_logs, tmpdir):
+    cfg, heatmap_data_module, video_list, tmpdir
+):
     """Test helper function that predicts videos then makes a labeled movie."""
     # make a basic heatmap tracker
     cfg_tmp = copy.deepcopy(cfg)
@@ -201,6 +198,7 @@ def test_export_predictions_and_labeled_video(
         check_val_every_n_epoch=1,
         log_every_n_steps=1,
         callbacks=[ckpt_callback],
+        logger=False,
         limit_train_batches=2,
     )
     trainer.fit(model=model, datamodule=heatmap_data_module)
@@ -281,6 +279,3 @@ def test_export_predictions_and_labeled_video(
     del model
     gc.collect()
     torch.cuda.empty_cache()
-
-    # clean up logging
-    remove_logs()


### PR DESCRIPTION
I have refactored it so that there is no cropzoom in the core lightning_pose code. All cropzoom stuff is invoked externally using `litpose crop` and `litpose remap`.

Reasons for this:
- allow us to modify cropzoom things without risk of breaking core lightning pose code
- if something fails, we can re-run just that thing (instead of all of training, or all of prediction)
- train, predict, crop, remap commands can be farmed out to different kinds of machines using slurm or lightning jobs.

See docs: https://lightning-pose--250.org.readthedocs.build/en/250/source/user_guide_advanced/cropzoom_pipeline.html