### PR TITLE
litpose predict on images with bbox

### DIFF
--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -566,22 +566,22 @@ class Model:
         data_dir: str | Path | None = None,
         compute_metrics: bool = True,
         add_train_val_test_set: bool = False,
+        bbox_file: str | Path | None = None,
     ) -> PredictionResult:
         """Predicts on a labeled dataset and computes error/loss metrics if applicable.
 
         Args:
-            csv_file (str | Path): Path to the CSV file of images, keypoint locations.
-            data_dir (str | Path, optional): Root path for relative paths in the CSV file.
-                Defaults to the data_dir originally used when training.
-            compute_metrics (bool, optional): Whether to compute pixel error and loss metrics on
-                predictions.
-            generate_labeled_images (bool, optional): Whether to save labeled images.
-                Defaults to False.
-            output_dir (str | Path, optional): The directory to save outputs to.
-                Defaults to `{model_dir}/image_preds/{csv_file_name}`.
-                If set to None, outputs are not saved.
-            add_train_val_test_set (bool): When predicting on training dataset, set to true to add
-                the `set` column to the prediction output.
+            csv_file: path to the CSV file of images and keypoint locations.
+            data_dir: root path for relative image paths in the CSV file. Defaults to the
+                data_dir used during training.
+            compute_metrics: whether to compute pixel error and loss metrics on predictions.
+            add_train_val_test_set: set to True when predicting on the training dataset to
+                add a ``set`` column to the output.
+            bbox_file: optional path to a bbox CSV produced by ``litpose create_bbox`` (or
+                any compatible source). When provided, each frame is cropped to its bounding
+                box before being passed to the model, and predictions are returned in the
+                original (un-cropped) coordinate space.
+
         Returns:
             PredictionResult: A PredictionResult object containing the predictions and metrics.
 
@@ -613,6 +613,7 @@ class Model:
             "data": {
                 "data_dir": str(data_dir),
                 "csv_file": str(csv_file),
+                "bbox_file": str(bbox_file) if bbox_file is not None else None,
             }
         }
 

--- a/lightning_pose/cli/commands/predict.py
+++ b/lightning_pose/cli/commands/predict.py
@@ -75,6 +75,19 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
         help="overwrite videos that already have prediction files",
     )
 
+    predict_parser.add_argument(
+        "--bbox_dir",
+        type=Path,
+        default=None,
+        help=(
+            "directory containing bbox CSV files produced by ``litpose create_bbox`` or a "
+            "compatible external source. For CSV inputs, looks for ``bbox.csv`` inside this "
+            "directory. When provided, each frame is cropped to its bounding box before "
+            "being passed to the model, and predictions are saved in the original coordinate "
+            "space. (Video support coming soon.)"
+        ),
+    )
+
     post_prediction_args = predict_parser.add_argument_group("post-prediction")
     post_prediction_args.add_argument(
         "--skip_viz",
@@ -113,7 +126,9 @@ def handle(args: argparse.Namespace) -> None:
     else:
         for p in input_paths:
             _predict_multi_type(
-                model, p, args.skip_viz, not args.overwrite, progress_file=args.progress_file
+                model, p, args.skip_viz, not args.overwrite,
+                progress_file=args.progress_file,
+                bbox_dir=args.bbox_dir,
             )
 
 
@@ -123,6 +138,7 @@ def _predict_multi_type(
     skip_viz: bool,
     skip_existing: bool,
     progress_file: Path | None = None,
+    bbox_dir: Path | None = None,
 ) -> None:
     """Run prediction on a single path, dispatching to video, CSV, or directory handling.
 
@@ -132,6 +148,9 @@ def _predict_multi_type(
         skip_viz: if True, skip generating labeled visualization outputs.
         skip_existing: if True, skip predictions for which an output CSV already exists.
         progress_file: optional path to write prediction progress as JSON.
+        bbox_dir: optional directory containing bbox CSV files. When provided and the input
+            is a CSV, ``bbox.csv`` inside this directory is used to crop frames before
+            passing them to the model.
     """
     if path.is_dir():
         image_files = [p for p in path.iterdir() if p.is_file() and p.suffix in [".png", ".jpg"]]
@@ -142,7 +161,11 @@ def _predict_multi_type(
 
         print(f"Processing directory {path}")
         for p in video_files:
-            _predict_multi_type(model, p, skip_viz, skip_existing, progress_file=progress_file)
+            _predict_multi_type(
+                model, p, skip_viz, skip_existing,
+                progress_file=progress_file,
+                bbox_dir=bbox_dir,
+            )
 
     elif path.suffix == ".mp4":
         # Check if prediction file already exists
@@ -165,6 +188,7 @@ def _predict_multi_type(
 
         model.predict_on_label_csv(
             csv_file=path,
+            bbox_file=bbox_dir / "bbox.csv" if bbox_dir is not None else None,
         )
     elif path.suffix in [".png", ".jpg"]:
         raise NotImplementedError("Not yet implemented: predicting on image files.")

--- a/lightning_pose/data/factory.py
+++ b/lightning_pose/data/factory.py
@@ -100,6 +100,7 @@ def get_dataset(
                 image_resize_width=cfg.data.image_resize_dims.width,
                 imgaug_transform=imgaug_transform,
                 do_context=False,  # no context for regression models
+                bbox_path=cfg.data.get('bbox_file', None),
             )
     elif cfg.model.model_type.find('heatmap') > -1:
         if cfg.data.get('view_names', None) and len(cfg.data.view_names) > 1:
@@ -141,6 +142,7 @@ def get_dataset(
                 downsample_factor=cfg.data.get('downsample_factor', 2),
                 do_context=cfg.model.model_type == 'heatmap_mhcrnn',  # context only for mhcrnn
                 uniform_heatmaps=cfg.training.get('uniform_heatmaps_for_nan_keypoints', False),
+                bbox_path=cfg.data.get('bbox_file', None),
             )
 
     else:

--- a/tests/cli/test_predict.py
+++ b/tests/cli/test_predict.py
@@ -1,10 +1,11 @@
 """Test the predict CLI command argument parsing."""
 
 import argparse
+from unittest.mock import MagicMock
 
 import pytest
 
-from lightning_pose.cli.commands.predict import get_parser
+from lightning_pose.cli.commands.predict import _predict_multi_type, get_parser
 
 
 class TestGetParser:
@@ -64,3 +65,63 @@ class TestPredictParser:
         override = 'dali.base.predict.batch_size=4'
         args = parser.parse_args(['predict', str(model_dir), 'video.mp4', '--overrides', override])
         assert args.overrides == [override]
+
+    def test_bbox_dir_default_is_none(self, parser, tmp_path):
+        """bbox_dir defaults to None when not provided."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['predict', str(model_dir), 'video.mp4'])
+        assert args.bbox_dir is None
+
+    def test_bbox_dir_arg(self, parser, tmp_path):
+        """--bbox_dir is parsed as a Path."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        bbox_dir = tmp_path / 'bboxes'
+        args = parser.parse_args([
+            'predict', str(model_dir), 'labels.csv', '--bbox_dir', str(bbox_dir),
+        ])
+        assert args.bbox_dir == bbox_dir
+
+
+class TestPredictMultiType:
+    """Test _predict_multi_type bbox threading."""
+
+    @pytest.fixture
+    def mock_model(self, tmp_path):
+        """Mock Model with path methods returning real paths."""
+        model = MagicMock()
+        model.image_preds_dir.return_value = tmp_path / 'image_preds'
+        model.video_preds_dir.return_value = tmp_path / 'video_preds'
+        return model
+
+    def test_csv_passes_bbox_file_when_bbox_dir_given(self, tmp_path, mock_model):
+        """CSV input with bbox_dir passes <bbox_dir>/bbox.csv to predict_on_label_csv."""
+        bbox_dir = tmp_path / 'bboxes'
+        csv_path = tmp_path / 'labels.csv'
+        _predict_multi_type(
+            mock_model, csv_path, skip_viz=True, skip_existing=False, bbox_dir=bbox_dir,
+        )
+        mock_model.predict_on_label_csv.assert_called_once()
+        call_kwargs = mock_model.predict_on_label_csv.call_args.kwargs
+        assert call_kwargs['bbox_file'] == bbox_dir / 'bbox.csv'
+
+    def test_csv_passes_none_bbox_file_when_no_bbox_dir(self, tmp_path, mock_model):
+        """CSV input without bbox_dir passes bbox_file=None to predict_on_label_csv."""
+        csv_path = tmp_path / 'labels.csv'
+        _predict_multi_type(
+            mock_model, csv_path, skip_viz=True, skip_existing=False, bbox_dir=None,
+        )
+        call_kwargs = mock_model.predict_on_label_csv.call_args.kwargs
+        assert call_kwargs['bbox_file'] is None
+
+    def test_mp4_does_not_use_bbox_dir(self, tmp_path, mock_model):
+        """MP4 input ignores bbox_dir (video sub-issue not yet implemented)."""
+        bbox_dir = tmp_path / 'bboxes'
+        video_path = tmp_path / 'vid.mp4'
+        _predict_multi_type(
+            mock_model, video_path, skip_viz=True, skip_existing=False, bbox_dir=bbox_dir,
+        )
+        mock_model.predict_on_video_file.assert_called_once()
+        call_kwargs = mock_model.predict_on_video_file.call_args.kwargs
+        assert 'bbox_file' not in call_kwargs

--- a/tests/cli/test_predict.py
+++ b/tests/cli/test_predict.py
@@ -1,11 +1,11 @@
 """Test the predict CLI command argument parsing."""
 
 import argparse
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from lightning_pose.cli.commands.predict import _predict_multi_type, get_parser
+from lightning_pose.cli.commands.predict import _predict_multi_type, get_parser, handle
 
 
 class TestGetParser:
@@ -125,3 +125,63 @@ class TestPredictMultiType:
         mock_model.predict_on_video_file.assert_called_once()
         call_kwargs = mock_model.predict_on_video_file.call_args.kwargs
         assert 'bbox_file' not in call_kwargs
+
+    def test_directory_input_with_bbox_dir_recurses_into_mp4s(self, tmp_path, mock_model):
+        """A directory input with bbox_dir passes through to each recursive mp4 call."""
+        video_dir = tmp_path / 'videos'
+        video_dir.mkdir()
+        (video_dir / 'a.mp4').touch()
+        bbox_dir = tmp_path / 'bboxes'
+        _predict_multi_type(
+            mock_model, video_dir, skip_viz=True, skip_existing=False, bbox_dir=bbox_dir,
+        )
+        mock_model.predict_on_video_file.assert_called_once()
+
+
+class TestHandle:
+    """Test the handle function."""
+
+    @pytest.fixture
+    def mock_model(self):
+        """Mock Model returned by Model.from_dir2."""
+        model = MagicMock()
+        model.config.is_multi_view.return_value = False
+        return model
+
+    def _make_args(self, tmp_path, video, bbox_dir=None):
+        return argparse.Namespace(
+            model_dir=tmp_path / 'model',
+            input_path=[video],
+            skip_viz=False,
+            overwrite=False,
+            overrides=None,
+            progress_file=None,
+            bbox_dir=bbox_dir,
+        )
+
+    def test_handle_threads_bbox_dir_to_predict_multi_type(self, tmp_path, mock_model):
+        """handle() forwards args.bbox_dir to _predict_multi_type."""
+        bbox_dir = tmp_path / 'bboxes'
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', bbox_dir=bbox_dir)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch(
+                'lightning_pose.cli.commands.predict._predict_multi_type',
+            ) as mock_predict,
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            handle(args)
+        assert mock_predict.call_args.kwargs['bbox_dir'] == bbox_dir
+
+    def test_handle_threads_none_bbox_dir_when_not_provided(self, tmp_path, mock_model):
+        """handle() passes bbox_dir=None to _predict_multi_type when not provided."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4', bbox_dir=None)
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch(
+                'lightning_pose.cli.commands.predict._predict_multi_type',
+            ) as mock_predict,
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            handle(args)
+        assert mock_predict.call_args.kwargs['bbox_dir'] is None

--- a/tests/data/test_factory.py
+++ b/tests/data/test_factory.py
@@ -12,10 +12,11 @@ from PIL import Image
 
 from lightning_pose.data import (
     get_data_module,
+    get_dataset,
     get_imgaug_transform,
 )
 from lightning_pose.data.datamodules import BaseDataModule, UnlabeledDataModule
-from lightning_pose.data.datasets import BaseTrackingDataset
+from lightning_pose.data.datasets import BaseTrackingDataset, HeatmapDataset
 
 
 class TestGetImgaugTransform:
@@ -323,3 +324,58 @@ class TestGetDataModule:
         cfg.dali.context.train.batch_size = 4
         with pytest.raises(ValidationError):
             get_data_module(cfg, heatmap_dataset, os.path.join(toy_data_dir, 'videos'))
+
+
+class TestGetDataset:
+    """Test the get_dataset function."""
+
+    def test_heatmap_singleview_bbox_path_none_by_default(
+        self, cfg, toy_data_dir, imgaug_transform, mocker,
+    ):
+        """Single-view HeatmapDataset is constructed with bbox_path=None by default."""
+        cfg_tmp = copy.deepcopy(cfg)
+        cfg_tmp.model.model_type = 'heatmap'
+        mock_init = mocker.patch.object(HeatmapDataset, '__init__', return_value=None)
+        get_dataset(cfg_tmp, data_dir=toy_data_dir, imgaug_transform=imgaug_transform)
+        assert mock_init.call_args.kwargs.get('bbox_path') is None
+
+    def test_heatmap_singleview_bbox_path_forwarded_from_config(
+        self, cfg, toy_data_dir, imgaug_transform, mocker, tmp_path,
+    ):
+        """Single-view HeatmapDataset receives bbox_path from cfg.data.bbox_file."""
+        cfg_tmp = copy.deepcopy(cfg)
+        cfg_tmp.model.model_type = 'heatmap'
+        bbox_file = str(tmp_path / 'bbox.csv')
+        cfg_tmp.data.bbox_file = bbox_file
+        mock_init = mocker.patch.object(HeatmapDataset, '__init__', return_value=None)
+        get_dataset(cfg_tmp, data_dir=toy_data_dir, imgaug_transform=imgaug_transform)
+        assert mock_init.call_args.kwargs.get('bbox_path') == bbox_file
+
+    def test_regression_bbox_path_none_by_default(
+        self, cfg, toy_data_dir, imgaug_transform, mocker,
+    ):
+        """BaseTrackingDataset is constructed with bbox_path=None by default."""
+        cfg_tmp = copy.deepcopy(cfg)
+        cfg_tmp.model.model_type = 'regression'
+        mock_init = mocker.patch.object(BaseTrackingDataset, '__init__', return_value=None)
+        get_dataset(cfg_tmp, data_dir=toy_data_dir, imgaug_transform=imgaug_transform)
+        assert mock_init.call_args.kwargs.get('bbox_path') is None
+
+    def test_regression_bbox_path_forwarded_from_config(
+        self, cfg, toy_data_dir, imgaug_transform, mocker, tmp_path,
+    ):
+        """BaseTrackingDataset receives bbox_path from cfg.data.bbox_file."""
+        cfg_tmp = copy.deepcopy(cfg)
+        cfg_tmp.model.model_type = 'regression'
+        bbox_file = str(tmp_path / 'bbox.csv')
+        cfg_tmp.data.bbox_file = bbox_file
+        mock_init = mocker.patch.object(BaseTrackingDataset, '__init__', return_value=None)
+        get_dataset(cfg_tmp, data_dir=toy_data_dir, imgaug_transform=imgaug_transform)
+        assert mock_init.call_args.kwargs.get('bbox_path') == bbox_file
+
+    def test_invalid_model_type_raises(self, cfg, toy_data_dir, imgaug_transform):
+        """get_dataset raises NotImplementedError for an unrecognised model type."""
+        cfg_tmp = copy.deepcopy(cfg)
+        cfg_tmp.model.model_type = 'invalid_type'
+        with pytest.raises(NotImplementedError):
+            get_dataset(cfg_tmp, data_dir=toy_data_dir, imgaug_transform=imgaug_transform)


### PR DESCRIPTION
Skip `litpose crop` command for cropzoom pipeline, which creates intermediate cropped videos before running pose estimation; just use bboxes and frames at original resolution. This PR only applies to labeled frames, not videos.

closes #422 