### PR TITLE
Fix: synchronize multiview DALI video readers under random_shuffle

### DIFF
--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -42,6 +42,7 @@ def video_pipe(
     pad_last_batch: bool = False,
     imgaug: str = "default",
     skip_vfr_check: bool = True,
+    reader_seed: int = 123456,
     # arguments consumed by decorator:
     # batch_size,
     # num_threads,
@@ -65,6 +66,9 @@ def video_pipe(
         pad_last_batch:
         imgaug: string identifying which imgaug pipeline to use; "default", "dlc", "dlc-top-down"
         skip_vfr_check: don't check for variable frame rates, can throw errors with small diffs
+        reader_seed: seed shared by all per-view video readers. For multiview pipelines this must
+            be identical across views so that every reader shuffles to the same sequence, keeping
+            the views frame-synchronized (same session, same timepoint) within a batch.
 
     Returns:
         pipeline object to be fed to DALIGenericIterator
@@ -102,6 +106,9 @@ def video_pipe(
             pad_last_batch=pad_last_batch,  # Important for context loaders
             file_list_include_preceding_frame=True,  # to get rid of dali warnings
             skip_vfr_check=skip_vfr_check,
+            # explicit, identical seed across views keeps multiview readers synchronized;
+            # without it DALI auto-assigns a different seed per reader and the views desync
+            seed=reader_seed,
         )
         orig_size = video.shape(device='gpu')  # type: ignore[union-attr]
         if resize_dims:
@@ -286,6 +293,9 @@ class PrepareDALI:
 
         Raises:
             FileNotFoundError: if any path in ``filenames`` does not exist or is not a file.
+            ValueError: for multiview inputs, if views have differing numbers of sessions or if a
+                session has differing frame counts across views (which would desynchronize the
+                per-view readers).
         """
         # determine if we have a multiview pipeline
         if isinstance(filenames, list) and isinstance(filenames[0], list):
@@ -304,13 +314,45 @@ class PrepareDALI:
                 if not os.path.exists(vid) or not os.path.isfile(vid):
                     raise FileNotFoundError(f"{vid} is not a video file!")
 
+        # frame counts of view 0, per session; reused below for `self.frame_count`
+        view0_frame_counts = list(map(count_frames, filenames_2d[0]))
+
+        # For multiview, the per-view DALI readers share a seed so they shuffle to the same
+        # sequence index. That only keeps the views frame-synchronized if every session has the
+        # same number of frames across all views (and the same number of sessions per view).
+        # Otherwise the readers silently drift apart, so fail loudly here instead.
+        if self.multiview:
+            num_sessions = len(filenames_2d[0])
+            for view_idx, view_list in enumerate(filenames_2d):
+                if len(view_list) != num_sessions:
+                    raise ValueError(
+                        f"View {view_idx} has {len(view_list)} video(s) but view 0 has "
+                        f"{num_sessions}; all views must have the same number of sessions for "
+                        "synchronized multiview loading."
+                    )
+            for session_idx in range(num_sessions):
+                counts = [view0_frame_counts[session_idx]] + [
+                    count_frames(filenames_2d[view_idx][session_idx])
+                    for view_idx in range(1, len(filenames_2d))
+                ]
+                if len(set(counts)) != 1:
+                    details = ", ".join(
+                        f"{filenames_2d[view_idx][session_idx]}={counts[view_idx]}"
+                        for view_idx in range(len(filenames_2d))
+                    )
+                    raise ValueError(
+                        "Mismatched frame counts across views for the same session; multiview "
+                        "video readers would desynchronize. Frame counts: "
+                        f"{details}"
+                    )
+
         self.train_stage = train_stage
         self.model_type = model_type
         self.filenames = filenames_2d
         self.resize_dims = resize_dims
         self.dali_config = dali_config
         self.num_threads = num_threads
-        self.frame_count = sum(map(count_frames, filenames_2d[0]))
+        self.frame_count = sum(view0_frame_counts)
         self._pipe_dict: dict = self._setup_pipe_dict(self.filenames, imgaug)
 
     @property
@@ -375,6 +417,10 @@ class PrepareDALI:
             "train": {"context": {}, "base": {}},
         }
         gen_cfg = self.dali_config.get("general", {"seed": 123456})  # type: ignore[arg-type]
+        # Multi-GPU strategy is to have each GPU randomize differently. The same value seeds every
+        # per-view reader (`reader_seed`) so that multiview readers shuffle identically and stay
+        # frame-synchronized within a pipeline.
+        pipeline_seed = gen_cfg["seed"] + device_id
 
         # base (vanilla single-frame model), train pipe args
         base_train_cfg = self.dali_config["base"]["train"]  # type: ignore[arg-type]
@@ -384,8 +430,8 @@ class PrepareDALI:
             "sequence_length": base_train_cfg["sequence_length"],
             "step": base_train_cfg["sequence_length"],
             "batch_size": 1,
-            # Multi-GPU strategy is to have each GPU randomize differently.
-            "seed": gen_cfg["seed"] + device_id,
+            "seed": pipeline_seed,
+            "reader_seed": pipeline_seed,
             "num_threads": self.num_threads,
             "device_id": device_id,
             "random_shuffle": True,
@@ -400,8 +446,8 @@ class PrepareDALI:
             "sequence_length": base_pred_cfg["sequence_length"],
             "step": base_pred_cfg["sequence_length"],
             "batch_size": 1,
-            # Multi-GPU strategy is to have each GPU randomize differently.
-            "seed": gen_cfg["seed"] + device_id,
+            "seed": pipeline_seed,
+            "reader_seed": pipeline_seed,
             "num_threads": self.num_threads,
             "device_id": device_id,
             "random_shuffle": False,
@@ -422,8 +468,8 @@ class PrepareDALI:
             "device_id": device_id,
             "random_shuffle": False,
             "name": "reader",
-            # Multi-GPU strategy is to have each GPU randomize differently.
-            "seed": gen_cfg["seed"] + device_id,
+            "seed": pipeline_seed,
+            "reader_seed": pipeline_seed,
             "pad_sequences": True,
             # "pad_last_batch": True,
             "imgaug": "default",  # no imgaug when predicting
@@ -440,8 +486,8 @@ class PrepareDALI:
             "sequence_length": context_train_cfg["batch_size"],
             "step": context_train_cfg["batch_size"],
             "batch_size": 1,
-            # Multi-GPU strategy is to have each GPU randomize differently.
-            "seed": gen_cfg["seed"] + device_id,
+            "seed": pipeline_seed,
+            "reader_seed": pipeline_seed,
             "num_threads": self.num_threads,
             "device_id": device_id,
             "random_shuffle": True,

--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -278,7 +278,7 @@ def get_videos_in_dir(
             [vid_name.split(f"_{view_names[v]}")[0] for vid_name in video_files_]
             for v, video_files_ in enumerate(video_files)
         ]
-        for view, view_files in zip(view_names, video_files):
+        for view, view_files in zip(view_names, video_files, strict=True):
             if len(view_files) == 0:
                 raise OSError(
                     f"Did not find any video files for view '{view}' in {video_dir}. "

--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -265,7 +265,9 @@ def get_videos_in_dir(
                 for f in all_video_files
                 if (
                     f.endswith(allowed_formats)
-                    and (f.split(".")[-2].endswith(view) or f"_{view}_" in f)
+                    and re.search(
+                        rf"(?<![0-9a-zA-Z]){re.escape(view)}(?![0-9a-zA-Z])", f
+                    )
                 )
             ]
             for view in view_names
@@ -276,6 +278,14 @@ def get_videos_in_dir(
             [vid_name.split(f"_{view_names[v]}")[0] for vid_name in video_files_]
             for v, video_files_ in enumerate(video_files)
         ]
+        for view, view_files in zip(view_names, video_files):
+            if len(view_files) == 0:
+                raise OSError(
+                    f"Did not find any video files for view '{view}' in {video_dir}. "
+                    "Video filenames must contain the view name delimited by "
+                    "non-alphanumeric characters, e.g. <vid_name>_<view_name>.mp4 "
+                    "or <vid_name>_<view_name>.short.mp4."
+                )
         for vids_view in vid_names:
             if set(vids_view) != set(vid_names[0]):
                 raise RuntimeError(

--- a/tests/data/test_dali.py
+++ b/tests/data/test_dali.py
@@ -228,3 +228,61 @@ def test_prepare_dali_multiview(cfg_multiview, video_list):
         assert batch["frames"].shape == frame_shape
         assert batch["transforms"].shape == (num_views, 1, 1)
         assert batch["bbox"].shape == (batch_size, num_views * 4)  # num_views * xyhw
+
+
+def test_prepare_dali_multiview_synchronized(cfg_multiview, video_list, tmp_path, monkeypatch):
+
+    import shutil
+
+    from lightning_pose.data import dali as dali_module
+    from lightning_pose.data.dali import PrepareDALI
+
+    im_height = 256
+    im_width = 256
+
+    num_views = 3
+    filenames = [video_list] * num_views  # really just copies of the same video
+
+    vid_pred_class = PrepareDALI(
+        train_stage="train",  # random_shuffle is True for training
+        model_type="base",
+        filenames=filenames,
+        dali_config=cfg_multiview.dali,
+        resize_dims=[im_height, im_width],
+        imgaug="default",  # no per-view augmentation, so frames are directly comparable
+    )
+
+    # all per-view readers share the same seed, so under random_shuffle every view must read the
+    # exact same frames (same session + timepoints) on every batch
+    loader = vid_pred_class()
+    for _ in range(4):
+        batch = loader.__next__()
+        frames = batch["frames"].cpu().numpy()  # (batch, num_views, channels, height, width)
+        for view in range(1, num_views):
+            assert np.allclose(frames[:, 0], frames[:, view])
+        # sanity: a shuffled sequence still contains distinct frames (not a constant clip)
+        assert not np.allclose(frames[:, 0, 0], frames[:, 0, -1])
+
+    # error is thrown if views have a different number of sessions
+    vid = video_list[0]
+    with pytest.raises(ValueError, match="same number of sessions"):
+        PrepareDALI(
+            train_stage="train",
+            model_type="base",
+            filenames=[[vid, vid], [vid]],
+            dali_config=cfg_multiview.dali,
+            resize_dims=[im_height, im_width],
+        )
+
+    # error is thrown if a session has different frame counts across views
+    vid_copy = str(tmp_path / "view1_session0.mp4")
+    shutil.copy(vid, vid_copy)
+    monkeypatch.setattr(dali_module, "count_frames", lambda p: {vid: 100, vid_copy: 90}[p])
+    with pytest.raises(ValueError, match="frame counts across views"):
+        PrepareDALI(
+            train_stage="train",
+            model_type="base",
+            filenames=[[vid], [vid_copy]],
+            dali_config=cfg_multiview.dali,
+            resize_dims=[im_height, im_width],
+        )


### PR DESCRIPTION
## Summary

In a multiview pipeline, each view is read by its own `fn.readers.video` operator. DALI auto-assigns a **different seed per operator**, so under `random_shuffle=True` (training) the per-view readers shuffled to unrelated sessions/timepoints. The views in a batch therefore came from different frames, silently breaking the multiview correspondence that the unsupervised losses (e.g. `pca_multiview`) depend on. Training/validation curves looked off because the geometric consistency the losses assume never held.

### Changes
- **`video_pipe`**: new explicit `reader_seed` argument, passed as `seed=` to every per-view `fn.readers.video` so all views shuffle to the same sequence.
- **`PrepareDALI._setup_pipe_dict`**: computes a single `pipeline_seed` (`seed + device_id`) once and uses it for both `seed` and `reader_seed` across all train/predict × base/context pipes (also removes prior duplication).
- **`PrepareDALI.__init__`**: validates multiview inputs — all views must have the same number of sessions and matching per-session frame counts — and raises `ValueError` instead of silently desyncing.
- **`get_videos_in_dir`**: matches view names as non-alphanumeric-delimited tokens (so filenames with infixes like `.short` resolve correctly) and raises if a view yields zero videos.

## Test plan
- [x] Added `test_prepare_dali_multiview_synchronized` (in `tests/data/test_dali.py`): builds the real training loader (3 views, shuffle on), asserts every view reads identical frames across 4 consecutive batches, asserts frames are non-degenerate, and checks both new `ValueError` guards.
- [x] **Verified the test fails without the fix**: temporarily giving each reader a differing seed makes the `np.allclose(frames[:, 0], frames[:, view])` assertion fail — confirming it is a genuine regression guard.
- [x] Test passes with the fix on an L4 GPU (DALI 1.46): `pytest tests/data/test_dali.py::test_prepare_dali_multiview_synchronized`.

Made with [Cursor](https://cursor.com)