### PR TITLE
Two small but important fixes

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -231,7 +231,9 @@ def _crop(args: argparse.Namespace):
     detector_cfg = OmegaConf.create(
         {
             "crop_ratio": args.crop_ratio,
-            "anchor_keypoints": args.anchor_keypoints.split(",") if args.anchor_keypoints else [],
+            "anchor_keypoints": (
+                args.anchor_keypoints.split(",") if args.anchor_keypoints else []
+            ),
         }
     )
     assert detector_cfg.crop_ratio > 1
@@ -239,9 +241,7 @@ def _crop(args: argparse.Namespace):
     for input_path in input_paths:
         if input_path.suffix == ".mp4":
             input_preds_file = model.video_preds_dir() / (input_path.stem + ".csv")
-            output_bbox_file = model.video_preds_dir() / (
-                input_path.stem + "_bbox.csv"
-            )
+            output_bbox_file = model.video_preds_dir() / (input_path.stem + "_bbox.csv")
             output_file = model.cropped_videos_dir() / ("cropped_" + input_path.name)
 
             cz.generate_cropped_video(
@@ -281,7 +281,7 @@ def _remap_preds(args: argparse.Namespace):
         input_csv_file=args.preds_file,
         input_bbox_file=args.bbox_file,
         output_csv_file=output_file,
-        mode='add',
+        mode="add",
     )
 
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -281,6 +281,7 @@ def _remap_preds(args: argparse.Namespace):
         input_csv_file=args.preds_file,
         input_bbox_file=args.bbox_file,
         output_csv_file=output_file,
+        mode='add',
     )
 
 

--- a/lightning_pose/model.py
+++ b/lightning_pose/model.py
@@ -90,6 +90,10 @@ class Model:
             ckpt_file = io_utils.ckpt_path_from_base_path(
                 base_path=str(self.model_dir), model_name=self.cfg.model.model_name
             )
+            if ckpt_file is None:
+                raise FileNotFoundError(
+                    "Checkpoint file not found, have you trained for enough epochs?"
+                )
             self.model = load_model_from_checkpoint(
                 cfg=self.cfg,
                 ckpt_file=ckpt_file,

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -511,7 +511,6 @@ def get_callbacks(
             monitor="val_supervised_loss",
             mode="min",
             filename="{epoch}-{step}-best",
-            enable_version_counter=False,
         )
         callbacks.append(ckpt_best_callback)
 
@@ -521,7 +520,6 @@ def get_callbacks(
             monitor=None,
             every_n_epochs=ckpt_every_n_epochs,
             save_top_k=-1,
-            enable_version_counter=False,
         )
         callbacks.append(ckpt_callback)
 


### PR DESCRIPTION
1. The litpose remap command had a glaring bug where we were subtracting bboxes instead of adding. This only impacted salamander analysis. Chickadee used a custom script where this bug was not present.

2. When running litpose train on the same output directory twice, we currently save out checkpoints in directories like version_0, version_1, ... I thought I had disabled this incrementing a while ago with the `enable_version_counter` flag to ModelCheckpoint, but turns out that is a totally different feature. The relevant feature is actually TensorBoardLogger `version` flag: https://lightning.ai/docs/pytorch/stable/extensions/generated/lightning.pytorch.loggers.TensorBoardLogger.html#lightning.pytorch.loggers.TensorBoardLogger.params.version

So fix the io.py method that gets the checkpoint. Bug is that it always gets version 0, fix is that it gets the latest version. Alternatively we can pass version=0 to TensorBoardLogger, but I figured better to keep old versions around in case of accidental retraining (acknowledged that this contrary to my previous change to always save to version_0).

Long term we should support resuming training as the default behavior, and perhaps an --overwrite flag. 