### PR TITLE
cropzoom with static bbox size

### DIFF
--- a/docs/source/user_guide_advanced/cropzoom_pipeline.rst
+++ b/docs/source/user_guide_advanced/cropzoom_pipeline.rst
@@ -23,7 +23,8 @@ lightning pose model. We provide additional tools that help you compose these mo
 * ``litpose remap``: Given the pose model's predictions and the crop bounding boxes,
   remaps the predictions to the original coordinate space.
 
-For the full command-line reference for these tools, see the CLI page sections: :ref:`Crop <cli-crop>` and :ref:`Remap <cli-remap>`.
+For the full command-line reference for these tools, see the CLI page sections:
+:ref:`Crop <cli-crop>` and :ref:`Remap <cli-remap>`.
 
 Training
 --------
@@ -45,6 +46,30 @@ Inference involves:
 4. Remap the pose model's predictions to the original coordinate space.
 
 
+Bounding box sizing
+===================
+
+The ``litpose crop`` command supports two ways to size the bounding box around the animal.
+The two options are mutually exclusive; if neither is provided, ``--crop_ratio=2.0`` is used.
+
+``--crop_ratio`` (default)
+    Sizes the bounding box relative to the per-frame span of the detected keypoints.
+    A value of 2.0 (the default) produces a box twice as wide and tall as the spread of
+    keypoints. Use this when the animal's apparent size varies across frames.
+
+    .. code-block:: bash
+
+        litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_ratio=2.0
+
+``--crop_size``
+    Produces a fixed square bounding box of the given pixel size, centred on the
+    per-frame mean of the detected keypoints. Use this when the animal occupies a
+    roughly consistent region of the frame and you want uniform crop dimensions.
+
+    .. code-block:: bash
+
+        litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_size=200
+
 Example
 =======
 
@@ -57,6 +82,7 @@ making modifications to this such as:
    your detector model and pose model. This can be accomplished using
    different config files for the detector and pose model.
 2. Limiting ``train_frames`` and ``max_epochs`` for testing purposes.
+3. Choosing ``--crop_ratio`` or ``--crop_size`` to suit your data (see `Bounding box sizing`_ above).
 
 We'll use some bash variables to avoid repeating paths below:
 
@@ -77,6 +103,7 @@ Training script
     litpose train config.yaml --output_dir $MODEL_DIR/$DETECTOR_MODEL
 
     # Crop data for pose model training.
+    # Use --crop_ratio (default) or --crop_size to control bounding box size.
     litpose crop $MODEL_DIR/$DETECTOR_MODEL data/CollectedData.csv
 
     # Train the pose model.

--- a/lightning_pose/cli/commands/crop.py
+++ b/lightning_pose/cli/commands/crop.py
@@ -62,23 +62,38 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
     crop_parser = subparsers.add_parser(
         "crop",
         description=description_text,
-        usage="litpose crop <model_dir> <input_path:video|csv>... --crop_ratio=CROP_RATIO --anchor_keypoints=x,y,z",  # noqa
+        usage=(
+            "litpose crop <model_dir> <input_path:video|csv>..."
+            " [--crop_ratio=CROP_RATIO | --crop_size=CROP_SIZE]"
+            " [--anchor_keypoints=x,y,z]"
+        ),
     )
     crop_parser.add_argument(
         "model_dir", type=types.existing_model_dir, help="path to a model directory"
     )
-
     crop_parser.add_argument("input_path", type=Path, nargs="+", help="one or more files")
     crop_parser.add_argument(
         "--crop_ratio",
         type=float,
-        default=2.0,
-        help="Crop a bounding box this much larger than the animal. Default is 2.",
+        default=None,
+        help=(
+            "Crop a bounding box this much larger than the animal (default 2.0 when neither"
+            " --crop_ratio nor --crop_size is given). Mutually exclusive with --crop_size."
+        ),
+    )
+    crop_parser.add_argument(
+        "--crop_size",
+        type=int,
+        default=None,
+        help=(
+            "Fixed square bounding box side length in pixels, centred on the per-frame mean"
+            " of the anchor keypoints. Mutually exclusive with --crop_ratio."
+        ),
     )
     crop_parser.add_argument(
         "--anchor_keypoints",
         type=str,
-        default="",  # Or a reasonable default like "0,0,0" if appropriate
+        default="",
         help="Comma-separated list of anchor keypoint names, defaults to all keypoints",
     )
     return crop_parser
@@ -108,15 +123,32 @@ def handle(args: argparse.Namespace) -> None:
 
     input_paths = [Path(p) for p in args.input_path]
 
-    detector_cfg = OmegaConf.create(
-        {
-            "crop_ratio": args.crop_ratio,
-            "anchor_keypoints": (
-                args.anchor_keypoints.split(",") if args.anchor_keypoints else []
-            ),
-        }
-    )
-    assert detector_cfg.crop_ratio > 1
+    crop_ratio = args.crop_ratio
+    crop_size = args.crop_size
+
+    if crop_ratio is not None and crop_size is not None:
+        raise ValueError('--crop_ratio and --crop_size are mutually exclusive.')
+    if crop_ratio is None and crop_size is None:
+        crop_ratio = 2.0
+
+    anchor_keypoints = args.anchor_keypoints.split(",") if args.anchor_keypoints else []
+
+    if crop_size is not None:
+        if crop_size <= 0:
+            raise ValueError(f'--crop_size must be a positive integer, got {crop_size}.')
+        detector_cfg = OmegaConf.create({
+            'crop_height': crop_size,
+            'crop_width': crop_size,
+            'anchor_keypoints': anchor_keypoints,
+        })
+    else:
+        assert crop_ratio is not None
+        if crop_ratio <= 1:
+            raise ValueError(f'--crop_ratio must be greater than 1, got {crop_ratio}.')
+        detector_cfg = OmegaConf.create({
+            'crop_ratio': crop_ratio,
+            'anchor_keypoints': anchor_keypoints,
+        })
 
     for input_path in input_paths:
         if input_path.suffix == ".mp4":

--- a/lightning_pose/utils/cropzoom.py
+++ b/lightning_pose/utils/cropzoom.py
@@ -56,23 +56,46 @@ def _calculate_bbox_size(keypoints_per_frame: np.ndarray, crop_ratio: float = 1.
 
 
 def _compute_bbox_df(
-    pred_df: pd.DataFrame, anchor_keypoints: list[str], crop_ratio: float = 1.0
+    pred_df: pd.DataFrame,
+    anchor_keypoints: list[str],
+    crop_ratio: float | None = None,
+    crop_height: int | None = None,
+    crop_width: int | None = None,
 ) -> pd.DataFrame:
     """Compute a bounding-box DataFrame from predicted keypoint positions.
 
     Each row corresponds to one frame and contains the top-left corner (x, y) and size (h, w)
-    of a square bounding box centred on the mean of the anchor keypoints.
+    of a square bounding box. Exactly one of ``crop_ratio`` or the pair
+    ``(crop_height, crop_width)`` must be provided.
+
+    When ``crop_ratio`` is used, the box is centred on the per-frame mean of the anchor
+    keypoints and sized by scaling the keypoint span by ``crop_ratio``.
+
+    When ``crop_height``/``crop_width`` are used, the box is a fixed size centred on the
+    per-frame mean of the anchor keypoints.
 
     Args:
         pred_df: DataFrame of predictions with a MultiIndex column of ``(scorer, bodypart, coord)``
             or equivalent; must contain x and y coordinate columns.
         anchor_keypoints: list of keypoint names used to determine the bounding box centre and
             size; pass an empty list to use all keypoints.
-        crop_ratio: scale factor applied to the bounding box size.
+        crop_ratio: scale factor applied to the keypoint span to determine bbox size.
+        crop_height: fixed bbox height in pixels; must be provided together with ``crop_width``.
+        crop_width: fixed bbox width in pixels; must be provided together with ``crop_height``.
 
     Returns:
         DataFrame with columns ``["x", "y", "h", "w"]`` and the same index as ``pred_df``.
+
+    Raises:
+        ValueError: if both ``crop_ratio`` and ``crop_height``/``crop_width`` are provided, or
+            if neither is provided.
     """
+    fixed_size_mode = crop_height is not None and crop_width is not None
+    if fixed_size_mode and crop_ratio is not None:
+        raise ValueError('provide either crop_ratio or (crop_height, crop_width), not both.')
+    if not fixed_size_mode and crop_ratio is None:
+        raise ValueError('one of crop_ratio or (crop_height, crop_width) must be provided.')
+
     # Get x,y columns for anchor_keypoints (or all keypoints if anchor_keypoints is empty)
     coord_mask = pred_df.columns.get_level_values("coords").isin(["x", "y"])
     if len(anchor_keypoints) > 0:
@@ -89,15 +112,20 @@ def _compute_bbox_df(
     # Shape: (frames, keypoints, x|y)
     keypoints_per_frame = pred_df.loc[:, coord_mask].to_numpy().reshape(pred_df.shape[0], -1, 2)
 
-    bbox_sizes = _calculate_bbox_size(keypoints_per_frame, crop_ratio=crop_ratio)
+    if fixed_size_mode:
+        assert crop_height is not None and crop_width is not None
+        # round up to even dimensions for video-player compatibility
+        crop_height += crop_height % 2
+        crop_width += crop_width % 2
+        bbox_sizes = np.tile([crop_height, crop_width], (len(pred_df), 1))
+        centroids = keypoints_per_frame.mean(axis=1)
+    else:
+        assert crop_ratio is not None
+        bbox_sizes = _calculate_bbox_size(keypoints_per_frame, crop_ratio=crop_ratio)
+        centroids = keypoints_per_frame.mean(axis=1)
 
-    # Shape: (frames, keypoints, x|y) -> (frames, x|y)
-    centroids = keypoints_per_frame.mean(axis=1)
-
-    # Instead of storing centroid, we'll store bbox top-left.
     # Shape: (frames, x|y)
     bbox_toplefts = centroids - bbox_sizes // 2
-    # Floor and store ints.
     bbox_toplefts = np.int64(bbox_toplefts)
 
     # Shape: (frames, x|y) -> (frames, x|y|h|w)
@@ -295,7 +323,11 @@ def generate_cropped_labeled_frames(
 
     # compute and save bbox_df
     bbox_df = _compute_bbox_df(
-        pred_df, list(detector_cfg.anchor_keypoints), crop_ratio=detector_cfg.crop_ratio
+        pred_df,
+        list(detector_cfg.anchor_keypoints),
+        crop_ratio=detector_cfg.get('crop_ratio'),
+        crop_height=detector_cfg.get('crop_height'),
+        crop_width=detector_cfg.get('crop_width'),
     )
 
     output_bbox_file.parent.mkdir(parents=True, exist_ok=True)
@@ -325,7 +357,11 @@ def generate_cropped_video(
 
     # Save cropping bboxes
     bbox_df = _compute_bbox_df(
-        pred_df, list(detector_cfg.anchor_keypoints), crop_ratio=detector_cfg.crop_ratio
+        pred_df,
+        list(detector_cfg.anchor_keypoints),
+        crop_ratio=detector_cfg.get('crop_ratio'),
+        crop_height=detector_cfg.get('crop_height'),
+        crop_width=detector_cfg.get('crop_width'),
     )
     output_bbox_file.parent.mkdir(parents=True, exist_ok=True)
     bbox_df.to_csv(output_bbox_file)

--- a/tests/cli/test_crop.py
+++ b/tests/cli/test_crop.py
@@ -29,7 +29,8 @@ class TestCropParser:
         args = parser.parse_args(['crop', str(model_dir), str(video)])
         assert args.model_dir == model_dir
         assert args.input_path == [video]
-        assert args.crop_ratio == 2.0
+        assert args.crop_ratio is None
+        assert args.crop_size is None
         assert args.anchor_keypoints == ''
 
     def test_missing_model_dir_exits(self, parser, tmp_path):
@@ -51,6 +52,13 @@ class TestCropParser:
             ['crop', str(model_dir), 'video.mp4', '--anchor_keypoints', 'nose,tail']
         )
         assert args.anchor_keypoints == 'nose,tail'
+
+    def test_crop_size(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['crop', str(model_dir), 'video.mp4', '--crop_size', '100'])
+        assert args.crop_size == 100
+        assert args.crop_ratio is None
 
     def test_multiple_input_paths(self, parser, tmp_path):
         model_dir = tmp_path / 'model'

--- a/tests/cli/test_crop.py
+++ b/tests/cli/test_crop.py
@@ -1,10 +1,11 @@
 """Test the crop CLI command argument parsing."""
 
 import argparse
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from lightning_pose.cli.commands.crop import get_parser
+from lightning_pose.cli.commands.crop import get_parser, handle
 
 
 class TestGetParser:
@@ -67,3 +68,109 @@ class TestCropParser:
         video2 = tmp_path / 'video2.mp4'
         args = parser.parse_args(['crop', str(model_dir), str(video1), str(video2)])
         assert args.input_path == [video1, video2]
+
+
+class TestHandle:
+    """Test the handle function."""
+
+    @pytest.fixture
+    def mock_model(self, tmp_path):
+        """Mock Model instance returned by Model.from_dir."""
+        model = MagicMock()
+        model.config.cfg.data.data_dir = str(tmp_path / 'data')
+        return model
+
+    def _make_args(
+        self,
+        tmp_path,
+        input_path,
+        crop_ratio=None,
+        crop_size=None,
+        anchor_keypoints='',
+    ):
+        return argparse.Namespace(
+            model_dir=tmp_path / 'model',
+            input_path=[input_path],
+            crop_ratio=crop_ratio,
+            crop_size=crop_size,
+            anchor_keypoints=anchor_keypoints,
+        )
+
+    def test_raises_when_both_crop_ratio_and_crop_size(self, tmp_path, mock_model):
+        """Raises ValueError when --crop_ratio and --crop_size are both provided."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=2.0, crop_size=100)
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            with pytest.raises(ValueError, match='mutually exclusive'):
+                handle(args)
+
+    def test_raises_when_crop_size_not_positive(self, tmp_path, mock_model):
+        """Raises ValueError when --crop_size is not a positive integer."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_size=0)
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            with pytest.raises(ValueError, match='positive integer'):
+                handle(args)
+
+    def test_raises_when_crop_ratio_not_greater_than_one(self, tmp_path, mock_model):
+        """Raises ValueError when --crop_ratio is <= 1."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=1.0)
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            with pytest.raises(ValueError, match='greater than 1'):
+                handle(args)
+
+    def test_default_crop_ratio_when_neither_given(self, tmp_path, mock_model):
+        """Defaults to crop_ratio=2.0 when neither flag is supplied."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_cropped_video') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        cfg = mock_gen.call_args.kwargs['detector_cfg']
+        assert cfg['crop_ratio'] == 2.0
+        assert 'crop_height' not in cfg
+        assert 'crop_width' not in cfg
+
+    def test_crop_size_sets_detector_cfg(self, tmp_path, mock_model):
+        """crop_height and crop_width are set from --crop_size; crop_ratio is absent."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_size=100)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_cropped_video') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        cfg = mock_gen.call_args.kwargs['detector_cfg']
+        assert cfg['crop_height'] == 100
+        assert cfg['crop_width'] == 100
+        assert 'crop_ratio' not in cfg
+
+    def test_crop_ratio_sets_detector_cfg(self, tmp_path, mock_model):
+        """crop_ratio is passed through to detector_cfg."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=3.5)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_cropped_video') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        cfg = mock_gen.call_args.kwargs['detector_cfg']
+        assert cfg['crop_ratio'] == 3.5
+        assert 'crop_height' not in cfg
+        assert 'crop_width' not in cfg
+
+    def test_csv_input_calls_generate_cropped_labeled_frames(self, tmp_path, mock_model):
+        """CSV input triggers generate_cropped_labeled_frames with correct detector_cfg."""
+        args = self._make_args(tmp_path, tmp_path / 'labels.csv', crop_size=200)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_cropped_labeled_frames') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        cfg = mock_gen.call_args.kwargs['detector_cfg']
+        assert cfg['crop_height'] == 200
+        assert cfg['crop_width'] == 200

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -4,6 +4,8 @@ import shutil
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
+import pytest
 from omegaconf import OmegaConf
 from PIL import Image
 
@@ -120,82 +122,117 @@ def compare_directories(dir1: Path, dir2: Path) -> int | dict:
     return results
 
 
-def test_generate_cropped_labeled_frames(tmp_path, request):
-    # Fetch a dataset and a fully trained model's predictions on it.
-    fetch_test_data_if_needed(request.path.parent, "test_cropzoom_data")
+class TestGenerateCroppedLabeledFrames:
+    """Test the generate_cropped_labeled_frames function."""
 
-    # Copy the model predictions to a temporary model directory.
-    tmp_model_directory = tmp_path / "test_model"
-    shutil.copytree(
-        request.path.parent / "test_cropzoom_data" / "test_model_output",
-        tmp_model_directory,
-    )
-
-    # Run cropzoom on the test data in the temporary model directory.
-    root_directory = request.path.parent / "test_cropzoom_data" / "test_data"
-    detector_cfg = OmegaConf.create(
-        {"crop_ratio": 1.5, "anchor_keypoints": ["A_head", "D_tailtip"]}
-    )
-    generate_cropped_labeled_frames(
-        input_data_dir=root_directory,
-        input_csv_file=root_directory / "CollectedData.csv",
-        input_preds_file=tmp_model_directory / "predictions.csv",
-        detector_cfg=detector_cfg,
-        output_data_dir=tmp_model_directory / "cropped_images",
-        output_bbox_file=tmp_model_directory / "cropped_images" / "bbox.csv",
-        output_csv_file=tmp_model_directory / "cropped_images" / "cropped_labels.csv",
-    )
-
-    # Assert cropzoom output matches expected output.
-    comparison = compare_directories(
-        tmp_model_directory / "cropped_images",
-        request.path.parent
-        / "test_cropzoom_data"
-        / "expected_model_output"
-        / "cropped_images",
-    )
-    # Successfully compared 24 objects.
-    assert comparison == 24
-
-
-def test_generate_cropped_video(tmp_path, request):
-    # Fetch a dataset and a fully trained model's predictions on it.
-    fetch_test_data_if_needed(request.path.parent, "test_cropzoom_data")
-
-    # Copy the model predictions to a temporary model directory.
-    tmp_model_directory = tmp_path / "test_model"
-    shutil.copytree(
-        request.path.parent / "test_cropzoom_data" / "test_model_output",
-        tmp_model_directory,
-    )
-
-    # Run cropzoom on the test data in the temporary model directory.
-    video_directory = (
-        request.path.parent / "test_cropzoom_data" / "test_data" / "videos"
-    )
-    detector_cfg = OmegaConf.create(
-        {"crop_ratio": 1.5, "anchor_keypoints": ["A_head", "D_tailtip"]}
-    )
-    for video_path in video_directory.iterdir():
-        generate_cropped_video(
-            input_video_file=video_path,
-            input_preds_file=tmp_model_directory
-            / "video_preds"
-            / (video_path.stem + ".csv"),
-            detector_cfg=detector_cfg,
-            output_bbox_file=tmp_model_directory
-            / "cropped_videos"
-            / (video_path.stem + "_bbox.csv"),
-            output_file=tmp_model_directory / "cropped_videos" / video_path.name,
+    @pytest.fixture
+    def setup(self, tmp_path, request):
+        fetch_test_data_if_needed(request.path.parent, 'test_cropzoom_data')
+        tmp_model_dir = tmp_path / 'test_model'
+        shutil.copytree(
+            request.path.parent / 'test_cropzoom_data' / 'test_model_output',
+            tmp_model_dir,
         )
+        return tmp_model_dir, request.path.parent / 'test_cropzoom_data'
 
-    # Assert cropzoom output matches expected output.
-    comparison = compare_directories(
-        tmp_model_directory / "cropped_videos",
-        request.path.parent
-        / "test_cropzoom_data"
-        / "expected_model_output"
-        / "cropped_videos",
-    )
-    # Successfully compared 2 objects (need to skip mp4s)
-    assert comparison == 2
+    def test_generate_cropped_labeled_frames_crop_ratio(self, setup):
+        tmp_model_dir, test_data_dir = setup
+        root_dir = test_data_dir / 'test_data'
+        detector_cfg = OmegaConf.create({
+            'crop_ratio': 1.5,
+            'anchor_keypoints': ['A_head', 'D_tailtip'],
+        })
+        generate_cropped_labeled_frames(
+            input_data_dir=root_dir,
+            input_csv_file=root_dir / 'CollectedData.csv',
+            input_preds_file=tmp_model_dir / 'predictions.csv',
+            detector_cfg=detector_cfg,
+            output_data_dir=tmp_model_dir / 'cropped_images',
+            output_bbox_file=tmp_model_dir / 'cropped_images' / 'bbox.csv',
+            output_csv_file=tmp_model_dir / 'cropped_images' / 'cropped_labels.csv',
+        )
+        comparison = compare_directories(
+            tmp_model_dir / 'cropped_images',
+            test_data_dir / 'expected_model_output' / 'cropped_images',
+        )
+        assert comparison == 24  # 24 files compared successfully
+
+    def test_generate_cropped_labeled_frames_crop_size(self, setup):
+        tmp_model_dir, test_data_dir = setup
+        root_dir = test_data_dir / 'test_data'
+        crop_size = 100
+        detector_cfg = OmegaConf.create({
+            'crop_height': crop_size,
+            'crop_width': crop_size,
+            'anchor_keypoints': ['A_head', 'D_tailtip'],
+        })
+        bbox_file = tmp_model_dir / 'cropped_images' / 'bbox.csv'
+        generate_cropped_labeled_frames(
+            input_data_dir=root_dir,
+            input_csv_file=root_dir / 'CollectedData.csv',
+            input_preds_file=tmp_model_dir / 'predictions.csv',
+            detector_cfg=detector_cfg,
+            output_data_dir=tmp_model_dir / 'cropped_images',
+            output_bbox_file=bbox_file,
+            output_csv_file=tmp_model_dir / 'cropped_images' / 'cropped_labels.csv',
+        )
+        bbox_df = pd.read_csv(bbox_file, index_col=0)
+        assert (bbox_df['h'] == crop_size).all()
+        assert (bbox_df['w'] == crop_size).all()
+
+
+class TestGenerateCroppedVideo:
+    """Test the generate_cropped_video function."""
+
+    @pytest.fixture
+    def setup(self, tmp_path, request):
+        fetch_test_data_if_needed(request.path.parent, 'test_cropzoom_data')
+        tmp_model_dir = tmp_path / 'test_model'
+        shutil.copytree(
+            request.path.parent / 'test_cropzoom_data' / 'test_model_output',
+            tmp_model_dir,
+        )
+        video_dir = request.path.parent / 'test_cropzoom_data' / 'test_data' / 'videos'
+        return tmp_model_dir, request.path.parent / 'test_cropzoom_data', video_dir
+
+    def test_generate_cropped_video_crop_ratio(self, setup):
+        tmp_model_dir, test_data_dir, video_dir = setup
+        detector_cfg = OmegaConf.create({
+            'crop_ratio': 1.5,
+            'anchor_keypoints': ['A_head', 'D_tailtip'],
+        })
+        for video_path in video_dir.iterdir():
+            bbox_file = tmp_model_dir / 'cropped_videos' / (video_path.stem + '_bbox.csv')
+            generate_cropped_video(
+                input_video_file=video_path,
+                input_preds_file=tmp_model_dir / 'video_preds' / (video_path.stem + '.csv'),
+                detector_cfg=detector_cfg,
+                output_bbox_file=bbox_file,
+                output_file=tmp_model_dir / 'cropped_videos' / video_path.name,
+            )
+        comparison = compare_directories(
+            tmp_model_dir / 'cropped_videos',
+            test_data_dir / 'expected_model_output' / 'cropped_videos',
+        )
+        assert comparison == 2  # 2 files compared successfully (mp4s skipped)
+
+    def test_generate_cropped_video_crop_size(self, setup):
+        tmp_model_dir, test_data_dir, video_dir = setup
+        crop_size = 100
+        detector_cfg = OmegaConf.create({
+            'crop_height': crop_size,
+            'crop_width': crop_size,
+            'anchor_keypoints': ['A_head', 'D_tailtip'],
+        })
+        for video_path in video_dir.iterdir():
+            bbox_file = tmp_model_dir / 'cropped_videos' / (video_path.stem + '_bbox.csv')
+            generate_cropped_video(
+                input_video_file=video_path,
+                input_preds_file=tmp_model_dir / 'video_preds' / (video_path.stem + '.csv'),
+                detector_cfg=detector_cfg,
+                output_bbox_file=bbox_file,
+                output_file=tmp_model_dir / 'cropped_videos' / video_path.name,
+            )
+            bbox_df = pd.read_csv(bbox_file, index_col=0)
+            assert (bbox_df['h'] == crop_size).all()
+            assert (bbox_df['w'] == crop_size).all()

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -10,6 +10,7 @@ from omegaconf import OmegaConf
 from PIL import Image
 
 from lightning_pose.utils.cropzoom import (
+    _compute_bbox_df,
     _crop_image,
     generate_cropped_labeled_frames,
     generate_cropped_video,
@@ -61,6 +62,41 @@ class TestCropImage:
         original = np.array(Image.open(img_path).crop(bbox))
         cropped = np.array(Image.open(out_path))
         assert np.array_equal(original, cropped)
+
+
+class TestComputeBboxDf:
+    """Test the _compute_bbox_df function."""
+
+    @pytest.fixture
+    def pred_df(self) -> pd.DataFrame:
+        """Minimal two-keypoint, three-frame prediction DataFrame."""
+        columns = pd.MultiIndex.from_tuples(
+            [
+                ('scorer', 'kp0', 'x'),
+                ('scorer', 'kp0', 'y'),
+                ('scorer', 'kp0', 'likelihood'),
+                ('scorer', 'kp1', 'x'),
+                ('scorer', 'kp1', 'y'),
+                ('scorer', 'kp1', 'likelihood'),
+            ],
+            names=['scorer', 'bodyparts', 'coords'],
+        )
+        data = [
+            [10.0, 20.0, 0.9, 30.0, 40.0, 0.8],
+            [15.0, 25.0, 0.9, 35.0, 45.0, 0.8],
+            [20.0, 30.0, 0.9, 40.0, 50.0, 0.8],
+        ]
+        return pd.DataFrame(data, columns=columns)
+
+    def test_raises_when_both_modes_provided(self, pred_df):
+        """Raises ValueError when crop_ratio and crop_height/width are both given."""
+        with pytest.raises(ValueError, match='not both'):
+            _compute_bbox_df(pred_df, [], crop_ratio=2.0, crop_height=100, crop_width=100)
+
+    def test_raises_when_neither_mode_provided(self, pred_df):
+        """Raises ValueError when neither crop_ratio nor crop_height/width are given."""
+        with pytest.raises(ValueError, match='must be provided'):
+            _compute_bbox_df(pred_df, [])
 
 
 # TODO: Move to utils.


### PR DESCRIPTION
**Add --crop_size option to litpose crop**
  
  Adds an alternative bounding-box sizing strategy for the cropzoom pipeline. Previously the only option was
  `--crop_ratio`, which scales the box relative to the per-frame keypoint span. The new `--crop_size` flag produces a
   fixed-pixel square crop centred on the per-frame mean of the anchor keypoints — useful when the animal
  occupies a roughly consistent region of the frame.

  The two flags are mutually exclusive; if neither is provided, `--crop_ratio=2.0` is used as before. Internally,
  generate_cropped_video and generate_cropped_labeled_frames now accept crop_height/crop_width in the detector
  config alongside the existing crop_ratio. Tests and docs updated accordingly.

Closes #413 
