### PR TITLE
imgaug refactor

### DIFF
--- a/docs/api/lightning_pose.callbacks.UnfreezeBackbone.rst
+++ b/docs/api/lightning_pose.callbacks.UnfreezeBackbone.rst
@@ -1,0 +1,17 @@
+UnfreezeBackbone
+================
+
+.. currentmodule:: lightning_pose.callbacks
+
+.. autoclass:: UnfreezeBackbone
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~UnfreezeBackbone.on_train_batch_start
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: on_train_batch_start

--- a/docs/source/user_guide/config_file.rst
+++ b/docs/source/user_guide/config_file.rst
@@ -77,6 +77,9 @@ See the :ref:`FAQs <faq_oom>` for more information on memory management.
   * dlc-lr: dlc augmentations plus horizontal flips
   * dlc-top-down: dlc augmentations plus additional vertical and horizontal flips
 
+  You can also define custom augmentation pipelines following
+  :ref:`these instructions <custom_imgaug_pipeline>`.
+
 * ``training.train_batch_size`` (*int, default: 16*): batch size for labeled data during training
 
 * ``training.val_batch_size`` (*int, default: 32*): batch size for labeled data during validation

--- a/docs/source/user_guide_advanced/custom_imgaug_pipeline.rst
+++ b/docs/source/user_guide_advanced/custom_imgaug_pipeline.rst
@@ -1,0 +1,113 @@
+.. _custom_imgaug_pipeline:
+
+#############################
+Custom augmentation pipelines
+#############################
+
+Overview
+========
+
+Data augmentation is essential for robust pose estimation.
+Augmentations fall into two categories:
+
+* **Image-only augmentations**: Modify images while preserving keypoint positions
+  (e.g., Gaussian noise, pixel dropout)
+* **Image-and-keypoint augmentations**: Transform both images and ground truth keypoints
+  (e.g., cropping, rotation)
+
+Built-in pipelines
+==================
+
+Lightning Pose provides predefined augmentation pipelines accessible via the ``training.imgaug``
+field in the config file.
+Set this to a string corresponding to one of the available options (see the
+:ref:`configuration file documentation<config_file>`).
+
+Creating custom pipelines
+=========================
+To define a custom augmentation pipeline, replace the string value in ``training.imgaug`` with a
+list of augmentations.
+For each augmentation, specify:
+
+1. The transformation name (from the `imgaug package <https://imgaug.readthedocs.io/>`_)
+2. Application probability
+3. Required arguments
+
+Simple example
+--------------
+This example applies an
+`Affine <https://imgaug.readthedocs.io/en/latest/source/overview/geometric.html#affine>`_
+transformation that randomly rotates images and keypoints between -10 and 10 degrees with 50%
+probability.
+
+.. code-block:: yaml
+
+    training:
+      imgaug:
+        Affine:
+          p: 0.5
+          kwargs:
+            rotate: [-10, 10]
+
+* ``p``: Probability of applying the transformation
+* ``kwargs`` arguments passed to the Affine function.
+
+Complex example: 'dlc' pipeline
+-------------------------------
+
+This more complex example combines multiple transformations.
+The order listed in the config file determines the sequence in which transformations are applied.
+
+.. note::
+
+    Parameters defined as tuples in the imgaug documentation must use square brackets in the config
+    file due to OmegaConf's YAML parsing behavior.
+
+.. code-block:: yaml
+
+    training:
+      imgaug:
+        Affine:
+          p: 0.4
+          kwargs:
+            rotate: [-25, 25]
+        MotionBlur:
+          p: 0.5
+          kwargs:
+            k: 5
+            angle: [-90, 90]
+        CoarseDropout:
+          p: 0.5
+          kwargs:
+            p: 0.02
+            size_percent: 0.3
+            per_channel: 0.5
+        CoarseSalt:
+          p: 0.5
+          kwargs:
+            p: 0.01
+            size_percent: [0.05, 0.1]
+        CoarsePepper:
+          p: 0.5
+          kwargs:
+            p: 0.01
+            size_percent: [0.05, 0.1]
+        ElasticTransformation:
+          p: 0.5
+          kwargs:
+            alpha: [0, 10]
+            sigma: 5
+        AllChannelsHistogramEqualization:
+          p: 0.1
+        AllChannelsCLAHE:
+          p: 0.1
+        Emboss:
+          p: 0.1
+          kwargs:
+            alpha: [0, 0.5]
+            strength: [0.5, 1.5]
+        CropAndPad:
+          p: 0.4
+          kwargs:
+            percent: [-0.15, 0.15]
+            keep_size: false

--- a/docs/source/user_guide_advanced/index.rst
+++ b/docs/source/user_guide_advanced/index.rst
@@ -16,3 +16,4 @@ For each feature, we point out necessary modifications and useful information re
    multiview_separate
    multi_gpu_training
    cropzoom_pipeline
+   custom_imgaug_pipeline

--- a/lightning_pose/data/augmentations.py
+++ b/lightning_pose/data/augmentations.py
@@ -16,19 +16,20 @@ def imgaug_transform(params_dict: dict | DictConfig) -> iaa.Sequential:
 
     Args:
         params_dict: each key must be the name of a transform importable from imgaug.augmenters,
-            e.g. "Affine", "Fliplr", etc. The value must be a dictionary with two keys: "p" is the
-            probability of applying the transform (using imgaug.augmenters.Sometimes) and
-            "kwargs" is a dictionary of keyword args sent to that specific augmentation.
+            e.g. "Affine", "Fliplr", etc. The value must be a dict with several optional keys:
+            - "p" (float): probability of applying transform (using imgaug.augmenters.Sometimes)
+            - "args" (list): arguments for transform
+            - "kwargs" (dict): keyword args for the transformation
 
     Examples:
 
-    1. Create a pipeline with
+        Create a pipeline with
         - Affine transformation applied 50% of the time with rotation uniformly sampled from
           (-25, 25) degrees
         - MotionBlur transformation that is applied 25% of the time with a kernel size of 5 pixels
           and blur direction uniformly sampled from (-90, 90) degrees
 
-        >>> params_dict{
+        >>> params_dict = {
         >>>    'Affine': {'p': 0.5, 'kwargs': {'rotate': (-25, 25)}},
         >>>    'MotionBlur': {'p': 0.25, 'kwargs': {'k': 5, 'angle': (-90, 90)}},
         >>> }

--- a/lightning_pose/data/augmentations.py
+++ b/lightning_pose/data/augmentations.py
@@ -1,5 +1,7 @@
 """Functions to build augmentation pipeline."""
 
+from typing import Any
+
 import imgaug.augmenters as iaa
 from omegaconf import DictConfig, ListConfig
 from typeguard import typechecked
@@ -71,11 +73,109 @@ def imgaug_transform(params_dict: dict | DictConfig) -> iaa.Sequential:
         if apply_prob == 0.0:
             pass
         elif apply_prob < 1.0:
-            data_transform.append(iaa.Sometimes(
-                apply_prob,
-                transform(*transform_args, **transform_kwargs),
-            ))
+            data_transform.append(
+                iaa.Sometimes(
+                    apply_prob,
+                    transform(*transform_args, **transform_kwargs),
+                )
+            )
         else:
             data_transform.append(transform(*transform_args, **transform_kwargs))
 
     return iaa.Sequential(data_transform)
+
+
+def expand_imgaug_str_to_dict(params: str) -> dict[str, Any]:
+    params_dict = {}
+    if params in ["default", "none"]:
+        pass  # no augmentations
+    elif params in ["dlc", "dlc-lr", "dlc-top-down"]:
+
+        # flip horizontally
+        if params in ["dlc-lr", "dlc-top-down"]:
+            params_dict["Fliplr"] = {"p": 1.0, "kwargs": {"p": 0.5}}
+
+        # flip vertically
+        if params in ["dlc-top-down"]:
+            params_dict["Flipud"] = {"p": 1.0, "kwargs": {"p": 0.5}}
+
+        # rotate
+        rotation = 25  # rotation uniformly sampled from (-rotation, +rotation)
+        params_dict["Affine"] = {"p": 0.4, "kwargs": {"rotate": (-rotation, rotation)}}
+
+        # motion blur
+        k = 5  # kernel size of blur
+        angle = 90  # blur direction uniformly sampled from (-angle, +angle)
+        params_dict["MotionBlur"] = {
+            "p": 0.5,
+            "kwargs": {"k": k, "angle": (-angle, angle)},
+        }
+
+        # coarse dropout
+        prct = 0.02  # drop `prct` of all pixels by converting them to black pixels
+        size_prct = 0.3  # drop pix on a low-res version of img that's `size_prct` of og
+        per_channel = 0.5  # per_channel transformations on `per_channel` frac of images
+        params_dict["CoarseDropout"] = {
+            "p": 0.5,
+            "kwargs": {
+                "p": prct,
+                "size_percent": size_prct,
+                "per_channel": per_channel,
+            },
+        }
+
+        # coarse salt and pepper
+        # bright reflections can often confuse the model into thinking they are paws
+        # (which can also just be bright blobs) - so include some additional transforms that
+        # put bright blobs (and dark blobs) into the image
+        # bigger chunks than coarse dropout
+        prct = 0.01  # probability of changing a pixel to salt/pepper noise
+        size_prct = (
+            0.05,
+            0.1,
+        )  # drop pix on low-res version of img that's `size_prct` of og
+        params_dict["CoarseSalt"] = {
+            "p": 0.5,
+            "kwargs": {"p": prct, "size_percent": size_prct},
+        }
+        params_dict["CoarsePepper"] = {
+            "p": 0.5,
+            "kwargs": {"p": prct, "size_percent": size_prct},
+        }
+
+        # elastic transform
+        alpha = (0, 10)  # controls strength of displacement
+        sigma = 5  # cotnrols smoothness of displacement
+        params_dict["ElasticTransformation"] = {
+            "p": 0.5,
+            "kwargs": {"alpha": alpha, "sigma": sigma},
+        }
+
+        # hist eq
+        params_dict["AllChannelsHistogramEqualization"] = {"p": 0.1, "kwargs": {}}
+
+        # clahe (contrast limited adaptive histogram equalization) -
+        # hist eq over image patches
+        params_dict["AllChannelsCLAHE"] = {"p": 0.1, "kwargs": {}}
+
+        # emboss
+        alpha = (0, 0.5)  # overlay embossed image on original with alpha in this range
+        strength = (0.5, 1.5)  # strength of embossing lies in this range
+        params_dict["Emboss"] = {
+            "p": 0.1,
+            "kwargs": {"alpha": alpha, "strength": strength},
+        }
+
+        # crop
+        crop_by = 0.15  # number of pix to crop on each side of img given as a fraction
+        params_dict["CropAndPad"] = {
+            "p": 0.4,
+            "kwargs": {"percent": (-crop_by, crop_by), "keep_size": False},
+        }
+    else:
+        raise NotImplementedError(
+            f"cfg.training.imgaug string {params} must be in "
+            "['none', 'default', 'dlc', 'dlc-lr', 'dlc-top-down']"
+        )
+
+    return params_dict

--- a/lightning_pose/data/augmentations.py
+++ b/lightning_pose/data/augmentations.py
@@ -1,7 +1,7 @@
 """Functions to build augmentation pipeline."""
 
 import imgaug.augmenters as iaa
-from omegaconf import DictConfig
+from omegaconf import DictConfig, ListConfig
 from typeguard import typechecked
 
 # to ignore imports for sphix-autoapidoc
@@ -11,121 +11,70 @@ __all__ = [
 
 
 @typechecked
-def imgaug_transform(cfg: DictConfig) -> iaa.Sequential:
-    """Create simple data transform pipeline that augments images.
+def imgaug_transform(params_dict: dict | DictConfig) -> iaa.Sequential:
+    """Create simple and flexible data transform pipeline that augments images and keypoints.
 
     Args:
-        cfg: standard config file that carries around dataset info; relevant is the parameter
-            "cfg.training.imgaug" which can take on the following values:
-            - default: resizing only
-            - dlc: imgaug pipeline implemented in DLC 2.0 package
-            - dlc-top-down: `dlc` pipeline plus random flipping along both horizontal and vertical
-              axes
+        params_dict: each key must be the name of a transform importable from imgaug.augmenters,
+            e.g. "Affine", "Fliplr", etc. The value must be a dictionary with two keys: "p" is the
+            probability of applying the transform (using imgaug.augmenters.Sometimes) and
+            "kwargs" is a dictionary of keyword args sent to that specific augmentation.
+
+    Examples:
+
+    1. Create a pipeline with
+        - Affine transformation applied 50% of the time with rotation uniformly sampled from
+          (-25, 25) degrees
+        - MotionBlur transformation that is applied 25% of the time with a kernel size of 5 pixels
+          and blur direction uniformly sampled from (-90, 90) degrees
+
+        >>> params_dict{
+        >>>    'Affine': {'p': 0.5, 'kwargs': {'rotate': (-25, 25)}},
+        >>>    'MotionBlur': {'p': 0.25, 'kwargs': {'k': 5, 'angle': (-90, 90)}},
+        >>> }
+
+        In a config file, this will look like:
+        >>> training:
+        >>>   imgaug:
+        >>>     Affine:
+        >>>       p: 0.5
+        >>>       kwargs:
+        >>>         rotate: [-10, 10]
+        >>>     MotionBlur:
+        >>>       p: 0.25
+        >>>       kwargs:
+        >>>         k: 5
+        >>>         angle: [-90, 90]
 
     Returns:
         imgaug pipeline
 
     """
 
-    kind = cfg.training.get("imgaug", "default")
-
     data_transform = []
 
-    if kind == "default":
+    for transform_str, args in params_dict.items():
 
-        # resizing happens below
-        print("using default image augmentation pipeline (resizing only)")
+        transform = getattr(iaa, transform_str)
+        apply_prob = args.get("p", 0.5)
+        transform_args = args.get("args", ())
+        transform_kwargs = args.get("kwargs", {})
 
-    elif kind in ["dlc", "dlc-lr", "dlc-top-down"]:
+        # make sure any lists are converted to tuples; DictConfig cannot load tuples from yaml
+        # files, but no iaa args are lists
+        for kw, arg in transform_kwargs.items():
+            if isinstance(arg, list) or isinstance(arg, ListConfig):
+                transform_kwargs[kw] = tuple(arg)
 
-        print(f"using {kind} image augmentation pipeline")
-
-        # flip horizontally/vertically
-        if kind in ["dlc-lr", "dlc-top-down"]:
-            # horizontal flip
-            data_transform.append(iaa.Fliplr(p=0.5))
-        if kind == "dlc-top-down":
-            # vertical flip
-            data_transform.append(iaa.Flipud(p=0.5))
-
-        apply_prob_0 = 0.5
-
-        # rotate
-        rotation = 25  # rotation uniformly sampled from (-rotation, +rotation)
-        data_transform.append(iaa.Sometimes(
-            0.4,
-            iaa.Affine(rotate=(-rotation, rotation))
-        ))
-        # motion blur
-        k = 5  # kernel size of blur
-        angle = 90  # blur direction uniformly sampled from (-angle, +angle)
-        data_transform.append(iaa.Sometimes(
-            apply_prob_0,
-            iaa.MotionBlur(k=k, angle=(-angle, angle))
-        ))
-        # coarse dropout
-        prct = 0.02  # drop `prct` of all pixels by converting them to black pixels
-        size_prct = 0.3  # drop pix on a low-res version of img that's `size_prct` of og
-        per_channel = 0.5  # per_channel transformations on `per_channel` frac of images
-        data_transform.append(iaa.Sometimes(
-            apply_prob_0,
-            iaa.CoarseDropout(p=prct, size_percent=size_prct, per_channel=per_channel)
-        ))
-        # coarse salt and pepper
-        # bright reflections can often confuse the model into thinking they are paws
-        # (which can also just be bright blobs) - so include some additional transforms that put
-        # bright blobs (and dark blobs) into the image
-        prct = 0.01  # probability of changing a pixel to salt/pepper noise
-        size_prct = (0.05, 0.1)  # drop pix on a low-res version of img that's `size_prct` of og
-        data_transform.append(iaa.Sometimes(
-            apply_prob_0,
-            iaa.CoarseSalt(p=prct, size_percent=size_prct),  # bigger chunks than coarse dropout
-        ))
-        data_transform.append(iaa.Sometimes(
-            apply_prob_0,
-            iaa.CoarsePepper(p=prct, size_percent=size_prct),
-        ))
-        # elastic transform
-        alpha = (0, 10)  # controls strength of displacement
-        sigma = 5  # cotnrols smoothness of displacement
-        data_transform.append(iaa.Sometimes(
-            apply_prob_0,
-            iaa.ElasticTransformation(alpha=alpha, sigma=sigma)
-        ))
-        # hist eq
-        data_transform.append(iaa.Sometimes(
-            0.1,
-            iaa.AllChannelsHistogramEqualization()
-        ))
-        # clahe (contrast limited adaptive histogram equalization) -
-        # hist eq over image patches
-        data_transform.append(iaa.Sometimes(
-            0.1,
-            iaa.AllChannelsCLAHE()
-        ))
-        # emboss
-        alpha = (0, 0.5)  # overlay embossed image on original with alpha in this range
-        strength = (0.5, 1.5)  # strength of embossing lies in this range
-        data_transform.append(iaa.Sometimes(
-            0.1,
-            iaa.Emboss(alpha=alpha, strength=strength)
-        ))
-        # crop
-        crop_by = 0.15  # number of pix to crop on each side of img given as a fraction
-        data_transform.append(iaa.Sometimes(
-            0.4,
-            iaa.CropAndPad(percent=(-crop_by, crop_by), keep_size=False)
-        ))
-
-    else:
-        raise NotImplementedError("must choose imgaug kind from 'default', 'dlc', 'dlc-top-down'")
-
-    # do not resize when using dynamic crop pipeline
-    if not cfg.data.get('dynamic_crop', False):
-        data_transform.append(
-            iaa.Resize({
-                "height": cfg.data.image_resize_dims.height,
-                "width": cfg.data.image_resize_dims.width}
+        # add transform to pipeline
+        if apply_prob == 0.0:
+            pass
+        elif apply_prob < 1.0:
+            data_transform.append(iaa.Sometimes(
+                apply_prob,
+                transform(*transform_args, **transform_kwargs),
             ))
+        else:
+            data_transform.append(transform(*transform_args, **transform_kwargs))
 
     return iaa.Sequential(data_transform)

--- a/lightning_pose/data/datamodules.py
+++ b/lightning_pose/data/datamodules.py
@@ -82,7 +82,6 @@ class BaseDataModule(pl.LightningDataModule):
         self.torch_seed = torch_seed
         self._setup()
 
-
     def _setup(self) -> None:
 
         datalen = self.dataset.__len__()
@@ -120,8 +119,20 @@ class BaseDataModule(pl.LightningDataModule):
 
             # only use the final resize transform for the validation and test datasets
             resize_transform = iaa.Sequential([self.dataset.imgaug_transform[-1]])
+
             self.val_dataset.dataset.imgaug_transform = resize_transform
+            if hasattr(self.val_dataset.dataset, "dataset"):
+                # this will get triggered for multiview datasets
+                print(f"val: updating children datasets with resize imgaug pipeline")
+                for view_name, dset in self.val_dataset.dataset.dataset.items():
+                    dset.imgaug_transform = resize_transform
+
             self.test_dataset.dataset.imgaug_transform = resize_transform
+            if hasattr(self.test_dataset.dataset, "dataset"):
+                # this will get triggered for multiview datasets
+                print(f"test: updating children datasets with resize imgaug pipeline")
+                for view_name, dset in self.test_dataset.dataset.dataset.items():
+                    dset.imgaug_transform = resize_transform
 
         # further subsample training data if desired
         if self.train_frames is not None:

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -235,7 +235,7 @@ class HeatmapDataset(BaseTrackingDataset):
             do_context: include additional frames of context if possible
             resize: True to add final resizing augmentation before sending data to network. This
                 can be set to False if inheritors of this class need to implement more
-                sohpisticated augmentations before resizing (e.g. 3d augmentations). Note that when
+                sophisticated augmentations before resizing (e.g. 3d augmentations). Note that when
                 this is False, it is up to the child class to perform this resizing on both images
                 and keypoints before returning a batch of data.
             uniform_heatmaps: True to force the model to output uniform heatmaps for missing data;

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -388,7 +388,14 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
         self.image_resize_width = image_resize_width
         self.do_context = do_context
 
+        # do this here so resizing doesn't get added multiple times when iterating over views
+        if resize:
+            imgaug_transform.add(iaa.Resize({
+                "height": image_resize_height,
+                "width": image_resize_width,
+            }))
         self.imgaug_transform = imgaug_transform
+
         self.downsample_factor = downsample_factor
         self.dataset = {}
         self.keypoint_names = {}
@@ -404,7 +411,7 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
                 imgaug_transform=imgaug_transform,
                 downsample_factor=downsample_factor,
                 do_context=do_context,
-                resize=resize,
+                resize=False,
                 uniform_heatmaps=uniform_heatmaps,
             )
             self.keypoint_names[view] = self.dataset[view].keypoint_names

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -67,7 +67,7 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             do_context: include additional frames of context if possible.
             resize: True to add final resizing augmentation before sending data to network. This
                 can be set to False if inheritors of this class need to implement more
-                sohpisticated augmentations before resizing (e.g. 3d augmentations). Note that when
+                sophisticated augmentations before resizing (e.g. 3d augmentations). Note that when
                 this is False, it is up to the child class to perform this resizing on both images
                 and keypoints before returning a batch of data.
 
@@ -370,7 +370,7 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
             do_context: include additional frames of context if possible
             resize: True to add final resizing augmentation before sending data to network. This
                 can be set to False if inheritors of this class need to implement more
-                sohpisticated augmentations before resizing (e.g. 3d augmentations). Note that when
+                sophisticated augmentations before resizing (e.g. 3d augmentations). Note that when
                 this is False, it is up to the child class to perform this resizing on both images
                 and keypoints before returning a batch of data.
             uniform_heatmaps: True to force the model to output uniform heatmaps for missing data;

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from typing import Callable, List, Literal, Tuple
 
+import imgaug.augmenters as iaa
 import numpy as np
 import pandas as pd
 import torch
@@ -36,9 +37,12 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
         self,
         root_directory: str,
         csv_path: str,
+        image_resize_height: int,
+        image_resize_width: int,
         header_rows: list[int] | None = [0, 1, 2],
         imgaug_transform: Callable | None = None,
         do_context: bool = False,
+        resize: bool = True,
     ) -> None:
         """Initialize a dataset for regression (rather than heatmap) models.
 
@@ -56,16 +60,30 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             csv_path: path to CSV file (within root_directory). CSV file should be in the form
                 (image_path, bodypart_1_x, bodypart_1_y, ..., bodypart_n_y)
                 Note: image_path is relative to the given root_directory
+            resize_height: height to resize images before sending to network
+            resize_width: height to resize images before sending to network
             header_rows: which rows in the csv are header rows
             imgaug_transform: imgaug transform pipeline to apply to images
             do_context: include additional frames of context if possible.
+            resize: True to add final resizing augmentation before sending data to network. This
+                can be set to False if inheritors of this class need to implement more
+                sohpisticated augmentations before resizing (e.g. 3d augmentations). Note that when
+                this is False, it is up to the child class to perform this resizing on both images
+                and keypoints before returning a batch of data.
 
         """
         self.root_directory = Path(root_directory)
+        self.image_resize_height = image_resize_height
+        self.image_resize_width = image_resize_width
         self.csv_path = csv_path
         self.header_rows = header_rows
-        self.imgaug_transform = imgaug_transform
         self.do_context = do_context
+        if resize:
+            imgaug_transform.add(iaa.Resize({
+                "height": image_resize_height,
+                "width": image_resize_width,
+            }))
+        self.imgaug_transform = imgaug_transform
 
         # load csv data
         if os.path.isfile(csv_path):
@@ -98,13 +116,11 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
 
     @property
     def height(self) -> int:
-        # assume resizing transformation is the last imgaug one
-        return self.imgaug_transform[-1].get_parameters()[0][0].value
+        return self.image_resize_height
 
     @property
     def width(self) -> int:
-        # assume resizing transformation is the last imgaug one
-        return self.imgaug_transform[-1].get_parameters()[0][1].value
+        return self.image_resize_width
 
     def __len__(self) -> int:
         return self.data_length
@@ -193,10 +209,13 @@ class HeatmapDataset(BaseTrackingDataset):
         self,
         root_directory: str,
         csv_path: str,
+        image_resize_height: int,
+        image_resize_width: int,
         header_rows: list[int] | None = [0, 1, 2],
         imgaug_transform: Callable | None = None,
         downsample_factor: Literal[1, 2, 3] = 2,
         do_context: bool = False,
+        resize: bool = True,
         uniform_heatmaps: bool = False,
     ) -> None:
         """Initialize the Heatmap Dataset.
@@ -207,19 +226,31 @@ class HeatmapDataset(BaseTrackingDataset):
                 should be in the form
                 (image_path, bodypart_1_x, bodypart_1_y, ..., bodypart_n_y)
                 Note: image_path is relative to the given root_directory
+            image_resize_height: height to resize images before sending to network
+            image_resize_width: height to resize images before sending to network
             header_rows: which rows in the csv are header rows
             imgaug_transform: imgaug transform pipeline to apply to images
             downsample_factor: factor by which to downsample original image dims to have a smaller
                 heatmap
             do_context: include additional frames of context if possible
+            resize: True to add final resizing augmentation before sending data to network. This
+                can be set to False if inheritors of this class need to implement more
+                sohpisticated augmentations before resizing (e.g. 3d augmentations). Note that when
+                this is False, it is up to the child class to perform this resizing on both images
+                and keypoints before returning a batch of data.
+            uniform_heatmaps: True to force the model to output uniform heatmaps for missing data;
+                False will output all-zero heatmaps
 
         """
         super().__init__(
             root_directory=root_directory,
             csv_path=csv_path,
+            image_resize_height=image_resize_height,
+            image_resize_width=image_resize_width,
             header_rows=header_rows,
             imgaug_transform=imgaug_transform,
             do_context=do_context,
+            resize=resize,
         )
 
         if self.height % 128 != 0 or self.height % 128 != 0:
@@ -310,11 +341,14 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
         root_directory: str,
         csv_paths: list[str],
         view_names: list[str],
+        image_resize_height: int,
+        image_resize_width: int,
         header_rows: list[int] | None = [0, 1, 2],
-        downsample_factor: Literal[1, 2, 3] = 2,
-        uniform_heatmaps: bool = False,
-        do_context: bool = False,
         imgaug_transform: Callable | None = None,
+        downsample_factor: Literal[1, 2, 3] = 2,
+        do_context: bool = False,
+        resize: bool = True,
+        uniform_heatmaps: bool = False,
     ) -> None:
         """Initialize the MultiViewHeatmap Dataset.
 
@@ -327,11 +361,21 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
                 Note: image_path is relative to the given root_directory
                 we suggest that these CSV files start with the view numbers
             view_names: a list of integers with the view numbers
+            image_resize_height: height to resize images before sending to network
+            image_resize_width: height to resize images before sending to network
             header_rows: which rows in the csv are header rows
             imgaug_transform: imgaug transform pipeline to apply to images
             downsample_factor: factor by which to downsample original image dims to have a smaller
                 heatmap
             do_context: include additional frames of context if possible
+            resize: True to add final resizing augmentation before sending data to network. This
+                can be set to False if inheritors of this class need to implement more
+                sohpisticated augmentations before resizing (e.g. 3d augmentations). Note that when
+                this is False, it is up to the child class to perform this resizing on both images
+                and keypoints before returning a batch of data.
+            uniform_heatmaps: True to force the model to output uniform heatmaps for missing data;
+                False will output all-zero heatmaps
+
         """
 
         if len(view_names) != len(csv_paths):
@@ -339,6 +383,9 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
 
         self.root_directory = root_directory
         self.csv_paths = csv_paths
+        self.view_names = view_names
+        self.image_resize_height = image_resize_height
+        self.image_resize_width = image_resize_width
         self.do_context = do_context
 
         self.imgaug_transform = imgaug_transform
@@ -351,17 +398,18 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
             self.dataset[view] = HeatmapDataset(
                 root_directory=root_directory,
                 csv_path=csv_path,
+                image_resize_height=image_resize_height,
+                image_resize_width=image_resize_width,
                 header_rows=header_rows,
                 imgaug_transform=imgaug_transform,
                 downsample_factor=downsample_factor,
                 do_context=do_context,
+                resize=resize,
                 uniform_heatmaps=uniform_heatmaps,
             )
             self.keypoint_names[view] = self.dataset[view].keypoint_names
             self.data_length[view] = len(self.dataset[view])
             self.num_keypoints[view] = self.dataset[view].num_keypoints
-
-        self.view_names = view_names
 
         # check if all CSV files have the same number of columns
         self.num_keypoints = sum(self.num_keypoints.values())
@@ -403,12 +451,11 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
 
     @property
     def height(self) -> int:
-        return self.imgaug_transform[-1].get_parameters()[0][0].value
+        return self.image_resize_height
 
     @property
     def width(self) -> int:
-        # assume resizing transformation is the last imgaug one
-        return self.imgaug_transform[-1].get_parameters()[0][1].value
+        return self.image_resize_width
 
     def __len__(self) -> int:
         return self.data_length

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -66,6 +66,8 @@ class DataExtractor(object):
                     dataset_new = HeatmapDataset(
                         root_directory=dataset_old.root_directory,
                         csv_path=dataset_old.csv_path,
+                        image_resize_height=dataset_old.image_resize_height,
+                        image_resize_width=dataset_old.image_resize_width,
                         imgaug_transform=imgaug_new,
                         downsample_factor=dataset_old.downsample_factor,
                         do_context=dataset_old.do_context,
@@ -74,6 +76,8 @@ class DataExtractor(object):
                     dataset_new = BaseTrackingDataset(
                         root_directory=dataset_old.root_directory,
                         csv_path=dataset_old.csv_path,
+                        image_resize_height=dataset_old.image_resize_height,
+                        image_resize_width=dataset_old.image_resize_width,
                         imgaug_transform=imgaug_new,
                         do_context=dataset_old.do_context,
                     )
@@ -82,6 +86,8 @@ class DataExtractor(object):
                         root_directory=dataset_old.root_directory,
                         csv_paths=dataset_old.csv_paths,
                         view_names=dataset_old.view_names,
+                        image_resize_height=dataset_old.image_resize_height,
+                        image_resize_width=dataset_old.image_resize_width,
                         imgaug_transform=imgaug_new,
                         do_context=dataset_old.do_context,
                     )

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -16,7 +16,7 @@ from omegaconf.errors import ValidationError
 from typeguard import typechecked
 
 from lightning_pose.callbacks import AnnealWeight, UnfreezeBackbone
-from lightning_pose.data.augmentations import imgaug_transform
+from lightning_pose.data.augmentations import imgaug_transform, expand_imgaug_str_to_dict
 from lightning_pose.data.datamodules import BaseDataModule, UnlabeledDataModule
 from lightning_pose.data.datasets import (
     BaseTrackingDataset,
@@ -70,84 +70,7 @@ def get_imgaug_transform(cfg: DictConfig) -> iaa.Sequential:
     """
     params = cfg.training.get("imgaug", "default")
     if isinstance(params, str):
-        params_dict = {}
-        if params in ["default", "none"]:
-            pass  # no augmentations
-        elif params in ["dlc", "dlc-lr", "dlc-top-down"]:
-
-            # flip horizontally
-            if params in ["dlc-lr", "dlc-top-down"]:
-                params_dict["Fliplr"] = {"p": 1.0, "kwargs": {"p": 0.5}}
-
-            # flip vertically
-            if params in ["dlc-top-down"]:
-                params_dict["Flipud"] = {"p": 1.0, "kwargs": {"p": 0.5}}
-
-            # rotate
-            rotation = 25  # rotation uniformly sampled from (-rotation, +rotation)
-            params_dict["Affine"] = {"p": 0.4, "kwargs": {"rotate": (-rotation, rotation)}}
-
-            # motion blur
-            k = 5  # kernel size of blur
-            angle = 90  # blur direction uniformly sampled from (-angle, +angle)
-            params_dict["MotionBlur"] = {"p": 0.5, "kwargs": {"k": k, "angle": (-angle, angle)}}
-
-            # coarse dropout
-            prct = 0.02  # drop `prct` of all pixels by converting them to black pixels
-            size_prct = 0.3  # drop pix on a low-res version of img that's `size_prct` of og
-            per_channel = 0.5  # per_channel transformations on `per_channel` frac of images
-            params_dict["CoarseDropout"] = {
-                "p": 0.5,
-                "kwargs": {"p": prct, "size_percent": size_prct, "per_channel": per_channel},
-            }
-
-            # coarse salt and pepper
-            # bright reflections can often confuse the model into thinking they are paws
-            # (which can also just be bright blobs) - so include some additional transforms that
-            # put bright blobs (and dark blobs) into the image
-            # bigger chunks than coarse dropout
-            prct = 0.01  # probability of changing a pixel to salt/pepper noise
-            size_prct = (0.05, 0.1)  # drop pix on low-res version of img that's `size_prct` of og
-            params_dict["CoarseSalt"] = {
-                "p": 0.5,
-                "kwargs": {"p": prct, "size_percent": size_prct},
-            }
-            params_dict["CoarsePepper"] = {
-                "p": 0.5,
-                "kwargs": {"p": prct, "size_percent": size_prct},
-            }
-
-            # elastic transform
-            alpha = (0, 10)  # controls strength of displacement
-            sigma = 5  # cotnrols smoothness of displacement
-            params_dict["ElasticTransformation"] = {
-                "p": 0.5,
-                "kwargs": {"alpha": alpha, "sigma": sigma},
-            }
-
-            # hist eq
-            params_dict["AllChannelsHistogramEqualization"] = {"p": 0.1, "kwargs": {}}
-
-            # clahe (contrast limited adaptive histogram equalization) -
-            # hist eq over image patches
-            params_dict["AllChannelsCLAHE"] = {"p": 0.1, "kwargs": {}}
-
-            # emboss
-            alpha = (0, 0.5)  # overlay embossed image on original with alpha in this range
-            strength = (0.5, 1.5)  # strength of embossing lies in this range
-            params_dict["Emboss"] = {"p": 0.1, "kwargs": {"alpha": alpha, "strength": strength}}
-
-            # crop
-            crop_by = 0.15  # number of pix to crop on each side of img given as a fraction
-            params_dict["CropAndPad"] = {
-                "p": 0.4,
-                "kwargs": {"percent": (-crop_by, crop_by), "keep_size": False},
-            }
-        else:
-            raise NotImplementedError(
-                f"cfg.training.imgaug string {params} must be in "
-                "['none', 'default', 'dlc', 'dlc-lr', 'dlc-top-down']"
-            )
+        params_dict = expand_imgaug_str_to_dict(params)
     elif isinstance(params, dict) or isinstance(params, DictConfig):
         if isinstance(params, DictConfig):
             # recursively convert Dict/ListConfigs to dicts/lists
@@ -155,9 +78,13 @@ def get_imgaug_transform(cfg: DictConfig) -> iaa.Sequential:
         else:
             params_dict = params.copy()
         for transform, val in params_dict.items():
-            assert getattr(iaa, transform), f"{transform} is not a valid imgaug transform"
+            assert getattr(
+                iaa, transform
+            ), f"{transform} is not a valid imgaug transform"
     else:
-        raise TypeError(f"params is of type {type(params)}, must be str, dict, or DictConfig")
+        raise TypeError(
+            f"params is of type {type(params)}, must be str, dict, or DictConfig"
+        )
 
     return imgaug_transform(params_dict)
 

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -86,6 +86,8 @@ def get_dataset(
             dataset = BaseTrackingDataset(
                 root_directory=data_dir,
                 csv_path=cfg.data.csv_file,
+                image_resize_height=cfg.data.image_resize_dims.height,
+                image_resize_width=cfg.data.image_resize_dims.width,
                 imgaug_transform=imgaug_transform,
                 do_context=False,  # no context for regression models
             )
@@ -98,6 +100,8 @@ def get_dataset(
             dataset = MultiviewHeatmapDataset(
                 root_directory=data_dir,
                 csv_paths=cfg.data.csv_file,
+                image_resize_height=cfg.data.image_resize_dims.height,
+                image_resize_width=cfg.data.image_resize_dims.width,
                 view_names=list(cfg.data.view_names),
                 downsample_factor=cfg.data.get("downsample_factor", 2),
                 imgaug_transform=imgaug_transform,
@@ -108,6 +112,8 @@ def get_dataset(
             dataset = HeatmapDataset(
                 root_directory=data_dir,
                 csv_path=cfg.data.csv_file,
+                image_resize_height=cfg.data.image_resize_dims.height,
+                image_resize_width=cfg.data.image_resize_dims.width,
                 imgaug_transform=imgaug_transform,
                 downsample_factor=cfg.data.get("downsample_factor", 2),
                 do_context=cfg.model.model_type == "heatmap_mhcrnn",  # context only for mhcrnn

--- a/tests/data/test_augmentations.py
+++ b/tests/data/test_augmentations.py
@@ -10,107 +10,134 @@ from PIL import Image
 from lightning_pose.data.augmentations import imgaug_transform
 
 
-def test_imgaug_transform_default(cfg, base_dataset):
-
-    cfg_tmp = copy.deepcopy(cfg)
+def test_imgaug_transform(base_dataset):
 
     idx = 0
     img_name = base_dataset.image_names[idx]
-    keypoints_on_image = base_dataset.keypoints[idx]
+    keypoints = base_dataset.keypoints[idx]
     file_name = os.path.join(base_dataset.root_directory, img_name)
     image = Image.open(file_name).convert("RGB")
 
-    # default pipeline: resize only
-    cfg_tmp.training.imgaug = "default"
-    pipe = imgaug_transform(cfg_tmp)
+    # play with several easy-to-verify transforms
+
+    # ------------
+    # NULL
+    # ------------
+    params_dict = {}
+    pipe = imgaug_transform(params_dict)
     im_0, kps_0 = pipe(
         images=np.expand_dims(image, axis=0),
-        keypoints=np.expand_dims(keypoints_on_image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
     )
     im_0 = im_0[0]
-    kps_0 = kps_0[0].reshape(-1)
-    assert im_0.shape[0] == cfg.data.image_resize_dims.height
-    assert im_0.shape[1] == cfg.data.image_resize_dims.width
+    kps_0 = kps_0[0]
+    assert np.allclose(image, im_0)
+    assert np.allclose(keypoints, kps_0, equal_nan=True)
 
-    # default pipeline: should be repeatable
+    # pipeline should not do anything if augmentation probabilities are all zero
+    params_dict = {
+        "ShearX": {"p": 0.0, "kwargs": {"shear": (-30, 30)}},
+        "Jigsaw": {"p": 0.0, "kwargs": {"nb_rows": (3, 10), "nb_cols": (5, 8)}},
+        "MultiplyAndAddToBrightness": {"p": 0.0, "kwargs": {"mul": (0.5, 1.5), "add": (-5, 5)}},
+    }
+    pipe = imgaug_transform(params_dict)
+    im_0, kps_0 = pipe(
+        images=np.expand_dims(image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
+    )
+    im_0 = im_0[0]
+    kps_0 = kps_0[0]
+    assert np.allclose(image, im_0)
+    assert np.allclose(keypoints, kps_0, equal_nan=True)
+
+    # ------------
+    # Resize
+    # ------------
+    params_dict = {"Resize": {"p": 1.0, "args": ({"height": 256, "width": 256},), "kwargs": {}}}
+    pipe = imgaug_transform(params_dict)
+    im_0, kps_0 = pipe(
+        images=np.expand_dims(image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
+    )
+    im_0 = im_0[0]
+    assert im_0.shape[0] == params_dict["Resize"]["args"][0]["height"]
+    assert im_0.shape[1] == params_dict["Resize"]["args"][0]["width"]
+
+    # resize should be repeatable
     im_1, kps_1 = pipe(
         images=np.expand_dims(image, axis=0),
-        keypoints=np.expand_dims(keypoints_on_image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
     )
     im_1 = im_1[0]
-    kps_1 = kps_1[0].reshape(-1)
+    kps_1 = kps_1[0]
     assert np.allclose(im_0, im_1)
     assert np.allclose(kps_0, kps_1, equal_nan=True)
 
-    # invalid pipeline: ensure error is raised
-    cfg_tmp.training.imgaug = "null"
-    with pytest.raises(NotImplementedError):
-        imgaug_transform(cfg_tmp)
-
-
-def test_imgaug_transform_dlc(cfg, base_dataset):
-
-    cfg_tmp = copy.deepcopy(cfg)
-
-    idx = 0
-    img_name = base_dataset.image_names[idx]
-    keypoints_on_image = base_dataset.keypoints[idx]
-    file_name = os.path.join(base_dataset.root_directory, img_name)
-    image = Image.open(file_name).convert("RGB")
-
-    # dlc pipeline: should not contain flips
-    cfg_tmp.training.imgaug = "dlc"
-    pipe = imgaug_transform(cfg_tmp)
-    assert pipe.__str__().find("Fliplr") == -1
-    assert pipe.__str__().find("Flipud") == -1
-
-    # dlc pipeline: should resize
+    # ------------
+    # Fliplr
+    # ------------
+    params_dict = {"Fliplr": {"p": 1.0, "kwargs": {"p": 1.0}}}
+    pipe = imgaug_transform(params_dict)
     im_0, kps_0 = pipe(
         images=np.expand_dims(image, axis=0),
-        keypoints=np.expand_dims(keypoints_on_image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
     )
     im_0 = im_0[0]
-    assert im_0.shape[0] == cfg.data.image_resize_dims.height
-    assert im_0.shape[1] == cfg.data.image_resize_dims.width
+    im_0 = im_0[:, ::-1, ...]  # lr flip
+    kps_0 = kps_0[0]
+    kps_0[:, 0] = image.size[0] - kps_0[:, 0]  # lr flip; PIL.Image.size is (width, height)
+    assert np.allclose(im_0, image)
+    assert np.allclose(kps_0, keypoints, equal_nan=True)
 
-    # dlc pipeline: should not be repeatable
-    im_1, kps_1 = pipe(
-        images=np.expand_dims(image, axis=0),
-        keypoints=np.expand_dims(keypoints_on_image, axis=0),
-    )
-    im_1 = im_1[0]
-    assert not np.allclose(im_0, im_1)
-
-
-def test_imgaug_transform_dlc_top_down(cfg, base_dataset):
-
-    cfg_tmp = copy.deepcopy(cfg)
-
-    idx = 0
-    img_name = base_dataset.image_names[idx]
-    keypoints_on_image = base_dataset.keypoints[idx]
-    file_name = os.path.join(base_dataset.root_directory, img_name)
-    image = Image.open(file_name).convert("RGB")
-
-    # dlc-top-down pipeline: should contain flips
-    cfg_tmp.training.imgaug = "dlc-top-down"
-    pipe = imgaug_transform(cfg_tmp)
-    assert pipe.__str__().find("Fliplr") != -1
-    assert pipe.__str__().find("Flipud") != -1
-
-    # dlc-top-down pipeline: should resize
+    # ------------
+    # Flipud
+    # ------------
+    params_dict = {"Flipud": {"p": 1.0, "kwargs": {"p": 1.0}}}
+    pipe = imgaug_transform(params_dict)
     im_0, kps_0 = pipe(
         images=np.expand_dims(image, axis=0),
-        keypoints=np.expand_dims(keypoints_on_image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
     )
     im_0 = im_0[0]
-    assert im_0.shape[0] == cfg.data.image_resize_dims.height
-    assert im_0.shape[1] == cfg.data.image_resize_dims.width
+    im_0 = im_0[::-1, :, ...]  # ud flip
+    kps_0 = kps_0[0]
+    kps_0[:, 1] = image.size[1] - kps_0[:, 1]  # ud flip; PIL.Image.size is (width, height)
+    assert np.allclose(im_0, image)
+    assert np.allclose(kps_0, keypoints, equal_nan=True)
 
-    # dlc-top-down pipeline: should not be repeatable
-    im_1, kps_1 = pipe(
+    # ------------
+    # misc
+    # ------------
+    # make sure various augmentations are not repeatable
+    params_dict = {"MotionBlur": {"p": 1.0, "kwargs": {"k": 5, "angle": (-90, 90)}}}
+    pipe = imgaug_transform(params_dict)
+    im_0, kps_0 = pipe(
         images=np.expand_dims(image, axis=0),
-        keypoints=np.expand_dims(keypoints_on_image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
     )
-    im_1 = im_1[0]
-    assert not np.allclose(im_0, im_1)
+    im_0 = im_0[0]
+    kps_0 = kps_0[0]
+    assert not np.allclose(im_0, image)  # image changed
+    assert np.allclose(kps_0, keypoints, equal_nan=True)  # keypoints do not
+
+    params_dict = {"CoarseSalt": {"p": 1.0, "kwargs": {"p": 0.1, "size_percent": (0.05, 1.0)}}}
+    pipe = imgaug_transform(params_dict)
+    im_0, kps_0 = pipe(
+        images=np.expand_dims(image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
+    )
+    im_0 = im_0[0]
+    kps_0 = kps_0[0]
+    assert not np.allclose(im_0, image)  # image changed
+    assert np.allclose(kps_0, keypoints, equal_nan=True)  # keypoints do not
+
+    params_dict = {"Affine": {"p": 1.0, "kwargs": {"rotate": (-90, 90)}}}
+    pipe = imgaug_transform(params_dict)
+    im_0, kps_0 = pipe(
+        images=np.expand_dims(image, axis=0),
+        keypoints=np.expand_dims(keypoints, axis=0),
+    )
+    im_0 = im_0[0]
+    kps_0 = kps_0[0]
+    assert not np.allclose(im_0, image)  # image changed
+    assert not np.allclose(kps_0, keypoints, equal_nan=True)  # keypoints changed

--- a/tests/data/test_datamodules.py
+++ b/tests/data/test_datamodules.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pytest
-import torch
 from lightning.pytorch.utilities import CombinedLoader
 from torch.utils.data import RandomSampler
 
@@ -55,11 +54,6 @@ def test_base_datamodule(cfg, base_data_module):
     assert np.allclose(b1["images"], b2["images"])
     assert np.allclose(b1["keypoints"], b2["keypoints"], equal_nan=True)
 
-    # cleanup
-    del batch
-    del b1
-    del b2
-
 
 def test_heatmap_datamodule(cfg, heatmap_data_module):
 
@@ -78,9 +72,6 @@ def test_heatmap_datamodule(cfg, heatmap_data_module):
         train_size, num_targets // 2, im_height_ds, im_width_ds,
     )
     assert batch["heatmaps"].shape[2:] == heatmap_data_module.dataset.output_shape
-
-    # cleanup
-    del batch
 
 
 def test_multiview_heatmap_datamodule(cfg_multiview, multiview_heatmap_data_module):
@@ -138,11 +129,6 @@ def test_multiview_heatmap_datamodule(cfg_multiview, multiview_heatmap_data_modu
     assert np.allclose(b1["images"], b2["images"])
     assert np.allclose(b1["keypoints"], b2["keypoints"], equal_nan=True)
 
-    # cleanup
-    del batch
-    del b1
-    del b2
-
 
 def test_heatmap_datamodule_context(cfg, heatmap_data_module_context):
 
@@ -162,9 +148,6 @@ def test_heatmap_datamodule_context(cfg, heatmap_data_module_context):
         train_size, num_targets // 2, im_height_ds, im_width_ds,
     )
     assert batch["heatmaps"].shape[2:] == heatmap_data_module_context.dataset.output_shape
-
-    # cleanup
-    del batch
 
 
 def test_multiview_heatmap_datamodule_context(
@@ -188,9 +171,6 @@ def test_multiview_heatmap_datamodule_context(
     )
     assert batch["heatmaps"].shape[2:] == \
         multiview_heatmap_data_module_context.dataset.output_shape
-
-    # cleanup
-    del batch
 
 
 def test_subsampling_of_training_frames(base_dataset):
@@ -236,11 +216,6 @@ def test_subsampling_of_training_frames(base_dataset):
         train_frames = -1
         BaseDataModule(base_dataset, train_frames=train_frames)
 
-    # cleanup
-    del heatmap_module
-    del train_dataloader
-    torch.cuda.empty_cache()
-
 
 def test_base_data_module_combined(cfg, base_data_module_combined):
 
@@ -280,12 +255,6 @@ def test_base_data_module_combined(cfg, base_data_module_combined):
         image_counter += len(batch["labeled"]["keypoints"])
     assert image_counter == dataset_length
 
-    # cleanup
-    del loader
-    del batch
-
-    torch.cuda.empty_cache()  # remove tensors from gpu
-
 
 def test_heatmap_data_module_combined(cfg, heatmap_data_module_combined):
 
@@ -311,11 +280,6 @@ def test_heatmap_data_module_combined(cfg, heatmap_data_module_combined):
         train_size_labeled, num_targets // 2, im_height_ds, im_width_ds,
     )
     assert batch["unlabeled"]["frames"].shape == (train_size_unlabel, 3, im_height, im_width)
-
-    # cleanup
-    del loader
-    del batch
-    torch.cuda.empty_cache()  # remove tensors from gpu
 
 
 def test_multiview_heatmap_data_module_combined(
@@ -363,11 +327,6 @@ def test_multiview_heatmap_data_module_combined(
     assert batch["unlabeled"]["transforms"].shape == (num_views, 1, 2, 3)
     assert batch["unlabeled"]["bbox"].shape == (train_size_unlabeled, num_views * 4)
 
-    # cleanup
-    del loader
-    del batch
-    torch.cuda.empty_cache()  # remove tensors from gpu
-
 
 def test_heatmap_data_module_combined_context(cfg, heatmap_data_module_combined_context):
 
@@ -397,11 +356,6 @@ def test_heatmap_data_module_combined_context(cfg, heatmap_data_module_combined_
         train_size_labeled, num_targets // 2, im_height_ds, im_width_ds,
     )
     assert batch["unlabeled"]["frames"].shape == (train_size_unlabel, 3, im_height, im_width)
-
-    # cleanup
-    del loader
-    del batch
-    torch.cuda.empty_cache()  # remove tensors from gpu
 
 
 def test_multiview_heatmap_data_module_combined_context(
@@ -450,8 +404,3 @@ def test_multiview_heatmap_data_module_combined_context(
     )
     assert batch["unlabeled"]["transforms"].shape == (num_views, 1, 2, 3)
     assert batch["unlabeled"]["bbox"].shape == (train_size_unlabeled, num_views * 4)
-
-    # cleanup
-    del loader
-    del batch
-    torch.cuda.empty_cache()  # remove tensors from gpu


### PR DESCRIPTION
The current imgaug code defines a handful of hard-coded pipelines that are defined by strings like "dlc", "dlc-top-down", etc. While succinct, this approach is not flexible and does not scale well.

To address this issue, I have refactored the imgaug code so that it can continue to use the previous string aliases (i.e. is backwards compatible), but also allows users to define their own custom pipeline in the config file.

Specifically:
- `lightning_pose.data.augmentations.imgaug_transform` is now a fully flexible core function that takes in a parameter dict and constructs an imgaug pipeline; the parameter dict defines the types of augmentations used, their various parameters, and their order. Unlike before, it does not rely on the bulky `cfg` DictConfig that specfies the entire Lightning Pose pipeline (data, model, training, etc)
- `lightning_pose.utils.scripts.get_imgaug_transform` now does more of the heavy lifting; it hard-codes the pipeline details if a user selects one of the previously used strings, but also allows for yaml files to define a custom pipeline.

generalizes #236 

This PR also removes the Resize augmentation from the end of the imgaug pipeline, and instead makes this a more flexible option that datasets can add in their constructors. This will be useful for more complex (i.e. 3d) image augmentation pipelines.