### PR TITLE
Remove unexpected save_heatmaps parameter predict_new_vids.py

### DIFF
--- a/scripts/predict_new_vids.py
+++ b/scripts/predict_new_vids.py
@@ -103,7 +103,6 @@ def predict_videos_in_dir(cfg: DictConfig):
                 trainer=trainer,
                 model=model,
                 data_module=data_module,
-                save_heatmaps=cfg.eval.get("predict_vids_after_training_save_heatmaps", False),
             )
 
             # compute and save various metrics


### PR DESCRIPTION
The predict_new_vids.py script still had `save_heatmaps` as a parameter in its call to `export_predictions_and_labeled_video` which was removed in https://github.com/paninski-lab/lightning-pose/commit/8b980a63b795fae077b7736b82c16843c826d821

These scripts are probably not really useful in the future (?). But I still use the hydra approach for running multiple models (via slurm and submitit) as well as running multiple models on a directory of videos (to use EKS later). This is still not possible with the CLI (if I am not mistaken).