### PR TITLE
Making sure path is str

### DIFF
--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -593,7 +593,7 @@ def compute_metrics(
         labels_file = Path(cfg.data.csv_file)
         if not labels_file.is_absolute():
             labels_file = Path(cfg.data.data_dir) / labels_file
-        labels_file = io_utils.return_absolute_path(labels_file)
+        labels_file = io_utils.return_absolute_path(str(labels_file))
         compute_metrics_single(
             cfg=cfg,
             labels_file=labels_file,


### PR DESCRIPTION
`return_absolute_path` expects an `str `instead of a `Path` object. It is done correctly in the upper part of the script but missing in the second part. 

This corrects it.