### PR TITLE
remove neck in vits to avoid over stacking issues

### DIFF
--- a/lightning_pose/models/backbones/config/vit_mae.yaml
+++ b/lightning_pose/models/backbones/config/vit_mae.yaml
@@ -1,0 +1,42 @@
+model_class: ViT_MAE
+
+hidden_size: 768
+num_hidden_layers: 12
+num_attention_heads: 12
+intermediate_size: 3072
+hidden_act: "gelu"
+hidden_dropout_prob: 0.0
+attention_probs_dropout_prob: 0.0
+initializer_range: 0.02
+layer_norm_eps: 1.e-12
+image_size: 256 # usually 224
+patch_size: 16 # default is 16, we use large patch size
+num_channels: 3 # 3 for RGB
+qkv_bias: True
+decoder_num_attention_heads: 16
+decoder_hidden_size: 512
+decoder_num_hidden_layers: 8
+decoder_intermediate_size: 2048
+mask_ratio: 0 # 0 for no masking, usually 0.75 (MAE)
+norm_pix_loss: False
+
+embed_size: 768 # projected embedding size, used for contrastive learning
+temp_scale: False # temperature scaling for contrastive loss
+proj_type: "bn" # projection head type, linear (ln) or batchnorm (bn)
+use_whitening: False # use whitening for contrastive loss
+shuffle_group: False # shuffle embeddings for contrastive loss
+var_reg: False # use variance regularization for contrastive loss
+cov_reg: False # use covariance regularization for contrastive loss
+
+output_channels: 256 # number of output channels for lightning pose heatmap
+
+random_init: False # use random initialization instead of pretrained weights
+use_infoNCE: True # use InfoNCE loss
+infoNCE_weight: 0.03 # weight for InfoNCE loss
+use_byol: False # use BYOL loss
+byol_weight: 0.1 # weight for BYOL loss
+use_vreg: False # use variance/covariance regularization for BYOL loss
+var_weight: 0.2 # weight for variance regularization
+cov_weight: 0.1 # weight for covariance regularization
+repr_weight: 0.5 # weight for representation loss
+recon_weight: 1.0 # weight for reconstruction loss, usually 1.0

--- a/lightning_pose/models/backbones/vit_img_encoder.py
+++ b/lightning_pose/models/backbones/vit_img_encoder.py
@@ -104,8 +104,7 @@ class ImageEncoderViT_FT(ImageEncoderViT):
 
         for blk in self.blocks:
             x = blk(x)
-
-        x = self.neck(x.permute(0, 3, 1, 2))
+        x = x.permute(0, 3, 1, 2)
 
         return x
 

--- a/lightning_pose/models/backbones/vit_mae.py
+++ b/lightning_pose/models/backbones/vit_mae.py
@@ -1,0 +1,76 @@
+from model.vit_mae.vit_mae import ContrastViTMAE
+import math
+import torch
+import torch.nn as nn
+from transformers import (
+    ViTMAEConfig, 
+    ViTMAEModel, 
+    ViTMAEForPreTraining,
+)
+from segment_anything.modeling import ImageEncoderViT
+from typing import Tuple, Type
+# to ignore imports for sphix-autoapidoc
+__all__ = [
+    "ImageEncoderViTMAE",
+]
+
+# From https://github.com/facebookresearch/detectron2/blob/main/detectron2/layers/batch_norm.py # noqa
+# Itself from https://github.com/facebookresearch/ConvNeXt/blob/d1fa8f6fef0a165b27399986cc2bdacc92777e40/models/convnext.py#L119  # noqa
+class LayerNorm2d(nn.Module):
+    def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(num_channels))
+        self.bias = nn.Parameter(torch.zeros(num_channels))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        u = x.mean(1, keepdim=True)
+        s = (x - u).pow(2).mean(1, keepdim=True)
+        x = (x - u) / torch.sqrt(s + self.eps)
+        x = self.weight[:, None, None] * x + self.bias[:, None, None]
+        return x
+
+class ImageEncoderViTMAE(nn.Module):
+    def __init__(self, config):
+        super().__init__() # Initialize parent nn.Module firsts
+        self.vit_mae = ContrastViTMAE(config).vit_mae
+        del(self.vit_mae.decoder) # remove the decoder from the vit_mae
+        self.config = config
+        # self.neck = nn.Sequential(
+        #     nn.Conv2d(
+        #         config['hidden_size'],
+        #         config['output_channels'],
+        #         kernel_size=1,
+        #         bias=False,
+        #     ),
+        #     LayerNorm2d(config['output_channels']),
+        #     nn.Conv2d(
+        #         config['output_channels'],
+        #         config['output_channels'],
+        #         kernel_size=3,
+        #         padding=1,
+        #         bias=False,
+        #     ),
+        #     LayerNorm2d(config['output_channels']),
+        # )
+
+    def forward(self, x):
+        N = x.shape[0]
+        if self.config['num_channels'] == 1:
+            print('num_channels is 1, should be 3')
+            # adjust input channels to 1
+            x = x[:, 0, ...].unsqueeze(1)
+            exit()
+        outputs = self.vit_mae(
+            pixel_values=x,
+            return_latent=True
+        )
+        # skip the cls token
+        outputs = outputs[:, 1:, ...] # [N, S, D]
+        # change the shape to [N, H, W, D] -> [N, D, H, W]
+        S = outputs.shape[1]
+        H, W = math.isqrt(S), math.isqrt(S)
+        outputs = outputs.reshape(N, H, W, -1).permute(0, 3, 1, 2)
+        # outputs = self.neck(outputs)
+        return outputs
+    

--- a/lightning_pose/models/backbones/vits.py
+++ b/lightning_pose/models/backbones/vits.py
@@ -87,10 +87,14 @@ def build_backbone(backbone_arch: str, image_size: int = 256, **kwargs):
             out_chans=prompt_embed_dim,
         )
         base.load_state_dict(new_state_dict, strict=False)
+        # remove the neck in the base
+        del base.neck
 
     else:
         raise NotImplementedError
 
-    num_fc_input_features = base.neck[-2].in_channels
+    # num_fc_input_features = base.neck[-2].in_channels
+    # vit models always have 768 features
+    num_fc_input_features = 768
 
     return base, num_fc_input_features

--- a/lightning_pose/models/base.py
+++ b/lightning_pose/models/base.py
@@ -110,6 +110,9 @@ ALLOWED_BACKBONES = Literal[
     "efficientnet_b2",
     # "vit_h_sam",
     "vit_b_sam",
+    "vit_mae",
+    "vit_m",
+    "vit_cm"
 ]
 
 
@@ -217,6 +220,7 @@ class BaseFeatureExtractor(LightningModule):
         do_context: bool = False,
         image_size: int = 256,
         model_type: Literal["heatmap", "regression"] = "heatmap",
+        model_path: str = None,
         **kwargs: Any,
     ) -> None:
         """A CNN model that takes in images and generates features.
@@ -235,6 +239,7 @@ class BaseFeatureExtractor(LightningModule):
             do_context: include temporal context when processing each frame
             image_size: height/width of frames, for ViT models only
             model_type: type of model
+            model_path: path to model weights file
 
         """
         super().__init__()
@@ -243,7 +248,7 @@ class BaseFeatureExtractor(LightningModule):
 
         self.backbone_arch = backbone
 
-        if "sam" in self.backbone_arch:
+        if self.backbone_arch in ['vit_b_sam', 'vit_mae', 'vit_m', 'vit_cm']:
             from lightning_pose.models.backbones.vits import build_backbone
         else:
             from lightning_pose.models.backbones.torchvision import build_backbone
@@ -253,6 +258,7 @@ class BaseFeatureExtractor(LightningModule):
             pretrained=pretrained,
             model_type=model_type,  # for torchvision only
             image_size=image_size,  # for ViTs only
+            model_path=model_path,  # pass model_path to backbone
         )
 
         self.lr_scheduler = lr_scheduler

--- a/lightning_pose/models/heatmap_tracker.py
+++ b/lightning_pose/models/heatmap_tracker.py
@@ -70,6 +70,7 @@ class HeatmapTracker(BaseSupervisedTracker):
         optimizer_params: DictConfig | dict | None = None,
         lr_scheduler: str = "multisteplr",
         lr_scheduler_params: DictConfig | dict | None = None,
+        model_path: str = None,
         **kwargs: Any,
     ) -> None:
         """Initialize a DLC-like model with resnet backbone.
@@ -86,6 +87,7 @@ class HeatmapTracker(BaseSupervisedTracker):
             lr_scheduler: how to schedule learning rate
             lr_scheduler_params: params for specific learning rate schedulers
                 multisteplr: milestones, gamma
+            model_path: path to model weights file
 
         """
 
@@ -99,6 +101,7 @@ class HeatmapTracker(BaseSupervisedTracker):
             optimizer_params=optimizer_params,
             lr_scheduler=lr_scheduler,
             lr_scheduler_params=lr_scheduler_params,
+            model_path=model_path,
             **kwargs,
         )
         self.num_keypoints = num_keypoints
@@ -243,7 +246,7 @@ class HeatmapTracker(BaseSupervisedTracker):
             )
         )  # up to here results in downsample_factor=3
         n_layers_to_build = 4 - self.downsample_factor - 1
-        if self.backbone_arch in ["vit_h_sam", "vit_b_sam"]:
+        if self.backbone_arch in ["vit_h_sam", "vit_b_sam"] or "vit" in self.backbone_arch:
             n_layers_to_build = -1
         for _ in range(n_layers_to_build):
             # add upsampling layer to account for heatmap downsampling
@@ -384,6 +387,7 @@ class SemiSupervisedHeatmapTracker(SemiSupervisedTrackerMixin, HeatmapTracker):
         optimizer_params: DictConfig | dict | None = None,
         lr_scheduler: str = "multisteplr",
         lr_scheduler_params: DictConfig | dict | None = None,
+        model_path: str = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -405,6 +409,7 @@ class SemiSupervisedHeatmapTracker(SemiSupervisedTrackerMixin, HeatmapTracker):
                 multisteplr
             lr_scheduler_params: params for specific learning rate schedulers
                 multisteplr: milestones, gamma
+            model_path: path to model weights file
 
         """
         super().__init__(
@@ -419,6 +424,7 @@ class SemiSupervisedHeatmapTracker(SemiSupervisedTrackerMixin, HeatmapTracker):
             optimizer_params=optimizer_params,
             lr_scheduler=lr_scheduler,
             lr_scheduler_params=lr_scheduler_params,
+            model_path=model_path,
             **kwargs,
         )
         self.loss_factory_unsup = loss_factory_unsupervised

--- a/lightning_pose/models/heatmap_tracker_mhcrnn.py
+++ b/lightning_pose/models/heatmap_tracker_mhcrnn.py
@@ -49,6 +49,7 @@ class HeatmapTrackerMHCRNN(HeatmapTracker):
         optimizer_params: DictConfig | dict | None = None,
         lr_scheduler: str = "multisteplr",
         lr_scheduler_params: DictConfig | dict | None = None,
+        model_path: str = None,
         **kwargs: Any,
     ):
         """Initialize a DLC-like model with resnet backbone.
@@ -64,7 +65,8 @@ class HeatmapTrackerMHCRNN(HeatmapTracker):
             torch_seed: make weight initialization reproducible
             lr_scheduler: how to schedule learning rate
             lr_scheduler_params: params for specific learning rate schedulers
-                - multisteplr: milestones, gamma
+                multisteplr: milestones, gamma
+            model_path: path to model weights file
 
         """
 
@@ -90,6 +92,7 @@ class HeatmapTrackerMHCRNN(HeatmapTracker):
             optimizer_params=optimizer_params,
             lr_scheduler=lr_scheduler,
             lr_scheduler_params=lr_scheduler_params,
+            model_path=model_path,
             do_context=True,
             **kwargs,
         )
@@ -283,6 +286,7 @@ class SemiSupervisedHeatmapTrackerMHCRNN(SemiSupervisedTrackerMixin, HeatmapTrac
         optimizer_params: DictConfig | dict | None = None,
         lr_scheduler: str = "multisteplr",
         lr_scheduler_params: DictConfig | dict | None = None,
+        model_path: str = None,
         **kwargs: Any,
     ):
         """
@@ -304,6 +308,7 @@ class SemiSupervisedHeatmapTrackerMHCRNN(SemiSupervisedTrackerMixin, HeatmapTrac
                 multisteplr
             lr_scheduler_params: params for specific learning rate schedulers
                 multisteplr: milestones, gamma
+            model_path: path to model weights file
 
         """
         super().__init__(
@@ -318,6 +323,7 @@ class SemiSupervisedHeatmapTrackerMHCRNN(SemiSupervisedTrackerMixin, HeatmapTrac
             optimizer_params=optimizer_params,
             lr_scheduler=lr_scheduler,
             lr_scheduler_params=lr_scheduler_params,
+            model_path=model_path,
             **kwargs,
         )
         self.loss_factory_unsup = loss_factory_unsupervised

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -361,6 +361,7 @@ def get_model(
             raise RuntimeError("ViT model requires resized height and width to be equal")
 
     backbone_pretrained = cfg.model.get("backbone_pretrained", True)
+    model_path = cfg.model.get("model_path", None)
     if not semi_supervised:
         if cfg.model.model_type == "regression":
             model = RegressionTracker(
@@ -374,6 +375,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                model_path=model_path,  # pass model_path to backbone
             )
         elif cfg.model.model_type == "heatmap":
             model = HeatmapTracker(
@@ -390,6 +392,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                model_path=model_path,  # pass model_path to backbone
             )
         elif cfg.model.model_type == "heatmap_mhcrnn":
             model = HeatmapTrackerMHCRNN(
@@ -405,6 +408,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                model_path=model_path,  # pass model_path to backbone
             )
         else:
             raise NotImplementedError(
@@ -426,6 +430,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                model_path=model_path,  # pass model_path to backbone
             )
 
         elif cfg.model.model_type == "heatmap":
@@ -443,6 +448,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                model_path=model_path,  # pass model_path to backbone
             )
         elif cfg.model.model_type == "heatmap_mhcrnn":
             model = SemiSupervisedHeatmapTrackerMHCRNN(
@@ -459,6 +465,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                model_path=model_path,  # pass model_path to backbone
             )
         else:
             raise NotImplementedError(


### PR DESCRIPTION
Remove the ViT neck struct in vit_b_sam. This avoid multiple layers stack together with the upsampling part without any norm/activation functions.