### PR TITLE
refactor CLI to create and smooth bboxes separately

### DIFF
--- a/docs/source/cli_reference/create_bbox.rst
+++ b/docs/source/cli_reference/create_bbox.rst
@@ -1,0 +1,9 @@
+.. _cli-create-bbox:
+
+Create bbox
+-----------
+
+.. argparse::
+   :module: lightning_pose.cli.commands.create_bbox
+   :func: get_parser
+   :prog: litpose create_bbox

--- a/docs/source/cli_reference/index.rst
+++ b/docs/source/cli_reference/index.rst
@@ -6,6 +6,8 @@ Lightning Pose command-line interface (CLI)
 
    train
    predict
+   create_bbox
+   smooth_bbox
    crop
    remap
    run_app

--- a/docs/source/cli_reference/smooth_bbox.rst
+++ b/docs/source/cli_reference/smooth_bbox.rst
@@ -1,0 +1,9 @@
+.. _cli-smooth-bbox:
+
+Smooth bbox
+-----------
+
+.. argparse::
+   :module: lightning_pose.cli.commands.smooth_bbox
+   :func: get_parser
+   :prog: litpose smooth_bbox

--- a/docs/source/user_guide_advanced/cropzoom_pipeline.rst
+++ b/docs/source/user_guide_advanced/cropzoom_pipeline.rst
@@ -4,53 +4,64 @@ Cropzoom pipeline
 
 For setups where an animal is freely moving in a large arena,
 it's advantageous to crop around the animal before running pose estimation.
-Lightning-pose calls this technique "cropzoom". This document describes how
+Lightning Pose calls this technique "cropzoom". This document describes how
 to set up a such a pipeline.
 
 Conceptual overview
 ===================
 
-A cropzoom pipeline consists of two lightning-pose models:
+A cropzoom pipeline consists of two Lightning Pose models:
 a "detector model" and a "pose model".
 
 * The detector model operates on the full image of the arena.
 * The pose model operates on the cropped animal.
 
 These two models are trained and predicted like any other
-lightning pose model. We provide additional tools that help you compose these models:
+Lightning Pose model. We provide additional tools that help you compose these models:
 
-* ``litpose crop``: Given the detector model's predictions, crops around the animal.
+* ``litpose create_bbox``: Given the detector model's predictions, computes per-frame
+  bounding boxes and saves them as CSV files.
+* ``litpose smooth_bbox``: *(optional)* Applies temporal smoothing to bbox CSV files,
+  which can reduce jitter in the cropped region.
+* ``litpose crop``: Given a directory of bbox CSV files, crops the animal out of each
+  frame or video.
 * ``litpose remap``: Given the pose model's predictions and the crop bounding boxes,
   remaps the predictions to the original coordinate space.
 
 For the full command-line reference for these tools, see the CLI page sections:
-:ref:`Crop <cli-crop>` and :ref:`Remap <cli-remap>`.
+:ref:`Create bbox <cli-create-bbox>`, :ref:`Smooth bbox <cli-smooth-bbox>`,
+:ref:`Crop <cli-crop>`, and :ref:`Remap <cli-remap>`.
 
 Training
 --------
 
 Training involves:
 
-1. Train a "detector model"
-2. Crop training data for the pose model.
-3. Train a "pose model".
+1. Train a "detector model".
+2. Predict on training data using the detector model.
+3. Create bounding boxes from detector predictions.
+4. Crop training data for the pose model.
+5. Train a "pose model".
 
 Inference
 ---------
 
 Inference involves:
 
-1. Predict using the "detector model"
-2. Crop the data using the above predictions
-3. Predict on the cropped data using the "pose model".
-4. Remap the pose model's predictions to the original coordinate space.
+1. Predict using the "detector model".
+2. Create bounding boxes from detector predictions.
+3. *(optional)* Smooth the bounding boxes.
+4. Crop the data using the bounding boxes.
+5. Predict on the cropped data using the "pose model".
+6. Remap the pose model's predictions to the original coordinate space.
 
 
 Bounding box sizing
 ===================
 
-The ``litpose crop`` command supports two ways to size the bounding box around the animal.
-The two options are mutually exclusive; if neither is provided, ``--crop_ratio=2.0`` is used.
+The ``litpose create_bbox`` command supports two ways to size the bounding box around the
+animal.  The two options are mutually exclusive; if neither is provided,
+``--crop_ratio=2.0`` is used.
 
 ``--crop_ratio`` (default)
     Sizes the bounding box relative to the per-frame span of the detected keypoints.
@@ -59,7 +70,7 @@ The two options are mutually exclusive; if neither is provided, ``--crop_ratio=2
 
     .. code-block:: bash
 
-        litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_ratio=2.0
+        litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_ratio=2.0
 
 ``--crop_size``
     Produces a fixed square bounding box of the given pixel size, centred on the
@@ -68,7 +79,39 @@ The two options are mutually exclusive; if neither is provided, ``--crop_ratio=2
 
     .. code-block:: bash
 
-        litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_size=200
+        litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_size=200
+
+Bounding box smoothing
+======================
+
+After running ``litpose create_bbox``, you can optionally smooth the resulting bbox files
+with ``litpose smooth_bbox``.  Smoothing reduces per-frame jitter in the crop region,
+which can improve pose estimation quality when the detector produces noisy predictions.
+
+Smoothed bboxes are written to a **new directory** alongside a ``metadata.json`` file
+that records the smoothing parameters.  You can then pass this directory to
+``litpose crop`` via ``--bbox_dir``.
+
+.. code-block:: bash
+
+    litpose smooth_bbox $MODEL_DIR/$DETECTOR_MODEL/video_preds \
+        --output_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth_w5 \
+        --window 5
+
+Using bboxes from an external source
+=====================================
+
+Because ``litpose crop`` accepts a ``--bbox_dir`` argument, you can use bounding boxes
+produced by any external tool, not just ``litpose create_bbox``
+(e.g., `idtracker.ai <https://idtracker.ai/latest/>`_, `SAM3 <https://ai.meta.com/research/sam3/>`_, etc.).
+Place your bbox CSV files in a directory following the naming convention below, then pass
+``--bbox_dir`` to ``litpose crop``:
+
+* **Videos**: ``<video_stem>_bbox.csv`` (one file per video)
+* **Labeled frames**: ``bbox.csv``
+
+Each bbox CSV must have columns ``x``, ``y``, ``h``, ``w`` (top-left corner and size in
+pixels), with one row per frame.
 
 Example
 =======
@@ -102,15 +145,22 @@ Training script
     # Train the detector model.
     litpose train config.yaml --output_dir $MODEL_DIR/$DETECTOR_MODEL
 
-    # Crop data for pose model training.
+    # Predict on training data with the detector model.
+    litpose predict $MODEL_DIR/$DETECTOR_MODEL data/CollectedData.csv
+
+    # Create bounding boxes from detector predictions.
     # Use --crop_ratio (default) or --crop_size to control bounding box size.
+    litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/CollectedData.csv
+
+    # Crop images for pose model training.
     litpose crop $MODEL_DIR/$DETECTOR_MODEL data/CollectedData.csv
 
     # Train the pose model.
     litpose train config.yaml --output_dir $MODEL_DIR/$POSE_MODEL \
         --detector_model=$MODEL_DIR/$DETECTOR_MODEL
 
-For command-line options of the ``litpose crop`` command used above, see :ref:`the CLI Crop section <cli-crop>`.
+For command-line options of the commands used above, see
+:ref:`Create bbox <cli-create-bbox>` and :ref:`Crop <cli-crop>`.
 
 Prediction on videos script
 ---------------------------
@@ -121,14 +171,26 @@ Prediction on videos script
 
     litpose predict $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4
 
+    litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4
+
+    # Optional: smooth bboxes before cropping.
+    litpose smooth_bbox $MODEL_DIR/$DETECTOR_MODEL/video_preds \
+        --output_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth
+
+    # Crop using raw bboxes (default):
     litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4
+
+    # Or crop using smoothed bboxes:
+    litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4 \
+        --bbox_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth
 
     litpose predict $MODEL_DIR/$POSE_MODEL $MODEL_DIR/$DETECTOR_MODEL/cropped_videos/cropped_test_vid.short.mp4
 
     litpose remap $MODEL_DIR/$POSE_MODEL/video_preds/cropped_TRQ177_200624_112234_lBack.short.csv \
         $MODEL_DIR/$DETECTOR_MODEL/video_preds/test_vid.short_bbox.csv
 
-For detailed command-line options, see :ref:`Crop <cli-crop>` and :ref:`Remap <cli-remap>`.
+For detailed command-line options, see :ref:`Create bbox <cli-create-bbox>`,
+:ref:`Smooth bbox <cli-smooth-bbox>`, :ref:`Crop <cli-crop>`, and :ref:`Remap <cli-remap>`.
 
 Prediction on OOD Labeled Data
 ------------------------------
@@ -141,6 +203,8 @@ and you want to predict on these frames as well as compute pixel error.
     #!/bin/bash
 
     litpose predict $MODEL_DIR/$DETECTOR_MODEL data/CollectedData_new.csv
+
+    litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/CollectedData_new.csv
 
     litpose crop $MODEL_DIR/$DETECTOR_MODEL data/CollectedData_new.csv
 

--- a/docs/source/user_guide_advanced/cropzoom_pipeline.rst
+++ b/docs/source/user_guide_advanced/cropzoom_pipeline.rst
@@ -70,7 +70,7 @@ animal.  The two options are mutually exclusive; if neither is provided,
 
     .. code-block:: bash
 
-        litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_ratio=2.0
+        litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_ratio 2.0
 
 ``--crop_size``
     Produces a fixed square bounding box of the given pixel size, centred on the
@@ -79,7 +79,7 @@ animal.  The two options are mutually exclusive; if neither is provided,
 
     .. code-block:: bash
 
-        litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_size=200
+        litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 --crop_size 200
 
 Bounding box smoothing
 ======================
@@ -157,7 +157,7 @@ Training script
 
     # Train the pose model.
     litpose train config.yaml --output_dir $MODEL_DIR/$POSE_MODEL \
-        --detector_model=$MODEL_DIR/$DETECTOR_MODEL
+        --detector_model $MODEL_DIR/$DETECTOR_MODEL
 
 For command-line options of the commands used above, see
 :ref:`Create bbox <cli-create-bbox>` and :ref:`Crop <cli-crop>`.

--- a/lightning_pose/cli/commands/__init__.py
+++ b/lightning_pose/cli/commands/__init__.py
@@ -1,12 +1,14 @@
 """Command modules for the lightning-pose CLI."""
 
-from . import crop, predict, remap, run_app, train
+from . import create_bbox, crop, predict, remap, run_app, smooth_bbox, train
 
 # List of all available commands
 COMMANDS = {
-    "train": train,
-    "predict": predict,
-    "crop": crop,
-    "remap": remap,
-    "run_app": run_app,
+    'train': train,
+    'predict': predict,
+    'create_bbox': create_bbox,
+    'smooth_bbox': smooth_bbox,
+    'crop': crop,
+    'remap': remap,
+    'run_app': run_app,
 }

--- a/lightning_pose/cli/commands/create_bbox.py
+++ b/lightning_pose/cli/commands/create_bbox.py
@@ -1,0 +1,156 @@
+"""Create-bbox command for the lightning-pose CLI."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from omegaconf import OmegaConf
+
+from .. import types
+
+if TYPE_CHECKING:
+    import lightning_pose.utils.cropzoom as cz  # noqa: F401
+    from lightning_pose.api import Model  # noqa: F401
+
+
+def register_parser(subparsers: Any) -> argparse.ArgumentParser:
+    """Register the create_bbox command parser."""
+    import sys
+    from textwrap import dedent
+
+    is_building_docs = 'sphinx' in sys.modules
+    _doc_link = (
+        ':doc:`Cropzoom pipeline </source/user_guide_advanced/cropzoom_pipeline>`'
+        if is_building_docs
+        else (
+            'https://lightning-pose.readthedocs.io/en/latest'
+            '/source/user_guide_advanced/cropzoom_pipeline.html'
+        )
+    )
+
+    description_text = dedent(
+        f"""\
+            Computes per-frame bounding boxes from detector predictions and saves them as
+            CSV files.  Run ``litpose predict`` first to generate the predictions.
+
+            For video inputs, bbox files are saved to::
+
+                <model_dir>/
+                └── video_preds/
+                    └── <video_stem>_bbox.csv
+
+            For labeled-frames inputs (CSV), bbox files are saved to::
+
+                <model_dir>/
+                └── image_preds/
+                    └── <csv_file_name>/
+                        └── bbox.csv
+
+            The bounding boxes produced here can optionally be smoothed with
+            ``litpose smooth_bbox`` before passing them to ``litpose crop``.
+
+            For an end-to-end usage example, see the user guide:
+            {_doc_link}.
+            """
+    )
+
+    parser = subparsers.add_parser(
+        'create_bbox',
+        description=description_text,
+        usage=(
+            'litpose create_bbox <model_dir> <input_path:video|csv>...'
+            ' [--crop_ratio=CROP_RATIO | --crop_size=CROP_SIZE]'
+            ' [--anchor_keypoints=x,y,z]'
+        ),
+    )
+    parser.add_argument(
+        'model_dir', type=types.existing_model_dir, help='path to a detector model directory'
+    )
+    parser.add_argument('input_path', type=Path, nargs='+', help='one or more video or CSV files')
+    parser.add_argument(
+        '--crop_ratio',
+        type=float,
+        default=None,
+        help=(
+            'size the bounding box this many times larger than the animal keypoint span'
+            ' (default 2.0 when neither --crop_ratio nor --crop_size is given).'
+            ' Mutually exclusive with --crop_size.'
+        ),
+    )
+    parser.add_argument(
+        '--crop_size',
+        type=int,
+        default=None,
+        help=(
+            'fixed square bounding box side length in pixels, centred on the per-frame mean'
+            ' of the anchor keypoints. Mutually exclusive with --crop_ratio.'
+        ),
+    )
+    parser.add_argument(
+        '--anchor_keypoints',
+        type=str,
+        default='',
+        help='comma-separated list of anchor keypoint names; defaults to all keypoints',
+    )
+    return parser
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Return an ArgumentParser for the ``litpose create_bbox`` subcommand (for docs)."""
+    parser = argparse.ArgumentParser(prog='litpose')
+    subparsers = parser.add_subparsers(dest='command')
+    return register_parser(subparsers)
+
+
+def handle(args: argparse.Namespace) -> None:
+    """Handle the create_bbox command."""
+    import lightning_pose.utils.cropzoom as cz  # noqa: F811
+    from lightning_pose.api import Model  # noqa: F811
+
+    model = Model.from_dir(args.model_dir)
+
+    crop_ratio = args.crop_ratio
+    crop_size = args.crop_size
+
+    if crop_ratio is not None and crop_size is not None:
+        raise ValueError('--crop_ratio and --crop_size are mutually exclusive.')
+    if crop_ratio is None and crop_size is None:
+        crop_ratio = 2.0
+
+    anchor_keypoints = args.anchor_keypoints.split(',') if args.anchor_keypoints else []
+
+    if crop_size is not None:
+        if crop_size <= 0:
+            raise ValueError(f'--crop_size must be a positive integer, got {crop_size}.')
+        detector_cfg = OmegaConf.create({
+            'crop_height': crop_size,
+            'crop_width': crop_size,
+            'anchor_keypoints': anchor_keypoints,
+        })
+    else:
+        assert crop_ratio is not None
+        if crop_ratio <= 1:
+            raise ValueError(f'--crop_ratio must be greater than 1, got {crop_ratio}.')
+        detector_cfg = OmegaConf.create({
+            'crop_ratio': crop_ratio,
+            'anchor_keypoints': anchor_keypoints,
+        })
+
+    for input_path in [Path(p) for p in args.input_path]:
+        if input_path.suffix == '.mp4':
+            input_preds_file = model.video_preds_dir() / (input_path.stem + '.csv')
+            output_bbox_file = model.video_preds_dir() / (input_path.stem + '_bbox.csv')
+        elif input_path.suffix == '.csv':
+            preds_dir = model.image_preds_dir() / input_path.name
+            input_preds_file = preds_dir / 'predictions.csv'
+            output_bbox_file = preds_dir / 'bbox.csv'
+        else:
+            raise NotImplementedError('only mp4 and csv files are supported.')
+
+        cz.generate_bbox(
+            input_preds_file=input_preds_file,
+            detector_cfg=detector_cfg,
+            output_bbox_file=output_bbox_file,
+        )

--- a/lightning_pose/cli/commands/create_bbox.py
+++ b/lightning_pose/cli/commands/create_bbox.py
@@ -68,7 +68,13 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
     parser.add_argument(
         'model_dir', type=types.existing_model_dir, help='path to a detector model directory'
     )
-    parser.add_argument('input_path', type=Path, nargs='+', help='one or more video or CSV files')
+    parser.add_argument(
+        'input_path',
+        type=Path,
+        nargs='+',
+        help='one or more video files, CSV files, or directories (directories are expanded to'
+        ' their contained *.mp4 files)',
+    )
     parser.add_argument(
         '--crop_ratio',
         type=float,
@@ -138,7 +144,16 @@ def handle(args: argparse.Namespace) -> None:
             'anchor_keypoints': anchor_keypoints,
         })
 
-    for input_path in [Path(p) for p in args.input_path]:
+    input_paths: list[Path] = []
+    for p in args.input_path:
+        p = Path(p)
+        if p.is_dir():
+            print(f'Processing directory {p}')
+            input_paths.extend(sorted(f for f in p.iterdir() if f.suffix == '.mp4'))
+        else:
+            input_paths.append(p)
+
+    for input_path in input_paths:
         if input_path.suffix == '.mp4':
             input_preds_file = model.video_preds_dir() / (input_path.stem + '.csv')
             output_bbox_file = model.video_preds_dir() / (input_path.stem + '_bbox.csv')
@@ -149,6 +164,7 @@ def handle(args: argparse.Namespace) -> None:
         else:
             raise NotImplementedError('only mp4 and csv files are supported.')
 
+        print(f'Creating bboxes for {input_path.name}')
         cz.generate_bbox(
             input_preds_file=input_preds_file,
             detector_cfg=detector_cfg,

--- a/lightning_pose/cli/commands/crop.py
+++ b/lightning_pose/cli/commands/crop.py
@@ -6,8 +6,6 @@ import argparse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from omegaconf import OmegaConf
-
 from .. import types
 
 if TYPE_CHECKING:
@@ -17,42 +15,44 @@ if TYPE_CHECKING:
 
 def register_parser(subparsers: Any) -> argparse.ArgumentParser:
     """Register the crop command parser."""
-    # Choose documentation link depending on whether we're being imported by Sphinx
     import sys
     from textwrap import dedent
 
-    is_building_docs = "sphinx" in sys.modules
+    is_building_docs = 'sphinx' in sys.modules
     _doc_link = (
-        ":doc:`Cropzoom pipeline </source/user_guide_advanced/cropzoom_pipeline>`"
+        ':doc:`Cropzoom pipeline </source/user_guide_advanced/cropzoom_pipeline>`'
         if is_building_docs
-        else "https://lightning-pose.readthedocs.io/en/latest/source/user_guide_advanced/cropzoom_pipeline.html"
+        else (
+            'https://lightning-pose.readthedocs.io/en/latest'
+            '/source/user_guide_advanced/cropzoom_pipeline.html'
+        )
     )
 
     description_text = dedent(
         f"""\
-            Crops a video or labeled frames based on model predictions.
-            Requires model predictions to already have been generated using ``litpose predict``.
+            Crops a video or labeled frames using pre-computed bounding boxes.
+            Run ``litpose create_bbox`` (and optionally ``litpose smooth_bbox``) first.
 
             Cropped videos are saved to::
 
                 <model_dir>/
-                └── video_preds/
-                    ├── <video_filename>.csv              (predictions)
-                    ├── <video_filename>_bbox.csv         (bbox)
-                    └── remapped_<video_filename>.csv     (TODO move to remap command)
                 └── cropped_videos/
-                    └── cropped_<video_filename>.mp4      (cropped video)
+                    └── cropped_<video_filename>.mp4
 
-            Cropped images are saved to::
+            Cropped images and a remapped labels CSV are saved to::
 
+                <model_dir>/
+                └── cropped_images/
+                        └── a/b/c/<image_name>.png
                 <model_dir>/
                 └── image_preds/
                     └── <csv_file_name>/
-                        ├── predictions.csv
-                        ├── bbox.csv                      (bbox)
-                        └── cropped_<csv_file_name>.csv   (cropped labels)
-                └── cropped_images/
-                        └── a/b/c/<image_name>.png        (cropped images)
+                        └── cropped_<csv_file_name>.csv
+
+            When ``--bbox_dir`` is omitted, bbox files are read from the default
+            locations written by ``litpose create_bbox``.  Pass ``--bbox_dir`` to use
+            bboxes from a different source (e.g. output of ``litpose smooth_bbox`` or
+            bboxes produced by an external tool).
 
             For an end-to-end usage example of the Cropzoom workflow, see the user guide:
             {_doc_link}.
@@ -60,49 +60,35 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
     )
 
     crop_parser = subparsers.add_parser(
-        "crop",
+        'crop',
         description=description_text,
         usage=(
-            "litpose crop <model_dir> <input_path:video|csv>..."
-            " [--crop_ratio=CROP_RATIO | --crop_size=CROP_SIZE]"
-            " [--anchor_keypoints=x,y,z]"
+            'litpose crop <model_dir> <input_path:video|csv>...'
+            ' [--bbox_dir=BBOX_DIR]'
         ),
     )
     crop_parser.add_argument(
-        "model_dir", type=types.existing_model_dir, help="path to a model directory"
+        'model_dir', type=types.existing_model_dir, help='path to a model directory'
     )
-    crop_parser.add_argument("input_path", type=Path, nargs="+", help="one or more files")
+    crop_parser.add_argument('input_path', type=Path, nargs='+', help='one or more files')
     crop_parser.add_argument(
-        "--crop_ratio",
-        type=float,
+        '--bbox_dir',
+        type=Path,
         default=None,
         help=(
-            "Crop a bounding box this much larger than the animal (default 2.0 when neither"
-            " --crop_ratio nor --crop_size is given). Mutually exclusive with --crop_size."
+            'directory containing bbox CSV files to use for cropping. '
+            'For videos, looks for <bbox_dir>/<video_stem>_bbox.csv; '
+            'for CSV inputs, looks for <bbox_dir>/bbox.csv. '
+            'Defaults to the location written by litpose create_bbox.'
         ),
-    )
-    crop_parser.add_argument(
-        "--crop_size",
-        type=int,
-        default=None,
-        help=(
-            "Fixed square bounding box side length in pixels, centred on the per-frame mean"
-            " of the anchor keypoints. Mutually exclusive with --crop_ratio."
-        ),
-    )
-    crop_parser.add_argument(
-        "--anchor_keypoints",
-        type=str,
-        default="",
-        help="Comma-separated list of anchor keypoint names, defaults to all keypoints",
     )
     return crop_parser
 
 
 def get_parser() -> argparse.ArgumentParser:
     """Return an ArgumentParser for the `litpose crop` subcommand (for docs)."""
-    parser = argparse.ArgumentParser(prog="litpose")
-    subparsers = parser.add_subparsers(dest="command")
+    parser = argparse.ArgumentParser(prog='litpose')
+    subparsers = parser.add_subparsers(dest='command')
     return register_parser(subparsers)
 
 
@@ -121,64 +107,38 @@ def handle(args: argparse.Namespace) -> None:
     model.cropped_data_dir().mkdir(parents=True, exist_ok=True)
     model.cropped_videos_dir().mkdir(parents=True, exist_ok=True)
 
-    input_paths = [Path(p) for p in args.input_path]
+    bbox_dir = args.bbox_dir
 
-    crop_ratio = args.crop_ratio
-    crop_size = args.crop_size
+    for input_path in [Path(p) for p in args.input_path]:
+        if input_path.suffix == '.mp4':
+            if bbox_dir is not None:
+                input_bbox_file = bbox_dir / (input_path.stem + '_bbox.csv')
+            else:
+                input_bbox_file = model.video_preds_dir() / (input_path.stem + '_bbox.csv')
+            output_file = model.cropped_videos_dir() / ('cropped_' + input_path.name)
 
-    if crop_ratio is not None and crop_size is not None:
-        raise ValueError('--crop_ratio and --crop_size are mutually exclusive.')
-    if crop_ratio is None and crop_size is None:
-        crop_ratio = 2.0
-
-    anchor_keypoints = args.anchor_keypoints.split(",") if args.anchor_keypoints else []
-
-    if crop_size is not None:
-        if crop_size <= 0:
-            raise ValueError(f'--crop_size must be a positive integer, got {crop_size}.')
-        detector_cfg = OmegaConf.create({
-            'crop_height': crop_size,
-            'crop_width': crop_size,
-            'anchor_keypoints': anchor_keypoints,
-        })
-    else:
-        assert crop_ratio is not None
-        if crop_ratio <= 1:
-            raise ValueError(f'--crop_ratio must be greater than 1, got {crop_ratio}.')
-        detector_cfg = OmegaConf.create({
-            'crop_ratio': crop_ratio,
-            'anchor_keypoints': anchor_keypoints,
-        })
-
-    for input_path in input_paths:
-        if input_path.suffix == ".mp4":
-            input_preds_file = model.video_preds_dir() / (input_path.stem + ".csv")
-            output_bbox_file = model.video_preds_dir() / (input_path.stem + "_bbox.csv")
-            output_file = model.cropped_videos_dir() / ("cropped_" + input_path.name)
-
-            cz.generate_cropped_video(
+            cz.crop_video(
                 input_video_file=input_path,
-                input_preds_file=input_preds_file,
-                detector_cfg=detector_cfg,
-                output_bbox_file=output_bbox_file,
+                input_bbox_file=input_bbox_file,
                 output_file=output_file,
             )
-        elif input_path.suffix == ".csv":
+        elif input_path.suffix == '.csv':
             preds_dir = model.image_preds_dir() / input_path.name
             input_data_dir = Path(model.config.cfg.data.data_dir)
             cropped_data_dir = model.cropped_data_dir()
 
-            output_bbox_file = preds_dir / "bbox.csv"
-            output_csv_file_path = preds_dir / ("cropped_" + input_path.name)
-            input_preds_file = preds_dir / "predictions.csv"
-            cz.generate_cropped_labeled_frames(
+            if bbox_dir is not None:
+                input_bbox_file = bbox_dir / 'bbox.csv'
+            else:
+                input_bbox_file = preds_dir / 'bbox.csv'
+            output_csv_file_path = preds_dir / ('cropped_' + input_path.name)
+
+            cz.crop_labeled_frames(
                 input_data_dir=input_data_dir,
                 input_csv_file=input_path,
-                input_preds_file=input_preds_file,
-                detector_cfg=detector_cfg,
+                input_bbox_file=input_bbox_file,
                 output_data_dir=cropped_data_dir,
-                output_bbox_file=output_bbox_file,
                 output_csv_file=output_csv_file_path,
             )
         else:
-            raise NotImplementedError("Only mp4 and csv files are supported.")
+            raise NotImplementedError('only mp4 and csv files are supported.')

--- a/lightning_pose/cli/commands/crop.py
+++ b/lightning_pose/cli/commands/crop.py
@@ -70,7 +70,13 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
     crop_parser.add_argument(
         'model_dir', type=types.existing_model_dir, help='path to a model directory'
     )
-    crop_parser.add_argument('input_path', type=Path, nargs='+', help='one or more files')
+    crop_parser.add_argument(
+        'input_path',
+        type=Path,
+        nargs='+',
+        help='one or more video files, CSV files, or directories (directories are expanded to'
+        ' their contained *.mp4 files)',
+    )
     crop_parser.add_argument(
         '--bbox_dir',
         type=Path,
@@ -109,7 +115,16 @@ def handle(args: argparse.Namespace) -> None:
 
     bbox_dir = args.bbox_dir
 
-    for input_path in [Path(p) for p in args.input_path]:
+    input_paths: list[Path] = []
+    for p in args.input_path:
+        p = Path(p)
+        if p.is_dir():
+            print(f'Processing directory {p}')
+            input_paths.extend(sorted(f for f in p.iterdir() if f.suffix == '.mp4'))
+        else:
+            input_paths.append(p)
+
+    for input_path in input_paths:
         if input_path.suffix == '.mp4':
             if bbox_dir is not None:
                 input_bbox_file = bbox_dir / (input_path.stem + '_bbox.csv')
@@ -117,6 +132,7 @@ def handle(args: argparse.Namespace) -> None:
                 input_bbox_file = model.video_preds_dir() / (input_path.stem + '_bbox.csv')
             output_file = model.cropped_videos_dir() / ('cropped_' + input_path.name)
 
+            print(f'Cropping {input_path.name}')
             cz.crop_video(
                 input_video_file=input_path,
                 input_bbox_file=input_bbox_file,
@@ -133,6 +149,7 @@ def handle(args: argparse.Namespace) -> None:
                 input_bbox_file = preds_dir / 'bbox.csv'
             output_csv_file_path = preds_dir / ('cropped_' + input_path.name)
 
+            print(f'Cropping {input_path.name}')
             cz.crop_labeled_frames(
                 input_data_dir=input_data_dir,
                 input_csv_file=input_path,

--- a/lightning_pose/cli/commands/smooth_bbox.py
+++ b/lightning_pose/cli/commands/smooth_bbox.py
@@ -80,9 +80,11 @@ def handle(args: argparse.Namespace) -> None:
     """Handle the smooth_bbox command."""
     import lightning_pose.utils.cropzoom as cz
 
+    print(f'Smoothing bboxes in {args.bbox_dir}')
     cz.smooth_bbox(
         input_bbox_dir=args.bbox_dir,
         output_dir=args.output_dir,
         method=args.method,
         window=args.window,
     )
+    print(f'Saved smoothed bboxes to {args.output_dir}')

--- a/lightning_pose/cli/commands/smooth_bbox.py
+++ b/lightning_pose/cli/commands/smooth_bbox.py
@@ -1,0 +1,88 @@
+"""Smooth-bbox command for the lightning-pose CLI."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+
+def register_parser(subparsers: Any) -> argparse.ArgumentParser:
+    """Register the smooth_bbox command parser."""
+    import sys
+    from textwrap import dedent
+
+    is_building_docs = 'sphinx' in sys.modules
+    _doc_link = (
+        ':doc:`Cropzoom pipeline </source/user_guide_advanced/cropzoom_pipeline>`'
+        if is_building_docs
+        else (
+            'https://lightning-pose.readthedocs.io/en/latest'
+            '/source/user_guide_advanced/cropzoom_pipeline.html'
+        )
+    )
+
+    description_text = dedent(
+        f"""\
+            Applies temporal smoothing to bounding-box CSV files produced by
+            ``litpose create_bbox``.  Reads every ``*_bbox.csv`` file in the input
+            directory, smooths the ``x``, ``y``, ``h``, and ``w`` columns, and writes
+            the results to a new output directory together with a ``metadata.json``
+            that records the smoothing parameters used.
+
+            The smoothed bboxes can then be passed to ``litpose crop`` via
+            ``--bbox_dir``.
+
+            For an end-to-end usage example, see the user guide:
+            {_doc_link}.
+            """
+    )
+
+    parser = subparsers.add_parser(
+        'smooth_bbox',
+        description=description_text,
+        usage='litpose smooth_bbox <bbox_dir> --output_dir <dir> [--method METHOD] [--window N]',
+    )
+    parser.add_argument(
+        'bbox_dir',
+        type=Path,
+        help='directory containing raw *_bbox.csv files (output of litpose create_bbox)',
+    )
+    parser.add_argument(
+        '--output_dir',
+        type=Path,
+        required=True,
+        help='directory where smoothed bbox files and metadata.json will be written',
+    )
+    parser.add_argument(
+        '--method',
+        type=str,
+        default='median',
+        help="smoothing method; currently only 'median' is supported (default: median)",
+    )
+    parser.add_argument(
+        '--window',
+        type=int,
+        default=5,
+        help='rolling window size in frames (default: 5)',
+    )
+    return parser
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Return an ArgumentParser for the ``litpose smooth_bbox`` subcommand (for docs)."""
+    parser = argparse.ArgumentParser(prog='litpose')
+    subparsers = parser.add_subparsers(dest='command')
+    return register_parser(subparsers)
+
+
+def handle(args: argparse.Namespace) -> None:
+    """Handle the smooth_bbox command."""
+    import lightning_pose.utils.cropzoom as cz
+
+    cz.smooth_bbox(
+        input_bbox_dir=args.bbox_dir,
+        output_dir=args.output_dir,
+        method=args.method,
+        window=args.window,
+    )

--- a/lightning_pose/utils/cropzoom.py
+++ b/lightning_pose/utils/cropzoom.py
@@ -1,5 +1,7 @@
 """Tools for cropping labeled frames and videos to bounding-box regions of interest."""
 
+import json
+import logging
 import multiprocessing
 from pathlib import Path
 from typing import Any
@@ -14,9 +16,13 @@ from PIL import Image
 
 from lightning_pose.utils import io
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
-    "generate_cropped_labeled_frames",
-    "generate_cropped_video",
+    "generate_bbox",
+    "smooth_bbox",
+    "crop_video",
+    "crop_labeled_frames",
     "generate_cropped_csv_file",
 ]
 
@@ -305,23 +311,22 @@ def _crop_video_moviepy(video_file: Path, bbox_df: pd.DataFrame, output_file: Pa
     cropped_clip.write_videofile(str(output_file), codec="libx264")
 
 
-def generate_cropped_labeled_frames(
-    input_data_dir: Path,
-    input_csv_file: Path,
+def generate_bbox(
     input_preds_file: Path,
     detector_cfg: DictConfig,
-    output_data_dir: Path,
     output_bbox_file: Path,
-    output_csv_file: Path,
 ) -> None:
-    """Given model predictions, generates a bbox.csv, crops frames,
-    and a cropped csv file."""
-    # Use predictions rather than CollectedData.csv because collected data can sometimes have NaNs.
-    # load predictions
+    """Compute bounding boxes from model predictions and save to a CSV file.
+
+    Args:
+        input_preds_file: path to the predictions CSV produced by ``litpose predict``.
+        detector_cfg: OmegaConf config containing ``anchor_keypoints`` and either
+            ``crop_ratio`` or ``crop_height``/``crop_width``.
+        output_bbox_file: path where the bbox CSV will be written.
+    """
+    # use predictions rather than CollectedData.csv because collected data can have NaNs
     pred_df = pd.read_csv(input_preds_file, header=[0, 1, 2], index_col=0)
     pred_df = io.fix_empty_first_row(pred_df)
-
-    # compute and save bbox_df
     bbox_df = _compute_bbox_df(
         pred_df,
         list(detector_cfg.anchor_keypoints),
@@ -329,45 +334,103 @@ def generate_cropped_labeled_frames(
         crop_height=detector_cfg.get('crop_height'),
         crop_width=detector_cfg.get('crop_width'),
     )
-
     output_bbox_file.parent.mkdir(parents=True, exist_ok=True)
     bbox_df.to_csv(output_bbox_file)
 
-    _crop_images(bbox_df, input_data_dir, output_data_dir)
 
-    generate_cropped_csv_file(
-        input_csv_file=input_csv_file,
-        input_bbox_file=output_bbox_file,
-        output_csv_file=output_csv_file,
-    )
+def smooth_bbox(
+    input_bbox_dir: Path,
+    output_dir: Path,
+    method: str = 'median',
+    window: int = 5,
+) -> None:
+    """Smooth bbox CSV files in a directory and save the results to a new directory.
+
+    Reads every ``*_bbox.csv`` file in ``input_bbox_dir``, applies a rolling smoothing
+    operation over the ``x``, ``y``, ``h``, ``w`` columns, and writes the smoothed files
+    to ``output_dir`` alongside a ``metadata.json`` that records the smoothing parameters.
+
+    Args:
+        input_bbox_dir: directory containing raw ``*_bbox.csv`` files.
+        output_dir: directory where smoothed files and ``metadata.json`` will be written.
+        method: smoothing method; currently only ``'median'`` is supported.
+        window: window size (number of frames) for the rolling operation.
+
+    Raises:
+        ValueError: if ``method`` is not supported or no ``*_bbox.csv`` files are found.
+    """
+    supported_methods = ('median',)
+    if method not in supported_methods:
+        raise ValueError(
+            f'unsupported method {method!r}; choose one of {supported_methods}.'
+        )
+
+    bbox_files = sorted(input_bbox_dir.glob('*_bbox.csv'))
+    if not bbox_files:
+        raise ValueError(f'no *_bbox.csv files found in {input_bbox_dir}.')
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for bbox_file in bbox_files:
+        bbox_df = pd.read_csv(bbox_file, index_col=0)
+        if method == 'median':
+            smoothed = bbox_df.rolling(window=window, center=True, min_periods=1).median()
+        smoothed = smoothed.round(0).astype(int)
+        smoothed.to_csv(output_dir / bbox_file.name)
+        logger.info(f'smoothed {bbox_file.name} → {output_dir / bbox_file.name}')
+
+    metadata = {
+        'method': method,
+        'window': window,
+        'source': str(input_bbox_dir.resolve()),
+    }
+    (output_dir / 'metadata.json').write_text(json.dumps(metadata, indent=2))
+    logger.info(f'wrote metadata to {output_dir / "metadata.json"}')
 
 
-def generate_cropped_video(
+def crop_video(
     input_video_file: Path,
-    input_preds_file: Path,
-    detector_cfg: DictConfig,
-    output_bbox_file: Path,
+    input_bbox_file: Path,
     output_file: Path,
 ) -> None:
-    """TODO make consistent with generate_cropped_labeled_frames"""
+    """Crop a video to per-frame bounding-box regions and save the result.
 
-    # Given the predictions, compute cropping bboxes
-    pred_df = pd.read_csv(input_preds_file, header=[0, 1, 2], index_col=0)
-    pred_df = io.fix_empty_first_row(pred_df)
-
-    # Save cropping bboxes
-    bbox_df = _compute_bbox_df(
-        pred_df,
-        list(detector_cfg.anchor_keypoints),
-        crop_ratio=detector_cfg.get('crop_ratio'),
-        crop_height=detector_cfg.get('crop_height'),
-        crop_width=detector_cfg.get('crop_width'),
-    )
-    output_bbox_file.parent.mkdir(parents=True, exist_ok=True)
-    bbox_df.to_csv(output_bbox_file)
-
-    # Generate a cropped video for debugging purposes.
+    Args:
+        input_video_file: path to the input video.
+        input_bbox_file: path to a bbox CSV produced by :func:`generate_bbox` or
+            :func:`smooth_bbox`.
+        output_file: path where the cropped video will be written.
+    """
+    bbox_df = pd.read_csv(input_bbox_file, index_col=0)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
     _crop_video_moviepy(input_video_file, bbox_df, output_file)
+
+
+def crop_labeled_frames(
+    input_data_dir: Path,
+    input_csv_file: Path,
+    input_bbox_file: Path,
+    output_data_dir: Path,
+    output_csv_file: Path,
+) -> None:
+    """Crop labeled frames to bounding-box regions and generate a remapped labels CSV.
+
+    Args:
+        input_data_dir: root directory containing the original images.
+        input_csv_file: path to the original labels CSV (e.g. ``CollectedData.csv``).
+        input_bbox_file: path to a bbox CSV produced by :func:`generate_bbox` or
+            :func:`smooth_bbox`.
+        output_data_dir: directory where cropped images will be saved.
+        output_csv_file: path where the remapped labels CSV will be written.
+    """
+    bbox_df = pd.read_csv(input_bbox_file, index_col=0)
+    output_data_dir.mkdir(parents=True, exist_ok=True)
+    _crop_images(bbox_df, input_data_dir, output_data_dir)
+    generate_cropped_csv_file(
+        input_csv_file=input_csv_file,
+        input_bbox_file=input_bbox_file,
+        output_csv_file=output_csv_file,
+    )
 
 
 def generate_cropped_csv_file(

--- a/tests/cli/test_create_bbox.py
+++ b/tests/cli/test_create_bbox.py
@@ -1,0 +1,206 @@
+"""Test the create_bbox CLI command argument parsing."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lightning_pose.cli.commands.create_bbox import get_parser, handle
+
+
+class TestGetParser:
+    """Test the get_parser function."""
+
+    def test_returns_argument_parser(self):
+        """Returns an ArgumentParser instance."""
+        assert isinstance(get_parser(), argparse.ArgumentParser)
+
+    def test_prog_is_litpose_create_bbox(self):
+        """Returned parser has prog set to 'litpose create_bbox'."""
+        assert get_parser().prog == 'litpose create_bbox'
+
+
+class TestCreateBboxParser:
+    """Test the create_bbox subcommand argument parsing."""
+
+    def test_valid_args(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        video = tmp_path / 'video.mp4'
+        args = parser.parse_args(['create_bbox', str(model_dir), str(video)])
+        assert args.model_dir == model_dir
+        assert args.input_path == [video]
+        assert args.crop_ratio is None
+        assert args.crop_size is None
+        assert args.anchor_keypoints == ''
+
+    def test_missing_model_dir_exits(self, parser, tmp_path):
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                ['create_bbox', str(tmp_path / 'missing'), str(tmp_path / 'video.mp4')]
+            )
+
+    def test_crop_ratio(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['create_bbox', str(model_dir), 'video.mp4', '--crop_ratio', '3.5']
+        )
+        assert args.crop_ratio == 3.5
+
+    def test_crop_size(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['create_bbox', str(model_dir), 'video.mp4', '--crop_size', '100']
+        )
+        assert args.crop_size == 100
+        assert args.crop_ratio is None
+
+    def test_anchor_keypoints(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['create_bbox', str(model_dir), 'video.mp4', '--anchor_keypoints', 'nose,tail']
+        )
+        assert args.anchor_keypoints == 'nose,tail'
+
+    def test_multiple_input_paths(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        video1 = tmp_path / 'video1.mp4'
+        video2 = tmp_path / 'video2.mp4'
+        args = parser.parse_args(
+            ['create_bbox', str(model_dir), str(video1), str(video2)]
+        )
+        assert args.input_path == [video1, video2]
+
+
+class TestHandle:
+    """Test the handle function."""
+
+    @pytest.fixture
+    def mock_model(self, tmp_path):
+        """Mock Model instance returned by Model.from_dir."""
+        model = MagicMock()
+        model.config.cfg.data.data_dir = str(tmp_path / 'data')
+        model.video_preds_dir.return_value = tmp_path / 'video_preds'
+        model.image_preds_dir.return_value = tmp_path / 'image_preds'
+        return model
+
+    def _make_args(
+        self,
+        tmp_path,
+        input_path,
+        crop_ratio=None,
+        crop_size=None,
+        anchor_keypoints='',
+    ):
+        return argparse.Namespace(
+            model_dir=tmp_path / 'model',
+            input_path=[input_path],
+            crop_ratio=crop_ratio,
+            crop_size=crop_size,
+            anchor_keypoints=anchor_keypoints,
+        )
+
+    def test_raises_when_both_crop_ratio_and_crop_size(self, tmp_path, mock_model):
+        """Raises ValueError when --crop_ratio and --crop_size are both provided."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=2.0, crop_size=100)
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            with pytest.raises(ValueError, match='mutually exclusive'):
+                handle(args)
+
+    def test_raises_when_crop_size_not_positive(self, tmp_path, mock_model):
+        """Raises ValueError when --crop_size is not a positive integer."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_size=0)
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            with pytest.raises(ValueError, match='positive integer'):
+                handle(args)
+
+    def test_raises_when_crop_ratio_not_greater_than_one(self, tmp_path, mock_model):
+        """Raises ValueError when --crop_ratio is <= 1."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=1.0)
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            with pytest.raises(ValueError, match='greater than 1'):
+                handle(args)
+
+    def test_default_crop_ratio_when_neither_given(self, tmp_path, mock_model):
+        """Defaults to crop_ratio=2.0 when neither flag is supplied."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_bbox') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        cfg = mock_gen.call_args.kwargs['detector_cfg']
+        assert cfg['crop_ratio'] == 2.0
+        assert 'crop_height' not in cfg
+        assert 'crop_width' not in cfg
+
+    def test_crop_size_sets_detector_cfg(self, tmp_path, mock_model):
+        """crop_height and crop_width are set from --crop_size; crop_ratio is absent."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_size=100)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_bbox') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        cfg = mock_gen.call_args.kwargs['detector_cfg']
+        assert cfg['crop_height'] == 100
+        assert cfg['crop_width'] == 100
+        assert 'crop_ratio' not in cfg
+
+    def test_crop_ratio_sets_detector_cfg(self, tmp_path, mock_model):
+        """crop_ratio is passed through to detector_cfg."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=3.5)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_bbox') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        cfg = mock_gen.call_args.kwargs['detector_cfg']
+        assert cfg['crop_ratio'] == 3.5
+
+    def test_csv_input_calls_generate_bbox(self, tmp_path, mock_model):
+        """CSV input triggers generate_bbox with the correct detector_cfg."""
+        args = self._make_args(tmp_path, tmp_path / 'labels.csv', crop_size=200)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_bbox') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        cfg = mock_gen.call_args.kwargs['detector_cfg']
+        assert cfg['crop_height'] == 200
+        assert cfg['crop_width'] == 200
+
+    def test_mp4_bbox_output_path(self, tmp_path, mock_model):
+        """MP4 input writes bbox to <video_preds_dir>/<stem>_bbox.csv."""
+        args = self._make_args(tmp_path, tmp_path / 'myvid.mp4')
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_bbox') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        output_path = mock_gen.call_args.kwargs['output_bbox_file']
+        assert output_path.name == 'myvid_bbox.csv'
+
+    def test_csv_bbox_output_path(self, tmp_path, mock_model):
+        """CSV input writes bbox to <image_preds_dir>/<csv_name>/bbox.csv."""
+        args = self._make_args(tmp_path, tmp_path / 'labels.csv')
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_bbox') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        output_path = mock_gen.call_args.kwargs['output_bbox_file']
+        assert output_path.name == 'bbox.csv'

--- a/tests/cli/test_create_bbox.py
+++ b/tests/cli/test_create_bbox.py
@@ -204,3 +204,34 @@ class TestHandle:
             handle(args)
         output_path = mock_gen.call_args.kwargs['output_bbox_file']
         assert output_path.name == 'bbox.csv'
+
+    def test_directory_input_expands_to_mp4s(self, tmp_path, mock_model):
+        """A directory input is expanded to the *.mp4 files it contains."""
+        video_dir = tmp_path / 'videos'
+        video_dir.mkdir()
+        (video_dir / 'a.mp4').touch()
+        (video_dir / 'b.mp4').touch()
+        (video_dir / 'notes.txt').touch()
+        args = self._make_args(tmp_path, video_dir)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_bbox') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        assert mock_gen.call_count == 2
+        called_stems = {c.kwargs['output_bbox_file'].stem for c in mock_gen.call_args_list}
+        assert called_stems == {'a_bbox', 'b_bbox'}
+
+    def test_empty_directory_calls_no_generate_bbox(self, tmp_path, mock_model):
+        """An empty directory (no mp4s) results in zero generate_bbox calls."""
+        video_dir = tmp_path / 'empty'
+        video_dir.mkdir()
+        args = self._make_args(tmp_path, video_dir)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.generate_bbox') as mock_gen,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        mock_gen.assert_not_called()

--- a/tests/cli/test_crop.py
+++ b/tests/cli/test_crop.py
@@ -132,3 +132,40 @@ class TestHandle:
             MockModel.from_dir.return_value = mock_model
             with pytest.raises(NotImplementedError):
                 handle(args)
+
+    def test_directory_input_expands_to_mp4s(self, tmp_path, mock_model):
+        """A directory input is expanded to the *.mp4 files it contains."""
+        video_dir = tmp_path / 'videos'
+        video_dir.mkdir()
+        (video_dir / 'a.mp4').touch()
+        (video_dir / 'b.mp4').touch()
+        (video_dir / 'notes.txt').touch()
+        args = argparse.Namespace(
+            model_dir=tmp_path / 'model',
+            input_path=[video_dir],
+            bbox_dir=None,
+        )
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.crop_video') as mock_crop,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        assert mock_crop.call_count == 2
+
+    def test_empty_directory_calls_no_crop_video(self, tmp_path, mock_model):
+        """An empty directory (no mp4s) results in zero crop_video calls."""
+        video_dir = tmp_path / 'empty'
+        video_dir.mkdir()
+        args = argparse.Namespace(
+            model_dir=tmp_path / 'model',
+            input_path=[video_dir],
+            bbox_dir=None,
+        )
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.utils.cropzoom.crop_video') as mock_crop,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        mock_crop.assert_not_called()

--- a/tests/cli/test_crop.py
+++ b/tests/cli/test_crop.py
@@ -30,9 +30,7 @@ class TestCropParser:
         args = parser.parse_args(['crop', str(model_dir), str(video)])
         assert args.model_dir == model_dir
         assert args.input_path == [video]
-        assert args.crop_ratio is None
-        assert args.crop_size is None
-        assert args.anchor_keypoints == ''
+        assert args.bbox_dir is None
 
     def test_missing_model_dir_exits(self, parser, tmp_path):
         with pytest.raises(SystemExit):
@@ -40,26 +38,14 @@ class TestCropParser:
                 ['crop', str(tmp_path / 'missing'), str(tmp_path / 'video.mp4')]
             )
 
-    def test_crop_ratio(self, parser, tmp_path):
+    def test_bbox_dir(self, parser, tmp_path):
         model_dir = tmp_path / 'model'
         model_dir.mkdir()
-        args = parser.parse_args(['crop', str(model_dir), 'video.mp4', '--crop_ratio', '3.5'])
-        assert args.crop_ratio == 3.5
-
-    def test_anchor_keypoints(self, parser, tmp_path):
-        model_dir = tmp_path / 'model'
-        model_dir.mkdir()
+        bbox_dir = tmp_path / 'bboxes'
         args = parser.parse_args(
-            ['crop', str(model_dir), 'video.mp4', '--anchor_keypoints', 'nose,tail']
+            ['crop', str(model_dir), 'video.mp4', '--bbox_dir', str(bbox_dir)]
         )
-        assert args.anchor_keypoints == 'nose,tail'
-
-    def test_crop_size(self, parser, tmp_path):
-        model_dir = tmp_path / 'model'
-        model_dir.mkdir()
-        args = parser.parse_args(['crop', str(model_dir), 'video.mp4', '--crop_size', '100'])
-        assert args.crop_size == 100
-        assert args.crop_ratio is None
+        assert args.bbox_dir == bbox_dir
 
     def test_multiple_input_paths(self, parser, tmp_path):
         model_dir = tmp_path / 'model'
@@ -80,97 +66,69 @@ class TestHandle:
         model.config.cfg.data.data_dir = str(tmp_path / 'data')
         return model
 
-    def _make_args(
-        self,
-        tmp_path,
-        input_path,
-        crop_ratio=None,
-        crop_size=None,
-        anchor_keypoints='',
-    ):
+    def _make_args(self, tmp_path, input_path, bbox_dir=None):
         return argparse.Namespace(
             model_dir=tmp_path / 'model',
             input_path=[input_path],
-            crop_ratio=crop_ratio,
-            crop_size=crop_size,
-            anchor_keypoints=anchor_keypoints,
+            bbox_dir=bbox_dir,
         )
 
-    def test_raises_when_both_crop_ratio_and_crop_size(self, tmp_path, mock_model):
-        """Raises ValueError when --crop_ratio and --crop_size are both provided."""
-        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=2.0, crop_size=100)
-        with patch('lightning_pose.api.Model') as MockModel:
-            MockModel.from_dir.return_value = mock_model
-            with pytest.raises(ValueError, match='mutually exclusive'):
-                handle(args)
-
-    def test_raises_when_crop_size_not_positive(self, tmp_path, mock_model):
-        """Raises ValueError when --crop_size is not a positive integer."""
-        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_size=0)
-        with patch('lightning_pose.api.Model') as MockModel:
-            MockModel.from_dir.return_value = mock_model
-            with pytest.raises(ValueError, match='positive integer'):
-                handle(args)
-
-    def test_raises_when_crop_ratio_not_greater_than_one(self, tmp_path, mock_model):
-        """Raises ValueError when --crop_ratio is <= 1."""
-        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=1.0)
-        with patch('lightning_pose.api.Model') as MockModel:
-            MockModel.from_dir.return_value = mock_model
-            with pytest.raises(ValueError, match='greater than 1'):
-                handle(args)
-
-    def test_default_crop_ratio_when_neither_given(self, tmp_path, mock_model):
-        """Defaults to crop_ratio=2.0 when neither flag is supplied."""
+    def test_mp4_calls_crop_video(self, tmp_path, mock_model):
+        """MP4 input triggers crop_video with default bbox path."""
         args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
         with (
             patch('lightning_pose.api.Model') as MockModel,
-            patch('lightning_pose.utils.cropzoom.generate_cropped_video') as mock_gen,
+            patch('lightning_pose.utils.cropzoom.crop_video') as mock_crop,
         ):
             MockModel.from_dir.return_value = mock_model
             handle(args)
-        cfg = mock_gen.call_args.kwargs['detector_cfg']
-        assert cfg['crop_ratio'] == 2.0
-        assert 'crop_height' not in cfg
-        assert 'crop_width' not in cfg
+        mock_crop.assert_called_once()
+        call_kwargs = mock_crop.call_args.kwargs
+        assert call_kwargs['input_video_file'] == tmp_path / 'vid.mp4'
 
-    def test_crop_size_sets_detector_cfg(self, tmp_path, mock_model):
-        """crop_height and crop_width are set from --crop_size; crop_ratio is absent."""
-        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_size=100)
+    def test_mp4_with_bbox_dir(self, tmp_path, mock_model):
+        """MP4 input with --bbox_dir uses the provided directory for bbox lookup."""
+        bbox_dir = tmp_path / 'bboxes'
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', bbox_dir=bbox_dir)
         with (
             patch('lightning_pose.api.Model') as MockModel,
-            patch('lightning_pose.utils.cropzoom.generate_cropped_video') as mock_gen,
+            patch('lightning_pose.utils.cropzoom.crop_video') as mock_crop,
         ):
             MockModel.from_dir.return_value = mock_model
             handle(args)
-        cfg = mock_gen.call_args.kwargs['detector_cfg']
-        assert cfg['crop_height'] == 100
-        assert cfg['crop_width'] == 100
-        assert 'crop_ratio' not in cfg
+        call_kwargs = mock_crop.call_args.kwargs
+        assert call_kwargs['input_bbox_file'] == bbox_dir / 'vid_bbox.csv'
 
-    def test_crop_ratio_sets_detector_cfg(self, tmp_path, mock_model):
-        """crop_ratio is passed through to detector_cfg."""
-        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', crop_ratio=3.5)
+    def test_csv_calls_crop_labeled_frames(self, tmp_path, mock_model):
+        """CSV input triggers crop_labeled_frames."""
+        args = self._make_args(tmp_path, tmp_path / 'labels.csv')
         with (
             patch('lightning_pose.api.Model') as MockModel,
-            patch('lightning_pose.utils.cropzoom.generate_cropped_video') as mock_gen,
+            patch('lightning_pose.utils.cropzoom.crop_labeled_frames') as mock_crop,
         ):
             MockModel.from_dir.return_value = mock_model
             handle(args)
-        cfg = mock_gen.call_args.kwargs['detector_cfg']
-        assert cfg['crop_ratio'] == 3.5
-        assert 'crop_height' not in cfg
-        assert 'crop_width' not in cfg
+        mock_crop.assert_called_once()
 
-    def test_csv_input_calls_generate_cropped_labeled_frames(self, tmp_path, mock_model):
-        """CSV input triggers generate_cropped_labeled_frames with correct detector_cfg."""
-        args = self._make_args(tmp_path, tmp_path / 'labels.csv', crop_size=200)
+    def test_csv_with_bbox_dir(self, tmp_path, mock_model):
+        """CSV input with --bbox_dir looks for bbox.csv inside that directory."""
+        bbox_dir = tmp_path / 'bboxes'
+        args = self._make_args(tmp_path, tmp_path / 'labels.csv', bbox_dir=bbox_dir)
         with (
             patch('lightning_pose.api.Model') as MockModel,
-            patch('lightning_pose.utils.cropzoom.generate_cropped_labeled_frames') as mock_gen,
+            patch('lightning_pose.utils.cropzoom.crop_labeled_frames') as mock_crop,
         ):
             MockModel.from_dir.return_value = mock_model
             handle(args)
-        cfg = mock_gen.call_args.kwargs['detector_cfg']
-        assert cfg['crop_height'] == 200
-        assert cfg['crop_width'] == 200
+        call_kwargs = mock_crop.call_args.kwargs
+        assert call_kwargs['input_bbox_file'] == bbox_dir / 'bbox.csv'
+
+    def test_unsupported_extension_raises(self, tmp_path, mock_model):
+        """Unsupported file extension raises NotImplementedError."""
+        args = self._make_args(tmp_path, tmp_path / 'file.avi')
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+        ):
+            MockModel.from_dir.return_value = mock_model
+            with pytest.raises(NotImplementedError):
+                handle(args)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -17,7 +17,7 @@ class TestBuildParser:
             a for a in parser._actions if hasattr(a, '_name_parser_map')
         )
         assert set(subparsers_action._name_parser_map.keys()) == {  # type: ignore[attr-defined]
-            "train", "predict", "crop", "remap", "run_app",
+            'train', 'predict', 'create_bbox', 'smooth_bbox', 'crop', 'remap', 'run_app',
         }
 
     def test_main_no_args_exits(self):

--- a/tests/cli/test_smooth_bbox.py
+++ b/tests/cli/test_smooth_bbox.py
@@ -1,0 +1,77 @@
+"""Test the smooth_bbox CLI command argument parsing."""
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from lightning_pose.cli.commands.smooth_bbox import get_parser, handle
+
+
+class TestGetParser:
+    """Test the get_parser function."""
+
+    def test_returns_argument_parser(self):
+        """Returns an ArgumentParser instance."""
+        assert isinstance(get_parser(), argparse.ArgumentParser)
+
+    def test_prog_is_litpose_smooth_bbox(self):
+        """Returned parser has prog set to 'litpose smooth_bbox'."""
+        assert get_parser().prog == 'litpose smooth_bbox'
+
+
+class TestSmoothBboxParser:
+    """Test the smooth_bbox subcommand argument parsing."""
+
+    def test_valid_args(self, parser, tmp_path):
+        bbox_dir = tmp_path / 'bboxes'
+        output_dir = tmp_path / 'smooth'
+        args = parser.parse_args([
+            'smooth_bbox', str(bbox_dir), '--output_dir', str(output_dir),
+        ])
+        assert args.bbox_dir == bbox_dir
+        assert args.output_dir == output_dir
+        assert args.method == 'median'
+        assert args.window == 5
+
+    def test_output_dir_required(self, parser, tmp_path):
+        """Exits when --output_dir is not provided."""
+        with pytest.raises(SystemExit):
+            parser.parse_args(['smooth_bbox', str(tmp_path / 'bboxes')])
+
+    def test_method_arg(self, parser, tmp_path):
+        args = parser.parse_args([
+            'smooth_bbox', str(tmp_path / 'bboxes'),
+            '--output_dir', str(tmp_path / 'out'),
+            '--method', 'median',
+        ])
+        assert args.method == 'median'
+
+    def test_window_arg(self, parser, tmp_path):
+        args = parser.parse_args([
+            'smooth_bbox', str(tmp_path / 'bboxes'),
+            '--output_dir', str(tmp_path / 'out'),
+            '--window', '11',
+        ])
+        assert args.window == 11
+
+
+class TestHandle:
+    """Test the handle function."""
+
+    def test_delegates_to_smooth_bbox(self, tmp_path):
+        """handle calls smooth_bbox with the parsed arguments."""
+        args = argparse.Namespace(
+            bbox_dir=tmp_path / 'raw',
+            output_dir=tmp_path / 'smooth',
+            method='median',
+            window=7,
+        )
+        with patch('lightning_pose.utils.cropzoom.smooth_bbox') as mock_smooth:
+            handle(args)
+        mock_smooth.assert_called_once_with(
+            input_bbox_dir=tmp_path / 'raw',
+            output_dir=tmp_path / 'smooth',
+            method='median',
+            window=7,
+        )

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -1,5 +1,6 @@
 import copy
 import filecmp
+import json
 import shutil
 from pathlib import Path
 
@@ -12,8 +13,10 @@ from PIL import Image
 from lightning_pose.utils.cropzoom import (
     _compute_bbox_df,
     _crop_image,
-    generate_cropped_labeled_frames,
-    generate_cropped_video,
+    crop_labeled_frames,
+    crop_video,
+    generate_bbox,
+    smooth_bbox,
 )
 
 from ..fetch_test_data import fetch_test_data_if_needed
@@ -158,8 +161,8 @@ def compare_directories(dir1: Path, dir2: Path) -> int | dict:
     return results
 
 
-class TestGenerateCroppedLabeledFrames:
-    """Test the generate_cropped_labeled_frames function."""
+class TestGenerateBbox:
+    """Test the generate_bbox function."""
 
     @pytest.fixture
     def setup(self, tmp_path, request):
@@ -171,20 +174,90 @@ class TestGenerateCroppedLabeledFrames:
         )
         return tmp_model_dir, request.path.parent / 'test_cropzoom_data'
 
-    def test_generate_cropped_labeled_frames_crop_ratio(self, setup):
+    def test_generate_bbox_crop_ratio(self, setup):
+        """generate_bbox with crop_ratio writes a valid bbox CSV."""
+        tmp_model_dir, _ = setup
+        detector_cfg = OmegaConf.create({
+            'crop_ratio': 1.5,
+            'anchor_keypoints': ['A_head', 'D_tailtip'],
+        })
+        output_bbox_file = tmp_model_dir / 'bbox.csv'
+        generate_bbox(
+            input_preds_file=tmp_model_dir / 'predictions.csv',
+            detector_cfg=detector_cfg,
+            output_bbox_file=output_bbox_file,
+        )
+        assert output_bbox_file.exists()
+        bbox_df = pd.read_csv(output_bbox_file, index_col=0)
+        assert list(bbox_df.columns) == ['x', 'y', 'h', 'w']
+
+    def test_generate_bbox_crop_size(self, setup):
+        """generate_bbox with crop_size produces constant h/w values."""
+        tmp_model_dir, _ = setup
+        crop_size = 100
+        detector_cfg = OmegaConf.create({
+            'crop_height': crop_size,
+            'crop_width': crop_size,
+            'anchor_keypoints': ['A_head', 'D_tailtip'],
+        })
+        output_bbox_file = tmp_model_dir / 'bbox.csv'
+        generate_bbox(
+            input_preds_file=tmp_model_dir / 'predictions.csv',
+            detector_cfg=detector_cfg,
+            output_bbox_file=output_bbox_file,
+        )
+        bbox_df = pd.read_csv(output_bbox_file, index_col=0)
+        assert (bbox_df['h'] == crop_size).all()
+        assert (bbox_df['w'] == crop_size).all()
+
+    def test_generate_bbox_creates_parent_dirs(self, setup):
+        """generate_bbox creates missing parent directories."""
+        tmp_model_dir, _ = setup
+        detector_cfg = OmegaConf.create({
+            'crop_ratio': 2.0,
+            'anchor_keypoints': [],
+        })
+        output_bbox_file = tmp_model_dir / 'new_dir' / 'bbox.csv'
+        generate_bbox(
+            input_preds_file=tmp_model_dir / 'predictions.csv',
+            detector_cfg=detector_cfg,
+            output_bbox_file=output_bbox_file,
+        )
+        assert output_bbox_file.exists()
+
+
+class TestCropLabeledFrames:
+    """Test the crop_labeled_frames function."""
+
+    @pytest.fixture
+    def setup(self, tmp_path, request):
+        fetch_test_data_if_needed(request.path.parent, 'test_cropzoom_data')
+        tmp_model_dir = tmp_path / 'test_model'
+        shutil.copytree(
+            request.path.parent / 'test_cropzoom_data' / 'test_model_output',
+            tmp_model_dir,
+        )
+        return tmp_model_dir, request.path.parent / 'test_cropzoom_data'
+
+    def test_crop_labeled_frames_crop_ratio(self, setup):
+        """crop_labeled_frames output matches expected directory (crop_ratio mode)."""
         tmp_model_dir, test_data_dir = setup
         root_dir = test_data_dir / 'test_data'
         detector_cfg = OmegaConf.create({
             'crop_ratio': 1.5,
             'anchor_keypoints': ['A_head', 'D_tailtip'],
         })
-        generate_cropped_labeled_frames(
-            input_data_dir=root_dir,
-            input_csv_file=root_dir / 'CollectedData.csv',
+        bbox_file = tmp_model_dir / 'cropped_images' / 'bbox.csv'
+        generate_bbox(
             input_preds_file=tmp_model_dir / 'predictions.csv',
             detector_cfg=detector_cfg,
+            output_bbox_file=bbox_file,
+        )
+        crop_labeled_frames(
+            input_data_dir=root_dir,
+            input_csv_file=root_dir / 'CollectedData.csv',
+            input_bbox_file=bbox_file,
             output_data_dir=tmp_model_dir / 'cropped_images',
-            output_bbox_file=tmp_model_dir / 'cropped_images' / 'bbox.csv',
             output_csv_file=tmp_model_dir / 'cropped_images' / 'cropped_labels.csv',
         )
         comparison = compare_directories(
@@ -193,7 +266,8 @@ class TestGenerateCroppedLabeledFrames:
         )
         assert comparison == 24  # 24 files compared successfully
 
-    def test_generate_cropped_labeled_frames_crop_size(self, setup):
+    def test_crop_labeled_frames_crop_size(self, setup):
+        """crop_labeled_frames with crop_size: h/w in bbox match requested size."""
         tmp_model_dir, test_data_dir = setup
         root_dir = test_data_dir / 'test_data'
         crop_size = 100
@@ -203,13 +277,16 @@ class TestGenerateCroppedLabeledFrames:
             'anchor_keypoints': ['A_head', 'D_tailtip'],
         })
         bbox_file = tmp_model_dir / 'cropped_images' / 'bbox.csv'
-        generate_cropped_labeled_frames(
-            input_data_dir=root_dir,
-            input_csv_file=root_dir / 'CollectedData.csv',
+        generate_bbox(
             input_preds_file=tmp_model_dir / 'predictions.csv',
             detector_cfg=detector_cfg,
-            output_data_dir=tmp_model_dir / 'cropped_images',
             output_bbox_file=bbox_file,
+        )
+        crop_labeled_frames(
+            input_data_dir=root_dir,
+            input_csv_file=root_dir / 'CollectedData.csv',
+            input_bbox_file=bbox_file,
+            output_data_dir=tmp_model_dir / 'cropped_images',
             output_csv_file=tmp_model_dir / 'cropped_images' / 'cropped_labels.csv',
         )
         bbox_df = pd.read_csv(bbox_file, index_col=0)
@@ -217,8 +294,8 @@ class TestGenerateCroppedLabeledFrames:
         assert (bbox_df['w'] == crop_size).all()
 
 
-class TestGenerateCroppedVideo:
-    """Test the generate_cropped_video function."""
+class TestCropVideo:
+    """Test the crop_video function."""
 
     @pytest.fixture
     def setup(self, tmp_path, request):
@@ -231,7 +308,8 @@ class TestGenerateCroppedVideo:
         video_dir = request.path.parent / 'test_cropzoom_data' / 'test_data' / 'videos'
         return tmp_model_dir, request.path.parent / 'test_cropzoom_data', video_dir
 
-    def test_generate_cropped_video_crop_ratio(self, setup):
+    def test_crop_video_crop_ratio(self, setup):
+        """crop_video bbox CSVs match expected output (crop_ratio mode)."""
         tmp_model_dir, test_data_dir, video_dir = setup
         detector_cfg = OmegaConf.create({
             'crop_ratio': 1.5,
@@ -239,20 +317,24 @@ class TestGenerateCroppedVideo:
         })
         for video_path in video_dir.iterdir():
             bbox_file = tmp_model_dir / 'cropped_videos' / (video_path.stem + '_bbox.csv')
-            generate_cropped_video(
-                input_video_file=video_path,
+            generate_bbox(
                 input_preds_file=tmp_model_dir / 'video_preds' / (video_path.stem + '.csv'),
                 detector_cfg=detector_cfg,
                 output_bbox_file=bbox_file,
+            )
+            crop_video(
+                input_video_file=video_path,
+                input_bbox_file=bbox_file,
                 output_file=tmp_model_dir / 'cropped_videos' / video_path.name,
             )
         comparison = compare_directories(
             tmp_model_dir / 'cropped_videos',
             test_data_dir / 'expected_model_output' / 'cropped_videos',
         )
-        assert comparison == 2  # 2 files compared successfully (mp4s skipped)
+        assert comparison == 2  # 2 bbox CSVs compared successfully (mp4s skipped)
 
-    def test_generate_cropped_video_crop_size(self, setup):
+    def test_crop_video_crop_size(self, setup):
+        """crop_video with crop_size: h/w in bbox match requested size."""
         tmp_model_dir, test_data_dir, video_dir = setup
         crop_size = 100
         detector_cfg = OmegaConf.create({
@@ -262,13 +344,79 @@ class TestGenerateCroppedVideo:
         })
         for video_path in video_dir.iterdir():
             bbox_file = tmp_model_dir / 'cropped_videos' / (video_path.stem + '_bbox.csv')
-            generate_cropped_video(
-                input_video_file=video_path,
+            generate_bbox(
                 input_preds_file=tmp_model_dir / 'video_preds' / (video_path.stem + '.csv'),
                 detector_cfg=detector_cfg,
                 output_bbox_file=bbox_file,
+            )
+            crop_video(
+                input_video_file=video_path,
+                input_bbox_file=bbox_file,
                 output_file=tmp_model_dir / 'cropped_videos' / video_path.name,
             )
             bbox_df = pd.read_csv(bbox_file, index_col=0)
             assert (bbox_df['h'] == crop_size).all()
             assert (bbox_df['w'] == crop_size).all()
+
+
+class TestSmoothBbox:
+    """Test the smooth_bbox function."""
+
+    def _make_bbox_file(self, path: Path, n_frames: int = 10) -> None:
+        """Write a simple bbox CSV at ``path``."""
+        pd.DataFrame({
+            'x': range(n_frames),
+            'y': range(n_frames),
+            'h': [50] * n_frames,
+            'w': [50] * n_frames,
+        }).to_csv(path)
+
+    def test_creates_output_files(self, tmp_path):
+        """Smoothed bbox files are written for every input file."""
+        input_dir = tmp_path / 'raw'
+        input_dir.mkdir()
+        for i in range(3):
+            self._make_bbox_file(input_dir / f'vid{i}_bbox.csv')
+        output_dir = tmp_path / 'smooth'
+        smooth_bbox(input_dir, output_dir, method='median', window=3)
+        for i in range(3):
+            assert (output_dir / f'vid{i}_bbox.csv').exists()
+
+    def test_writes_metadata(self, tmp_path):
+        """metadata.json records method, window, and source."""
+        input_dir = tmp_path / 'raw'
+        input_dir.mkdir()
+        self._make_bbox_file(input_dir / 'vid_bbox.csv')
+        output_dir = tmp_path / 'smooth'
+        smooth_bbox(input_dir, output_dir, method='median', window=7)
+        meta = json.loads((output_dir / 'metadata.json').read_text())
+        assert meta['method'] == 'median'
+        assert meta['window'] == 7
+        assert str(input_dir.resolve()) == meta['source']
+
+    def test_output_has_integer_values(self, tmp_path):
+        """Smoothed values are cast to integers."""
+        input_dir = tmp_path / 'raw'
+        input_dir.mkdir()
+        self._make_bbox_file(input_dir / 'vid_bbox.csv', n_frames=9)
+        output_dir = tmp_path / 'smooth'
+        smooth_bbox(input_dir, output_dir, method='median', window=3)
+        result = pd.read_csv(output_dir / 'vid_bbox.csv', index_col=0)
+        for col in result.columns:
+            assert result[col].dtype == int
+
+    def test_raises_on_unknown_method(self, tmp_path):
+        """Raises ValueError for an unsupported smoothing method."""
+        input_dir = tmp_path / 'raw'
+        input_dir.mkdir()
+        output_dir = tmp_path / 'smooth'
+        with pytest.raises(ValueError, match='unsupported method'):
+            smooth_bbox(input_dir, output_dir, method='foo', window=5)
+
+    def test_raises_when_no_bbox_files(self, tmp_path):
+        """Raises ValueError when no *_bbox.csv files are found."""
+        input_dir = tmp_path / 'empty'
+        input_dir.mkdir()
+        output_dir = tmp_path / 'smooth'
+        with pytest.raises(ValueError, match=r'no \*_bbox\.csv files found'):
+            smooth_bbox(input_dir, output_dir, method='median', window=5)


### PR DESCRIPTION
In the cropzoom pipeline, the `litpose  crop` command currently performs two separate actions: creating bboxes, and cropping images/videos/labels. This PR splits this command into two, with an additional optional command for smoothing the bboxes:

```
litpose predict ...  # with detector
litpose create_bbox ...
litpose smooth_bbox <bbox_path> ...
litpose crop <bbox_path> ...
```

The initial implementation just uses a median filter with configurable window length, but sets up the code to expand to more smoother types in the future.

closes #415 