### PR TITLE
new backbone: ViT pretrained on imagenet with mae loss

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 88
+max-line-length = 99
 # E203: black conflict
 # E701: black conflict
 # F821: lot of issues regarding type annotations

--- a/docs/api/lightning_pose.models.backbones.vit_mae.ViTVisionEncoder.rst
+++ b/docs/api/lightning_pose.models.backbones.vit_mae.ViTVisionEncoder.rst
@@ -1,0 +1,17 @@
+ViTVisionEncoder
+================
+
+.. currentmodule:: lightning_pose.models.backbones.vit_mae
+
+.. autoclass:: ViTVisionEncoder
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~ViTVisionEncoder.forward
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: forward

--- a/docs/api/lightning_pose.models.backbones.vit_sam.load_sam_vision_encoder_hf.rst
+++ b/docs/api/lightning_pose.models.backbones.vit_sam.load_sam_vision_encoder_hf.rst
@@ -1,6 +1,0 @@
-load_sam_vision_encoder_hf
-==========================
-
-.. currentmodule:: lightning_pose.models.backbones.vit_sam
-
-.. autofunction:: load_sam_vision_encoder_hf

--- a/docs/modules/lightning_pose.models.backbones.rst
+++ b/docs/modules/lightning_pose.models.backbones.rst
@@ -4,6 +4,9 @@ lightning\_pose.models.backbones
 .. automodapi:: lightning_pose.models.backbones.torchvision
    :no-inheritance-diagram:
 
+.. automodapi:: lightning_pose.models.backbones.vit_mae
+   :no-inheritance-diagram:
+
 .. automodapi:: lightning_pose.models.backbones.vit_sam
    :no-inheritance-diagram:
 

--- a/lightning_pose/models/backbones/__init__.py
+++ b/lightning_pose/models/backbones/__init__.py
@@ -17,4 +17,5 @@ ALLOWED_BACKBONES = Literal[
     "efficientnet_b1",
     "efficientnet_b2",
     "vitb_sam",
+    "vitb_imagenet",
 ]

--- a/lightning_pose/models/backbones/vit_mae.py
+++ b/lightning_pose/models/backbones/vit_mae.py
@@ -1,0 +1,238 @@
+import math
+
+import torch
+import torch.nn as nn
+from transformers import ViTMAEConfig, ViTMAEForPreTraining
+
+# to ignore imports for sphix-autoapidoc
+__all__ = [
+    "ViTVisionEncoder",
+]
+
+
+class ViTVisionEncoder(nn.Module):
+    """Wrapper around HuggingFace's ViTMAE Vision Encoder."""
+
+    def __init__(
+        self,
+        model_name: str = "facebook/vit-mae-base",
+        finetune_img_size: int = 256,
+    ):
+        super().__init__()
+
+        if model_name == "facebook/vit-mae-base":
+            img_size = 224
+            config = {
+                'hidden_size': 768,
+                'num_hidden_layers': 12,
+                'num_attention_heads': 12,
+                'intermediate_size': 3072,
+                'hidden_act': "gelu",
+                'hidden_dropout_prob': 0.0,
+                'attention_probs_dropout_prob': 0.0,
+                'initializer_range': 0.02,
+                'layer_norm_eps': 1.e-12,
+                'image_size': img_size,  # usually 224
+                'patch_size': 16,   # default is 16, we use large patch size
+                'num_channels': 3,  # 3 for RGB
+                'qkv_bias': True,
+                'decoder_num_attention_heads': 16,
+                'decoder_hidden_size': 512,
+                'decoder_num_hidden_layers': 8,
+                'decoder_intermediate_size': 2048,
+                'mask_ratio': 0,  # 0 for no masking, usually 0.75 (MAE)
+                'norm_pix_loss': False,
+            }
+        else:
+            raise NotImplementedError(f"{model_name} is not a valid ViTVisionEncoder model name")
+
+        # Load the full ViT model and extract encoder
+        self.config = ViTMAEConfig(**config)
+        self.vision_encoder = ViTMAE.from_pretrained(model_name)
+        del self.vision_encoder.decoder  # remove the decoder from the vit_mae
+        self.vision_encoder.config.mask_ratio = 0
+
+        # Store size information
+        self.img_size = img_size
+        self.finetune_img_size = finetune_img_size
+        self.patch_size = self.vision_encoder.config.patch_size
+
+        # Store original positional embeddings for potential resizing
+        self.original_pos_embed = None
+        if hasattr(self.vision_encoder.vit.embeddings, 'position_embeddings'):
+            self.original_pos_embed = \
+                self.vision_encoder.vit.embeddings.position_embeddings.clone()
+
+        # Check if we need to resize positional embeddings
+        if (
+            self.finetune_img_size != img_size
+            and hasattr(self.vision_encoder.vit.embeddings, 'position_embeddings')
+            and self.vision_encoder.vit.embeddings.position_embeddings is not None
+        ):
+            # Resize positional embeddings if needed
+            print(
+                f"Finetune image size ({finetune_img_size}) does not match model size ({img_size})"
+                f" - recomputing position embeddings"
+            )
+            self._resize_pos_embed()
+
+        # Bypass size check entirely
+        self._bypass_size_check()
+
+    def _bypass_size_check(self):
+        """Completely bypass the size check in patch embedding"""
+
+        def no_size_check_forward(pixel_values, interpolate_pos_encoding: bool = False):
+            batch_size, num_channels, height, width = pixel_values.shape
+
+            # Only check channel dimension
+            if num_channels != self.vision_encoder.vit.config.num_channels:
+                raise ValueError(
+                    "Make sure that the channel dimension of the pixel values match with the one "
+                    "set in the configuration."
+                )
+
+            # Skip size check entirely - just do the convolution
+            embeddings = self.vision_encoder.vit.embeddings.patch_embeddings.projection(
+                pixel_values
+            ).flatten(2).transpose(1, 2)
+            return embeddings
+
+        # Replace the forward method
+        self.vision_encoder.vit.embeddings.patch_embeddings.forward = no_size_check_forward
+        print("Bypassed all size checking in embeddings")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        N = x.shape[0]
+        if self.config.num_channels == 1:
+            # adjust input channels to 1
+            x = x[:, 0, ...].unsqueeze(1)
+        outputs = self.vision_encoder(
+            pixel_values=x,
+            return_latent=True,
+        )
+        # skip the cls token
+        outputs = outputs[:, 1:, ...]  # [N, S, D]
+        # change the shape to [N, H, W, D] -> [N, D, H, W]
+        S = outputs.shape[1]
+        H, W = math.isqrt(S), math.isqrt(S)
+        outputs = outputs.reshape(N, H, W, -1).permute(0, 3, 1, 2)
+        return outputs
+
+    def _resize_pos_embed(self):
+        """Resize positional embeddings for different input sizes"""
+
+        if self.original_pos_embed is None:
+            return
+
+        # Calculate target size
+        old_size = self.img_size // self.patch_size  # 224 // 16 = 14
+        new_size = self.finetune_img_size // self.patch_size  # 128 // 16 = 8
+
+        if old_size == new_size:
+            return
+
+        print(f"Resizing pos_embed from {old_size}x{old_size} to {new_size}x{new_size}")
+
+        # Original pos_embed format: [1, H*W + 1, C]
+        pos_embed = self.original_pos_embed  # [1, 197, 768] for 224x224 input
+
+        # Separate CLS token embedding from spatial embeddings
+        cls_token_embed = pos_embed[:, 0:1, :]  # [1, 1, 768] - CLS token
+        spatial_embeddings = pos_embed[:, 1:, :]  # [1, 196, 768] - spatial patches
+
+        # Reshape spatial embeddings to 2D spatial format
+        # [1, H*W, C] -> [1, H, W, C]
+        batch_size, num_patches, embed_dim = spatial_embeddings.shape
+        spatial_2d = spatial_embeddings.reshape(batch_size, old_size, old_size, embed_dim)
+
+        # Convert to [1, C, H, W] for interpolation
+        spatial_2d = spatial_2d.permute(0, 3, 1, 2)  # [1, 768, 14, 14]
+
+        # Resize using interpolation
+        spatial_resized = nn.functional.interpolate(
+            spatial_2d,
+            size=(new_size, new_size),  # (8, 8)
+            mode='bicubic',
+            antialias=True,
+        )  # [1, 768, 8, 8]
+
+        # Convert back to sequence format
+        # [1, C, H, W] -> [1, H, W, C] -> [1, H*W, C]
+        spatial_resized = spatial_resized.permute(0, 2, 3, 1)  # [1, 8, 8, 768]
+        spatial_resized = spatial_resized.reshape(batch_size, new_size * new_size, embed_dim)
+
+        # Concatenate CLS token back at the beginning
+        pos_embed_final = torch.cat([cls_token_embed, spatial_resized], dim=1)  # [1, 65, 768]
+
+        # Update the position embeddings
+        self.vision_encoder.vit.embeddings.position_embeddings = nn.Parameter(pos_embed_final)
+
+
+class ViTMAE(ViTMAEForPreTraining):
+
+    def forward(
+            self,
+            pixel_values,
+            noise=None,
+            head_mask=None,
+            output_attentions=None,
+            output_hidden_states=None,
+            return_dict=None,
+            interpolate_pos_encoding=False,
+            return_latent=False,
+            return_recon=False,
+    ):
+        # Setting default for return_dict based on the configuration
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        if (self.training and self.config.mask_ratio > 0) or return_recon:
+            outputs = self.vit(
+                pixel_values,
+                noise=noise,
+                head_mask=head_mask,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=return_dict,
+            )
+            latent = outputs.last_hidden_state
+        else:
+            # use for fine-tuning, or inference
+            # mask_ratio = 0
+            embedding_output, mask, ids_restore = self.vit.embeddings(pixel_values)
+            embedding_output_ = embedding_output[:, 1:, :]  # no cls token
+            # unshuffle the embedding output
+            embedding_output_ = torch.gather(
+                embedding_output_,
+                dim=1,
+                index=ids_restore.unsqueeze(-1).repeat(
+                    1, 1, embedding_output_.shape[2]
+                ).to(embedding_output_.device))
+            # add cls token back
+            embedding_output = torch.cat((embedding_output[:, :1, :], embedding_output_), dim=1)
+            encoder_outputs = self.vit.encoder(
+                embedding_output,
+                return_dict=return_dict,
+            )
+            sequence_output = encoder_outputs[0]
+            latent = self.vit.layernorm(sequence_output)
+            if not return_latent:
+                # return the cls token and 0 loss if not return_latent
+                return latent[:, 0], 0
+
+        if return_latent:
+            return latent
+
+        # extract cls latent
+        cls_latent = latent[:, 0]  # shape (batch_size, hidden_size)
+        ids_restore = outputs.ids_restore
+        mask = outputs.mask
+
+        decoder_outputs = self.decoder(latent, ids_restore)
+        # shape (batch_size, num_patches, patch_size*patch_size*num_channels)
+        logits = decoder_outputs.logits
+        # print(decoder_outputs.keys())
+        loss = self.forward_loss(pixel_values, logits, mask)
+        if return_recon:
+            return cls_latent, loss, logits
+
+        return cls_latent, loss

--- a/lightning_pose/models/backbones/vit_sam.py
+++ b/lightning_pose/models/backbones/vit_sam.py
@@ -53,6 +53,11 @@ class SamVisionEncoderHF(nn.Module):
         # Bypass size check entirely
         self._bypass_size_check()
 
+        # Disable relative positional encoding in SAM
+        for layer in self.vision_encoder.layers:
+            if hasattr(layer.attn, "use_rel_pos"):
+                layer.attn.use_rel_pos = False
+
     def _bypass_size_check(self):
         """Completely bypass the size check in patch embedding"""
 

--- a/lightning_pose/models/backbones/vit_sam.py
+++ b/lightning_pose/models/backbones/vit_sam.py
@@ -5,6 +5,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers import SamModel
 
+# to ignore imports for sphix-autoapidoc
+__all__ = [
+    "SamVisionEncoderHF",
+]
+
 
 class SamVisionEncoderHF(nn.Module):
     """Wrapper around HuggingFace's SAM Vision Encoder."""
@@ -147,31 +152,3 @@ class SamVisionEncoderHF(nn.Module):
 
         # Update the vision encoder's positional embeddings
         self.vision_encoder.pos_embed = nn.Parameter(pos_embed_final)
-
-
-def load_sam_vision_encoder_hf(
-    model_name: str = "facebook/sam-vit-base",
-    finetune_image_size: int = 1024,
-    image_size: int = 1024
-):
-    """Load SAM vision encoder from HuggingFace.
-
-    Args:
-        model_name: HuggingFace model name
-            (facebook/sam-vit-base, facebook/sam-vit-large, facebook/sam-vit-huge)
-        finetune_image_size: Target image size for fine-tuning
-        image_size: Original image size (usually 1024 for SAM)
-
-    Returns:
-        SamVisionEncoderHF instance
-
-    """
-
-    # Create the wrapper
-    encoder = SamVisionEncoderHF(
-        model_name=model_name,
-        finetune_img_size=finetune_image_size,
-        img_size=image_size
-    )
-
-    return encoder

--- a/lightning_pose/models/backbones/vits.py
+++ b/lightning_pose/models/backbones/vits.py
@@ -1,9 +1,7 @@
-from functools import partial
-
-import torch
 from typeguard import typechecked
 
-from lightning_pose.models.backbones.vit_sam import load_sam_vision_encoder_hf
+from lightning_pose.models.backbones.vit_mae import ViTVisionEncoder
+from lightning_pose.models.backbones.vit_sam import SamVisionEncoderHF
 
 # to ignore imports for sphix-autoapidoc
 __all__ = [
@@ -37,11 +35,19 @@ def build_backbone(backbone_arch: str, image_size: int = 256, **kwargs):
 
     if "vitb_sam" in backbone_arch:
 
-        base = load_sam_vision_encoder_hf(
+        base = SamVisionEncoderHF(
             model_name="facebook/sam-vit-base",
-            finetune_image_size=image_size,
+            finetune_img_size=image_size,
         )
         encoder_embed_dim = 768
+
+    elif "vitb_imagenet" in backbone_arch:
+
+        base = ViTVisionEncoder(
+            model_name="facebook/vit-mae-base",
+            finetune_img_size=image_size,
+        )
+        encoder_embed_dim = base.vision_encoder.config.hidden_size
 
     else:
         raise NotImplementedError(f"{backbone_arch} is not a valid backbone")

--- a/lightning_pose/models/backbones/vits.py
+++ b/lightning_pose/models/backbones/vits.py
@@ -1,3 +1,4 @@
+import torch
 from typeguard import typechecked
 
 from lightning_pose.models.backbones.vit_mae import ViTVisionEncoder
@@ -49,9 +50,36 @@ def build_backbone(backbone_arch: str, image_size: int = 256, **kwargs):
         )
         encoder_embed_dim = base.vision_encoder.config.hidden_size
 
+        if kwargs.get("backbone_checkpoint"):
+            load_vit_backbone_checkpoint(base, kwargs["backbone_checkpoint"])
+
     else:
         raise NotImplementedError(f"{backbone_arch} is not a valid backbone")
 
     num_fc_input_features = encoder_embed_dim
 
     return base, num_fc_input_features
+
+
+def load_vit_backbone_checkpoint(base, checkpoint: str):
+    print(f"Loading VIT-MAE weights from {checkpoint}")
+    ckpt_vit_pretrain = torch.load(checkpoint, map_location="cpu")
+    # Create a filtered state dict for the VIT-MAE part only
+    vit_mae_state_dict = {}
+    for key, value in ckpt_vit_pretrain.items():
+        if key.startswith("vit_mae."):
+            model_key = key.replace("vit_mae.", "")
+            # Skip known problematic layers with size mismatches
+            if any(prob in model_key for prob in [
+                "position_embeddings",
+                "patch_embeddings.projection",
+                "decoder_pos_embed",
+                "decoder_pred",
+            ]):
+                continue
+            # Check if shapes match before including in state dict
+            if model_key in base.vision_encoder.state_dict():
+                if base.vision_encoder.state_dict()[model_key].shape == value.shape:
+                    vit_mae_state_dict[model_key] = value
+    # Load the filtered weights
+    base.vision_encoder.load_state_dict(vit_mae_state_dict, strict=False)

--- a/lightning_pose/models/base.py
+++ b/lightning_pose/models/base.py
@@ -222,7 +222,7 @@ class BaseFeatureExtractor(LightningModule):
 
         self.backbone_arch = backbone
 
-        if "sam" in self.backbone_arch:
+        if self.backbone_arch.startswith("vit"):
             from lightning_pose.models.backbones.vits import build_backbone
         else:
             from lightning_pose.models.backbones.torchvision import build_backbone

--- a/lightning_pose/models/base.py
+++ b/lightning_pose/models/base.py
@@ -232,6 +232,7 @@ class BaseFeatureExtractor(LightningModule):
             pretrained=pretrained,
             model_type=model_type,  # for torchvision only
             image_size=image_size,  # for ViTs only
+            backbone_checkpoint=kwargs.get('backbone_checkpoint'),  # for ViTMAE's only
         )
 
         self.lr_scheduler = lr_scheduler

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -406,6 +406,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                backbone_checkpoint=cfg.model.get("backbone_checkpoint"),  # only used by ViTMAE
             )
         elif cfg.model.model_type == "heatmap_mhcrnn":
             model = HeatmapTrackerMHCRNN(
@@ -420,6 +421,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                backbone_checkpoint=cfg.model.get("backbone_checkpoint"),  # only used by ViTMAE
             )
         else:
             raise NotImplementedError(
@@ -457,6 +459,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                backbone_checkpoint=cfg.model.get("backbone_checkpoint"),  # only used by ViTMAE
             )
         elif cfg.model.model_type == "heatmap_mhcrnn":
             model = SemiSupervisedHeatmapTrackerMHCRNN(
@@ -472,6 +475,7 @@ def get_model(
                 lr_scheduler=lr_scheduler,
                 lr_scheduler_params=lr_scheduler_params,
                 image_size=image_h,  # only used by ViT
+                backbone_checkpoint=cfg.model.get("backbone_checkpoint"),  # only used by ViTMAE
             )
         else:
             raise NotImplementedError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,22 @@ dev = [
 ]
 extra-models = ["lightning-bolts"]
 
+[tool.flake8]
+max-line-length = 99
+ignore = ["F821", "W503"]
+extend-ignore = ["E203"]
+exclude = [
+    ".git",
+    "__pycache__",
+    "__init__.py",
+    "build",
+    "dist",
+    "docs/",
+    "scripts/",
+]
+
 [tool.isort]
-line_length = 88
+line_length = 99
 profile = "black"
 src_paths = ["lightning_pose", "tests"]
 

--- a/scripts/configs/config_default.yaml
+++ b/scripts/configs/config_default.yaml
@@ -100,6 +100,7 @@ model:
   # resnet50_human_jhmdb | resnet50_human_res_rle | resnet50_human_top_res | resnet50_human_hand
   # efficientnet_b0 | efficientnet_b1 | efficientnet_b2
   # vitb_sam
+  # vitb_imagenet
   backbone: resnet50_animal_ap10k
   # prediction mode: regression | heatmap | heatmap_mhcrnn (context)
   model_type: heatmap

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -21,7 +21,7 @@ WIDTHS = [120, 246, 380]  # similar but not square
 RESNET_BACKBONES = ["resnet18", "resnet34", "resnet50", "resnet101", "resnet152"]
 EFFICIENTNET_BACKBONES = ["efficientnet_b0", "efficientnet_b1", "efficientnet_b2"]
 VIT_BACKBONES = [
-    # "vitb_sam",
+    "vitb_sam",
     "vitb_imagenet"
 ]
 

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -13,7 +13,6 @@ from lightning_pose.models.base import (
     normalized_to_bbox,
 )
 
-# TODO: cleanup
 _TORCH_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 BATCH_SIZE = 2
@@ -22,7 +21,8 @@ WIDTHS = [120, 246, 380]  # similar but not square
 RESNET_BACKBONES = ["resnet18", "resnet34", "resnet50", "resnet101", "resnet152"]
 EFFICIENTNET_BACKBONES = ["efficientnet_b0", "efficientnet_b1", "efficientnet_b2"]
 VIT_BACKBONES = [
-    "vitb_sam",
+    # "vitb_sam",
+    "vitb_imagenet"
 ]
 
 
@@ -197,10 +197,14 @@ def test_backbones_efficientnet():
 
 
 def test_backbones_vit():
-    from transformers.models.sam.modeling_sam import SamPatchEmbeddings
     for ind, backbone in enumerate(VIT_BACKBONES):
         model = BaseFeatureExtractor(backbone=backbone).to(_TORCH_DEVICE)
-        assert isinstance(model.backbone.vision_encoder.patch_embed, SamPatchEmbeddings)
+        if backbone == "vitb_sam":
+            from transformers.models.sam.modeling_sam import SamPatchEmbeddings
+            assert isinstance(model.backbone.vision_encoder.patch_embed, SamPatchEmbeddings)
+        elif backbone == "vitb_imagenet":
+            from transformers.models.vit_mae.modeling_vit_mae import ViTMAEEmbeddings
+            assert isinstance(model.backbone.vision_encoder.vit.embeddings, ViTMAEEmbeddings)
         # remove model from gpu; then cache can be cleared
         del model
         gc.collect()

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -22,7 +22,7 @@ RESNET_BACKBONES = ["resnet18", "resnet34", "resnet50", "resnet101", "resnet152"
 EFFICIENTNET_BACKBONES = ["efficientnet_b0", "efficientnet_b1", "efficientnet_b2"]
 VIT_BACKBONES = [
     "vitb_sam",
-    "vitb_imagenet"
+    "vitb_imagenet",
 ]
 
 
@@ -353,7 +353,7 @@ def test_representation_shapes_vit():
             )
             # representation dim depends on both image size and backbone network
             representations = model(fake_image_batch)
-            assert representations.shape == shape_list_pre_pool[idx_image][idx_backbone]
+            assert representations.shape == shape_list_pre_pool[idx_image][0]
             # remove model/data from gpu; then cache can be cleared
             del fake_image_batch
             del representations


### PR DESCRIPTION
The LP repo currently only supports the Segment Anything ViT backbone; this PR introduces another backbone (still vit-b/16) but pretrained on imagenet using a masked autoencoding loss (from HuggingFace). This PR opens the door to using our own pretrained ViT models.