### PR TITLE
litpose predict on videos with bbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,3 +181,37 @@ def function_name(
 - Keep branches focused and short-lived
 - Merge with pull requests
 - Delete merged branches
+
+## Architecture
+
+### DALI Pipeline (`lightning_pose/data/dali.py`)
+
+**`PrepareDALI`** — two-phase construction:
+- `__init__`: validates inputs and pre-computes pipe arguments for all four
+  `{train,predict}×{base,context}` combinations. Raises early so invalid configs are caught
+  before GPU allocation.
+- `__call__`: builds and returns the GPU pipeline as a `LitDaliWrapper`.
+
+**`LitDaliWrapper`** — wraps `DALIGenericIterator`; converts raw DALI batch dicts to
+`(frames, transforms)` tensors expected by the model. Manages `_frame_idx`, a cursor into
+`bbox_df` that advances by `seq_len` (base models) or `seq_len - 4` (context models, because
+consecutive DALI windows overlap by 4 frames to share context).
+
+### Bbox / Cropzoom (`docs/source/user_guide_advanced/cropzoom_pipeline.rst`)
+
+**CSV format**: columns `x`, `y`, `h`, `w` (top-left corner and size in pixels), one row per
+frame. The index column is ignored on read.
+
+**Naming convention**:
+- Videos: `{video_stem}_bbox.csv` (one file per video)
+- Labeled frames: `bbox.csv`
+
+**Two prediction modes** (selected by whether `bbox_df` is passed to `PrepareDALI`):
+- *Standard*: DALI resizes frames on GPU before passing them to the model. `resize_dims` is set.
+- *Bbox-crop*: DALI delivers full-resolution frames; `LitDaliWrapper._apply_bbox_crop` crops and
+  resizes each frame in PyTorch using per-frame rows from `bbox_df`. `resize_dims=None` in the
+  pipe dict for bbox predict entries.
+
+**Data flow**: `litpose predict --bbox_dir` → `_predict_multi_type` →
+`model.predict_on_video_file(bbox_file=...)` → `predict_video(bbox_file=...)` →
+`PrepareDALI(bbox_df=...)` → `LitDaliWrapper._apply_bbox_crop`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,13 +61,22 @@ pre-commit run --all-files
 ```
 
 #### Testing
-We currently do not have a continuous integration (CI) setup for the Lightning Pose repo due to its
-reliance on GPUs (and the relative expense of CI services that provide GPU machines for testing).
-Therefore, it is imperative that you run the unit tests yourself and verify that all tests have
-passed before submitting your request (and upon each new push to that request).
 
 To run the tests locally, you must have access to a GPU. Navigate to the Lightning Pose directory
 and simply run
 ```bash
 pytest
 ```
+
+#### Building the docs
+
+Documentation is built automatically when a pull request is opened, so this step is not
+required. If you have changed the docs and want to preview the result locally before pushing,
+from the `lightning-pose` directory run:
+
+```bash
+cd docs
+make html
+```
+
+Then open `docs/_build/html/index.html` in your browser.

--- a/docs/source/user_guide_advanced/cropzoom_pipeline.rst
+++ b/docs/source/user_guide_advanced/cropzoom_pipeline.rst
@@ -5,7 +5,17 @@ Cropzoom pipeline
 For setups where an animal is freely moving in a large arena,
 it's advantageous to crop around the animal before running pose estimation.
 Lightning Pose calls this technique "cropzoom". This document describes how
-to set up a such a pipeline.
+to set up such a pipeline.
+
+.. tip::
+
+   This pipeline works equally well with bounding boxes from any external source
+   (e.g., `idtracker.ai <https://idtracker.ai/latest/>`_,
+   `SAM3 <https://ai.meta.com/research/sam3/>`_, or your own custom detection scripts).
+   Wherever the examples below call ``litpose predict [detector_model]`` and
+   ``litpose create_bbox [detector_model]``, substitute your own scripts that produce
+   bbox CSV files in the required format (see `Using bboxes from an external source`_
+   below). All downstream steps are identical.
 
 Conceptual overview
 ===================
@@ -27,6 +37,9 @@ Lightning Pose model. We provide additional tools that help you compose these mo
   frame or video.
 * ``litpose remap``: Given the pose model's predictions and the crop bounding boxes,
   remaps the predictions to the original coordinate space.
+
+Alternatively, ``litpose predict --bbox_dir`` combines the crop, predict, and remap steps
+into a single command — see :ref:`prediction-on-videos` for details.
 
 For the full command-line reference for these tools, see the CLI page sections:
 :ref:`Create bbox <cli-create-bbox>`, :ref:`Smooth bbox <cli-smooth-bbox>`,
@@ -54,6 +67,11 @@ Inference involves:
 4. Crop the data using the bounding boxes.
 5. Predict on the cropped data using the "pose model".
 6. Remap the pose model's predictions to the original coordinate space.
+
+.. note::
+
+   Steps 4–6 can be replaced by a single ``litpose predict --bbox_dir`` call —
+   see :ref:`prediction-on-videos` in the example below.
 
 
 Bounding box sizing
@@ -90,7 +108,7 @@ which can improve pose estimation quality when the detector produces noisy predi
 
 Smoothed bboxes are written to a **new directory** alongside a ``metadata.json`` file
 that records the smoothing parameters.  You can then pass this directory to
-``litpose crop`` via ``--bbox_dir``.
+``litpose crop`` or ``litpose predict`` via ``--bbox_dir``.
 
 .. code-block:: bash
 
@@ -101,11 +119,12 @@ that records the smoothing parameters.  You can then pass this directory to
 Using bboxes from an external source
 =====================================
 
-Because ``litpose crop`` accepts a ``--bbox_dir`` argument, you can use bounding boxes
-produced by any external tool, not just ``litpose create_bbox``
-(e.g., `idtracker.ai <https://idtracker.ai/latest/>`_, `SAM3 <https://ai.meta.com/research/sam3/>`_, etc.).
+Because ``litpose crop`` and ``litpose predict`` both accept a ``--bbox_dir`` argument,
+you can use bounding boxes produced by any external tool, not just ``litpose create_bbox``
+(e.g., `idtracker.ai <https://idtracker.ai/latest/>`_,
+`SAM3 <https://ai.meta.com/research/sam3/>`_, etc.).
 Place your bbox CSV files in a directory following the naming convention below, then pass
-``--bbox_dir`` to ``litpose crop``:
+``--bbox_dir`` to either command:
 
 * **Videos**: ``<video_stem>_bbox.csv`` (one file per video)
 * **Labeled frames**: ``bbox.csv``
@@ -162,57 +181,86 @@ Training script
 For command-line options of the commands used above, see
 :ref:`Create bbox <cli-create-bbox>` and :ref:`Crop <cli-crop>`.
 
-Prediction on videos script
----------------------------
+.. _prediction-on-videos:
 
-.. code-block:: bash
+Prediction on videos
+--------------------
 
-    #!/bin/bash
+.. tab-set::
 
-    litpose predict $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4
+   .. tab-item:: Predict from cropped videos
 
-    litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4
+      **Pros**
 
-    # Optional: smooth bboxes before cropping.
-    litpose smooth_bbox $MODEL_DIR/$DETECTOR_MODEL/video_preds \
-        --output_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth
+      - Intermediate cropped videos are stored on disk, making it straightforward to
+        inspect each stage of the pipeline and diagnose potential issues in the detector
+        or pose estimator.
 
-    # Crop using raw bboxes (default):
-    litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4
+      **Cons**
 
-    # Or crop using smoothed bboxes:
-    litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.short.mp4 \
-        --bbox_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth
+      - Cropped videos are written to disk, requiring additional storage and compute.
+      - An extra remap step is needed to convert predictions back to the original
+        coordinate space.
 
-    litpose predict $MODEL_DIR/$POSE_MODEL $MODEL_DIR/$DETECTOR_MODEL/cropped_videos/cropped_test_vid.short.mp4
+      .. code-block:: bash
 
-    litpose remap $MODEL_DIR/$POSE_MODEL/video_preds/cropped_TRQ177_200624_112234_lBack.short.csv \
-        $MODEL_DIR/$DETECTOR_MODEL/video_preds/test_vid.short_bbox.csv
+         #!/bin/bash
+
+         litpose predict $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4
+
+         litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4
+
+         # Optional: smooth bboxes before cropping.
+         litpose smooth_bbox $MODEL_DIR/$DETECTOR_MODEL/video_preds \
+             --output_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth
+
+         # Crop using raw bboxes (default):
+         litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4
+
+         # Or crop using smoothed bboxes:
+         litpose crop $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4 \
+             --bbox_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth
+
+         litpose predict $MODEL_DIR/$POSE_MODEL \
+             $MODEL_DIR/$DETECTOR_MODEL/cropped_videos/cropped_test_vid.mp4
+
+         litpose remap $MODEL_DIR/$POSE_MODEL/video_preds/cropped_test_vid.csv \
+             $MODEL_DIR/$DETECTOR_MODEL/video_preds/test_vid_bbox.csv
+
+   .. tab-item:: Predict from original videos
+
+      **Pros**
+
+      - Runs entirely in memory — no intermediate cropped files are written to disk.
+      - Predictions are returned in the original coordinate space; no remap step is needed.
+
+      **Cons**
+
+      - Without intermediate cropped files, it is harder to inspect the detector output
+        or diagnose issues at each stage of the pipeline.
+
+      .. code-block:: bash
+
+         #!/bin/bash
+
+         litpose predict $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4
+
+         litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/videos/test_vid.mp4
+
+         # Optional: smooth bboxes.
+         litpose smooth_bbox $MODEL_DIR/$DETECTOR_MODEL/video_preds \
+             --output_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth
+
+         # Predict using raw bboxes:
+         litpose predict $MODEL_DIR/$POSE_MODEL data/videos/test_vid.mp4 \
+             --bbox_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds
+
+         # Or predict using smoothed bboxes:
+         litpose predict $MODEL_DIR/$POSE_MODEL data/videos/test_vid.mp4 \
+             --bbox_dir $MODEL_DIR/$DETECTOR_MODEL/video_preds/bboxes_smooth
 
 For detailed command-line options, see :ref:`Create bbox <cli-create-bbox>`,
 :ref:`Smooth bbox <cli-smooth-bbox>`, :ref:`Crop <cli-crop>`, and :ref:`Remap <cli-remap>`.
-
-Prediction on OOD Labeled Data
-------------------------------
-
-Say you have new labeled data for OoD animals, at `data/CollectedData_new.csv`,
-and you want to predict on these frames as well as compute pixel error.
-
-.. code-block:: bash
-
-    #!/bin/bash
-
-    litpose predict $MODEL_DIR/$DETECTOR_MODEL data/CollectedData_new.csv
-
-    litpose create_bbox $MODEL_DIR/$DETECTOR_MODEL data/CollectedData_new.csv
-
-    litpose crop $MODEL_DIR/$DETECTOR_MODEL data/CollectedData_new.csv
-
-    litpose predict $MODEL_DIR/$POSE_MODEL \
-      $MODEL_DIR/$DETECTOR_MODEL/image_preds/CollectedData_new.csv/cropped_CollectedData_new.csv
-
-    litpose remap $MODEL_DIR/$POSE_MODEL/image_preds/cropped_CollectedData_new.csv/predictions.csv \
-      $MODEL_DIR/$DETECTOR_MODEL/image_preds/CollectedData_new.csv/bbox.csv
 
 Limitations
 ===========

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -747,6 +747,7 @@ class Model:
         compute_metrics: bool = True,
         generate_labeled_video: bool = False,
         progress_file: Path | None = None,
+        bbox_file: str | Path | None = None,
     ) -> PredictionResult:
         """Predicts on a video file and computes unsupervised loss metrics if applicable.
 
@@ -761,6 +762,10 @@ class Model:
                 Defaults to False.
             progress_file (Path, optional): Path to a file to save progress information for the
                 App. Defaults to None.
+            bbox_file (str | Path, optional): Path to a per-frame bbox CSV (columns x, y, h, w;
+                one row per frame). When provided, each frame is cropped to its bounding box
+                before being passed to the model, and predictions are returned in the original
+                coordinate space. Single-view only. Defaults to None.
 
         Returns:
             PredictionResult: A PredictionResult object containing the predictions and metrics.
@@ -795,6 +800,7 @@ class Model:
             model=self,
             output_pred_file=str(prediction_csv_file),
             progress_file=progress_file,
+            bbox_file=bbox_file,
         )
         if generate_labeled_video:
             labeled_mp4_file = str(self.labeled_videos_dir() / f"{video_file.stem}_labeled.mp4")

--- a/lightning_pose/cli/commands/predict.py
+++ b/lightning_pose/cli/commands/predict.py
@@ -82,9 +82,10 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
         help=(
             "directory containing bbox CSV files produced by ``litpose create_bbox`` or a "
             "compatible external source. For CSV inputs, looks for ``bbox.csv`` inside this "
+            "directory. For video inputs, looks for ``<video_stem>_bbox.csv`` inside this "
             "directory. When provided, each frame is cropped to its bounding box before "
             "being passed to the model, and predictions are saved in the original coordinate "
-            "space. (Video support coming soon.)"
+            "space."
         ),
     )
 
@@ -148,9 +149,8 @@ def _predict_multi_type(
         skip_viz: if True, skip generating labeled visualization outputs.
         skip_existing: if True, skip predictions for which an output CSV already exists.
         progress_file: optional path to write prediction progress as JSON.
-        bbox_dir: optional directory containing bbox CSV files. When provided and the input
-            is a CSV, ``bbox.csv`` inside this directory is used to crop frames before
-            passing them to the model.
+        bbox_dir: optional directory containing bbox CSV files. For CSV inputs, ``bbox.csv``
+            inside this directory is used. For video inputs, ``<stem>_bbox.csv`` is used.
     """
     if path.is_dir():
         image_files = [p for p in path.iterdir() if p.is_file() and p.suffix in [".png", ".jpg"]]
@@ -178,6 +178,7 @@ def _predict_multi_type(
             video_file=path,
             generate_labeled_video=(not skip_viz),
             progress_file=progress_file,
+            bbox_file=bbox_dir / f'{path.stem}_bbox.csv' if bbox_dir is not None else None,
         )
     elif path.suffix == ".csv":
         # Check if prediction file already exists

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -345,12 +345,19 @@ class LitDaliWrapper(DALIGenericIterator):
                 ignore_index=True,
             )
 
+        frame_h, frame_w = frames.shape[2], frames.shape[3]
         cropped_frames = []
         bboxes = []
         for i in range(seq_len):
             row = rows.iloc[i]
-            x, y, h, w = int(row['x']), int(row['y']), int(row['h']), int(row['w'])
-            frame_cropped = frames[i, :, y:y + h, x:x + w]
+            # clamp to frame bounds: create_bbox can produce negative x/y for edge frames
+            # (centroid - bbox_size//2 < 0). negative pytorch slice indices count from the
+            # end rather than clamping, producing an empty crop.
+            x1 = max(0, int(row['x']))
+            y1 = max(0, int(row['y']))
+            x2 = max(x1 + 1, min(frame_w, int(row['x']) + int(row['w'])))
+            y2 = max(y1 + 1, min(frame_h, int(row['y']) + int(row['h'])))
+            frame_cropped = frames[i, :, y1:y2, x1:x2]
             frame_resized = F.interpolate(
                 frame_cropped.unsqueeze(0),
                 size=self.resize_dims,
@@ -359,7 +366,9 @@ class LitDaliWrapper(DALIGenericIterator):
             ).squeeze(0)
             cropped_frames.append(frame_resized)
             bboxes.append(
-                torch.tensor([x, y, h, w], dtype=torch.float32, device=frames.device)
+                torch.tensor(
+                    [x1, y1, y2 - y1, x2 - x1], dtype=torch.float32, device=frames.device,
+                )
             )
 
         self._frame_idx += step

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -6,7 +6,9 @@ from typing import Any, Literal
 import numpy as np
 import nvidia.dali.fn as fn
 import nvidia.dali.types as types
+import pandas as pd
 import torch
+import torch.nn.functional as F
 from nvidia.dali import pipeline_def
 from nvidia.dali.plugin.pytorch import DALIGenericIterator, LastBatchPolicy
 from omegaconf import DictConfig, ListConfig
@@ -166,21 +168,32 @@ class LitDaliWrapper(DALIGenericIterator):
         eval_mode: Literal["train", "predict"],
         num_iters: int = 1,
         do_context: bool = False,
+        bbox_df: pd.DataFrame | None = None,
+        resize_dims: list[int] | None = None,
         **kwargs: Any,
     ) -> None:
         """Wrapper around DALIGenericIterator to get batches for pl.
 
         Args:
-            eval_mode
+            eval_mode: ``"train"`` or ``"predict"``.
             num_iters: number of enumerations of dataloader (should be computed outside for now;
                 should be fixed by lightning/dali teams)
             do_context: whether model/loader use 5-frame context or not
+            bbox_df: optional DataFrame with columns ``["x", "y", "h", "w"]``, one row per
+                frame. When provided, each batch's frames are cropped per-frame and resized
+                to ``resize_dims`` before being returned, and the ``bbox`` field of the
+                batch dict is populated with the actual bbox coordinates.
+            resize_dims: target ``[height, width]`` for post-crop resize; required when
+                ``bbox_df`` is not None.
 
         """
         self.num_iters = num_iters
         self.do_context = do_context
         self.eval_mode = eval_mode
         self.batch_sampler = 1  # hack to get around DALI-ptl issue
+        self.bbox_df = bbox_df
+        self.resize_dims = resize_dims
+        self._frame_idx = 0
         # call parent
         super().__init__(*args, **kwargs)
 
@@ -254,10 +267,61 @@ class LitDaliWrapper(DALIGenericIterator):
                 frames=frames, transforms=transforms, bbox=bbox, is_multiview=True,
             )
 
+    def _apply_bbox_crop(self, batch_dict: UnlabeledBatchDict) -> UnlabeledBatchDict:
+        """Crop frames to per-frame bboxes and resize to the model's input dimensions.
+
+        Args:
+            batch_dict: single-view unlabeled batch with full-resolution frames from DALI.
+
+        Returns:
+            new UnlabeledBatchDict with cropped+resized frames and real bbox values.
+        """
+        frames = batch_dict['frames']  # (seq_len, 3, H, W)
+        seq_len = frames.shape[0]
+        step = seq_len - 4 if self.do_context else seq_len
+
+        # slice bbox rows for this batch; pad last partial batch with the final row
+        rows = self.bbox_df.iloc[self._frame_idx:self._frame_idx + seq_len]
+        if len(rows) < seq_len:
+            last_row = self.bbox_df.iloc[[-1]]
+            rows = pd.concat(
+                [rows] + [last_row] * (seq_len - len(rows)),
+                ignore_index=True,
+            )
+
+        cropped_frames = []
+        bboxes = []
+        for i in range(seq_len):
+            row = rows.iloc[i]
+            x, y, h, w = int(row['x']), int(row['y']), int(row['h']), int(row['w'])
+            frame_cropped = frames[i, :, y:y + h, x:x + w]
+            frame_resized = F.interpolate(
+                frame_cropped.unsqueeze(0),
+                size=self.resize_dims,
+                mode='bilinear',
+                align_corners=False,
+            ).squeeze(0)
+            cropped_frames.append(frame_resized)
+            bboxes.append(
+                torch.tensor([x, y, h, w], dtype=torch.float32, device=frames.device)
+            )
+
+        self._frame_idx += step
+
+        return UnlabeledBatchDict(
+            frames=torch.stack(cropped_frames),
+            transforms=batch_dict['transforms'],
+            bbox=torch.stack(bboxes),
+            is_multiview=False,
+        )
+
     def __next__(self) -> UnlabeledBatchDict | MultiviewUnlabeledBatchDict:
-        """Fetch the next batch and convert it to a typed batch dictionary."""
+        """Fetch the next batch, applying per-frame bbox crop+resize when configured."""
         batch = super().__next__()
-        return self._dali_output_to_tensors(batch=batch)
+        batch_dict = self._dali_output_to_tensors(batch=batch)
+        if self.bbox_df is not None and not batch_dict['is_multiview']:
+            return self._apply_bbox_crop(batch_dict)  # type: ignore[arg-type]
+        return batch_dict
 
 
 class PrepareDALI:

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -340,6 +340,7 @@ class PrepareDALI:
         dali_config: dict | DictConfig | ListConfig | None = None,
         imgaug: str | None = "default",
         num_threads: int = 1,
+        bbox_df: pd.DataFrame | None = None,
     ) -> None:
         """Initialize DALI pipelines and dataloaders for training or prediction.
 
@@ -350,10 +351,15 @@ class PrepareDALI:
             filenames: for single-view models, a flat list of video file paths; for
                 multi-view models, a list of per-view lists of video file paths.
             resize_dims: ``[height, width]`` to resize frames to before feeding the model.
+                Also used as the post-crop resize target when ``bbox_df`` is provided.
             dali_config: DALI-specific config dict; falls back to package defaults when None.
             imgaug: name of the augmentation pipeline to apply during training (e.g.
                 ``"dlc"``); pass ``"default"`` for resize-only or ``None`` to disable.
             num_threads: number of CPU threads used by DALI pipelines.
+            bbox_df: optional DataFrame with columns ``["x", "y", "h", "w"]``, one row per
+                frame. When provided, the predict pipeline loads full-resolution frames
+                (DALI resize is disabled) and ``LitDaliWrapper`` crops each frame to its
+                bbox before resizing to ``resize_dims``.
 
         Raises:
             FileNotFoundError: if any path in ``filenames`` does not exist or is not a file.
@@ -416,6 +422,7 @@ class PrepareDALI:
         self.resize_dims = resize_dims
         self.dali_config = dali_config
         self.num_threads = num_threads
+        self.bbox_df = bbox_df
         self.frame_count = sum(view0_frame_counts)
         self._pipe_dict: dict = self._setup_pipe_dict(self.filenames, imgaug)
 
@@ -559,6 +566,12 @@ class PrepareDALI:
         }
         # our floor above should prevent us from getting to the very final batch.
 
+        # when per-frame bbox cropping is enabled, DALI must deliver full-resolution frames so
+        # that LitDaliWrapper can crop them; the post-crop resize happens in PyTorch instead
+        if self.bbox_df is not None:
+            dict_args['predict']['base']['resize_dims'] = None
+            dict_args['predict']['context']['resize_dims'] = None
+
         return dict_args
 
     def _get_dali_pipe(self) -> Any:
@@ -636,9 +649,11 @@ class PrepareDALI:
         return dict_args
 
     def __call__(self) -> LitDaliWrapper:
-        """
-        Returns a LightningWrapper object.
-        """
+        """Return a LitDaliWrapper configured for the current train stage and model type."""
         pipe = self._get_dali_pipe()
         args = self._setup_dali_iterator_args()
-        return LitDaliWrapper(pipe, **args[self.train_stage][self.model_type])
+        iterator_args = args[self.train_stage][self.model_type]
+        if self.bbox_df is not None:
+            iterator_args['bbox_df'] = self.bbox_df
+            iterator_args['resize_dims'] = self.resize_dims
+        return LitDaliWrapper(pipe, **iterator_args)

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -330,6 +330,7 @@ class LitDaliWrapper(DALIGenericIterator):
             new ``UnlabeledBatchDict`` with cropped+resized frames and the actual bbox
             coordinates in the ``bbox`` field (shape ``(seq_len, 4)``, order x y h w).
         """
+        assert self.bbox_df is not None  # guarded by caller; assertion narrows type
         frames = batch_dict['frames']  # (seq_len, 3, H, W)
         seq_len = frames.shape[0]
         # context-model DALI reader uses step=seq_len-4 so consecutive windows overlap by 4

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -1,4 +1,28 @@
-"""Data pipelines based on efficient video reading by nvidia dali package."""
+"""Data pipelines based on efficient video reading by nvidia dali package.
+
+Architecture overview
+---------------------
+``PrepareDALI`` is the entry point. Its ``__init__`` validates inputs and pre-computes
+pipeline arguments for all four combinations of stage (``"train"``, ``"predict"``) and
+model type (``"base"``, ``"context"``). Calling the instance (``__call__``) builds the DALI
+pipe for the requested combination and returns a ready-to-iterate ``LitDaliWrapper``.
+
+``LitDaliWrapper`` extends ``DALIGenericIterator`` and converts raw DALI output into typed
+``UnlabeledBatchDict`` or ``MultiviewUnlabeledBatchDict`` instances on every ``__next__``.
+
+Two prediction modes
+--------------------
+Standard mode (no ``bbox_df``):
+    DALI resizes frames to ``resize_dims`` on the GPU. The ``bbox`` field of each returned
+    batch covers the full frame (x=0, y=0, h=H, w=W).
+
+Bbox-crop mode (``bbox_df`` supplied to ``PrepareDALI``):
+    DALI delivers full-resolution frames (``resize_dims=None`` in the predict pipe) so that
+    ``LitDaliWrapper._apply_bbox_crop`` can crop each frame to its per-frame bounding box
+    and resize to the original ``resize_dims`` using ``torch.nn.functional.interpolate``.
+    The ``bbox`` field of each batch contains the actual crop coordinates, so downstream
+    code can remap predictions back to the original coordinate space.
+"""
 
 import os
 from typing import Any, Literal
@@ -160,7 +184,30 @@ def video_pipe(
 
 
 class LitDaliWrapper(DALIGenericIterator):
-    """wrapper around a DALI pipeline to get batches for ptl."""
+    """Typed wrapper around a DALI pipeline iterator for Lightning Pose models.
+
+    Converts the raw list-of-dicts that ``DALIGenericIterator`` yields into
+    ``UnlabeledBatchDict`` or ``MultiviewUnlabeledBatchDict`` instances.  When a
+    ``bbox_df`` is provided, each batch's frames are also cropped per-frame and resized
+    to the model's input dimensions before being returned.
+
+    ``_frame_idx`` tracks the iterator's position in the video (by frame number) so that
+    ``_apply_bbox_crop`` reads the correct rows from ``bbox_df``.  It advances by
+    ``seq_len`` for base models (non-overlapping windows) and by ``seq_len - 4`` for
+    context models, because the DALI reader for context prediction uses a step of
+    ``seq_len - 4`` so that consecutive 5-frame windows overlap by 4 frames.
+
+    Testing without a GPU
+    +++++++++++++++++++++
+    This class can be instantiated without a real DALI pipeline or GPU for unit tests
+    that only exercise the PyTorch post-processing logic (e.g. ``_apply_bbox_crop``)::
+
+        wrapper = object.__new__(LitDaliWrapper)
+        wrapper.do_context = False
+        wrapper.bbox_df = my_df
+        wrapper.resize_dims = [256, 256]
+        wrapper._frame_idx = 0
+    """
 
     def __init__(
         self,
@@ -193,6 +240,7 @@ class LitDaliWrapper(DALIGenericIterator):
         self.batch_sampler = 1  # hack to get around DALI-ptl issue
         self.bbox_df = bbox_df
         self.resize_dims = resize_dims
+        # cursor into bbox_df; advances by seq_len (base) or seq_len-4 (context) per batch
         self._frame_idx = 0
         # call parent
         super().__init__(*args, **kwargs)
@@ -270,14 +318,22 @@ class LitDaliWrapper(DALIGenericIterator):
     def _apply_bbox_crop(self, batch_dict: UnlabeledBatchDict) -> UnlabeledBatchDict:
         """Crop frames to per-frame bboxes and resize to the model's input dimensions.
 
+        Called only in bbox-crop mode (when ``bbox_df`` is not None). DALI has already
+        delivered full-resolution frames; this method crops each frame individually,
+        resizes to ``self.resize_dims``, and advances ``_frame_idx`` by the same step
+        that the DALI reader used, so the two cursors stay in sync.
+
         Args:
             batch_dict: single-view unlabeled batch with full-resolution frames from DALI.
 
         Returns:
-            new UnlabeledBatchDict with cropped+resized frames and real bbox values.
+            new ``UnlabeledBatchDict`` with cropped+resized frames and the actual bbox
+            coordinates in the ``bbox`` field (shape ``(seq_len, 4)``, order x y h w).
         """
         frames = batch_dict['frames']  # (seq_len, 3, H, W)
         seq_len = frames.shape[0]
+        # context-model DALI reader uses step=seq_len-4 so consecutive windows overlap by 4
+        # frames; _frame_idx must advance by the same amount to stay in sync with the reader
         step = seq_len - 4 if self.do_context else seq_len
 
         # slice bbox rows for this batch; pad last partial batch with the final row
@@ -325,10 +381,19 @@ class LitDaliWrapper(DALIGenericIterator):
 
 
 class PrepareDALI:
-    """All the DALI stuff in one place.
+    """Factory for DALI video-reading pipelines used during training and prediction.
 
-    Big picture: this will initialize the pipes and dataloaders for both training and prediction.
+    Construction is split into two phases:
 
+    1. ``__init__``: validates inputs (file existence, multiview frame-count consistency),
+       pre-computes pipe arguments for all four combinations of
+       ``{train, predict}`` × ``{base, context}``, and stores them in ``_pipe_dict``.
+    2. ``__call__``: builds the DALI pipe for the requested ``train_stage`` /
+       ``model_type`` combination and returns a ready-to-iterate ``LitDaliWrapper``.
+
+    Splitting validation from pipe-building lets callers inspect ``num_iters`` and other
+    properties before committing GPU memory, and makes it straightforward to call
+    ``__call__`` again with a different stage without repeating validation.
     """
 
     def __init__(
@@ -477,7 +542,16 @@ class PrepareDALI:
         filenames: list[str] | list[list[str]],
         imgaug: str | None,
     ) -> dict[str, dict]:
-        """All of the pipeline args in one place."""
+        """Build DALI pipeline arguments for all stage/model-type combinations.
+
+        Returns a nested dict of shape ``{stage: {model_type: kwargs}}`` (stored as
+        ``self._pipe_dict``) that is consumed by ``_get_dali_pipe``.
+
+        When ``bbox_df`` is set, predict entries have ``resize_dims`` forced to ``None``
+        so DALI delivers full-resolution frames.  The per-frame resize happens in PyTorch
+        inside ``LitDaliWrapper._apply_bbox_crop`` after cropping, using the original
+        ``resize_dims`` stored on the wrapper.
+        """
         assert self.dali_config is not None
         # When running with multiple GPUs, the LOCAL_RANK variable correctly
         # contains the DDP Local Rank, which is also the cuda device index.
@@ -575,8 +649,10 @@ class PrepareDALI:
         return dict_args
 
     def _get_dali_pipe(self) -> Any:
-        """
-        Return a DALI pipe with predefined args.
+        """Build and return a DALI pipeline for the current stage and model type.
+
+        Returns:
+            Compiled DALI pipeline ready to be passed to ``LitDaliWrapper``.
         """
 
         pipe_args = self._pipe_dict[self.train_stage][self.model_type]
@@ -584,11 +660,24 @@ class PrepareDALI:
         return pipe
 
     def _setup_dali_iterator_args(self) -> dict:
-        """Builds args for Lightning iterator.
+        """Build ``LitDaliWrapper`` constructor kwargs for all stage/model-type combinations.
 
-        If you want to extract more outputs from DALI, e.g., optical flow, you should also add
-        this in the "output_map" arg
+        Returns a nested dict of shape ``{stage: {model_type: kwargs}}`` mirroring
+        ``_pipe_dict``.  The kwargs are passed directly to ``LitDaliWrapper.__init__``
+        (via ``DALIGenericIterator``) in ``__call__``.
 
+        Key design choices:
+
+        - ``output_map`` lists the DALI output names in the order ``video_pipe`` returns
+          them: ``frames``, ``transforms``, ``frame_size`` (repeated per view for
+          multiview).  Adding new DALI outputs (e.g. optical flow) requires updating this
+          map as well as ``_dali_output_to_tensors``.
+        - Predict pipelines use ``LastBatchPolicy.FILL`` (repeat the last frame to
+          complete the final batch) rather than ``PARTIAL`` (drop the incomplete batch),
+          so ``PredictionHandler`` always receives a full-sized tensor and trims excess
+          frames itself.
+        - ``auto_reset=False`` for predict so the iterator raises ``StopIteration`` at
+          the end of the video rather than cycling back to the start.
         """
         dict_args = {
             "predict": {"context": {}, "base": {}},
@@ -649,10 +738,16 @@ class PrepareDALI:
         return dict_args
 
     def __call__(self) -> LitDaliWrapper:
-        """Return a LitDaliWrapper configured for the current train stage and model type."""
+        """Build the DALI pipeline and return a ready-to-iterate ``LitDaliWrapper``.
+
+        Returns:
+            ``LitDaliWrapper`` configured for ``self.train_stage`` and ``self.model_type``.
+        """
         pipe = self._get_dali_pipe()
         args = self._setup_dali_iterator_args()
         iterator_args = args[self.train_stage][self.model_type]
+        # injected here rather than in _setup_dali_iterator_args so that the standard
+        # iterator arg dict remains self-contained for the non-bbox case
         if self.bbox_df is not None:
             iterator_args['bbox_df'] = self.bbox_df
             iterator_args['resize_dims'] = self.resize_dims

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -397,6 +397,7 @@ def predict_video(
     model: Model,
     output_pred_file: str | None = None,
     progress_file: Path | None = None,
+    bbox_file: str | Path | None = None,
 ) -> pd.DataFrame: ...
 
 
@@ -414,6 +415,7 @@ def predict_video(
     model: Model,
     output_pred_file: str | list[str] | None = None,
     progress_file: Path | None = None,
+    bbox_file: str | Path | None = None,
 ) -> pd.DataFrame | list[pd.DataFrame]:
     """
     Args:
@@ -422,6 +424,9 @@ def predict_video(
         model: The model to predict with.
         output_pred_file: (optional) File to save predictions in.
             For multiview, a list of files (1-1 correspondance to cfg.data.view_names).
+        bbox_file: (optional) path to a bbox CSV (columns x, y, h, w; one row per frame).
+            when provided, DALI delivers full-resolution frames and the wrapper crops each
+            frame to the bbox before resizing to the model's input dims. single-view only.
     """
 
     is_multiview = not isinstance(video_file, str)
@@ -442,6 +447,18 @@ def predict_video(
             assert (
                 view_name in Path(single_video_file).stem
             ), "expected video_file to correspond 1-1 with cfg.data.view_name"
+
+    bbox_df: pd.DataFrame | None = None
+    if bbox_file is not None:
+        if is_multiview:
+            raise ValueError('bbox_file is not supported for multiview prediction')
+        assert isinstance(video_file, str)
+        bbox_df = pd.read_csv(bbox_file, index_col=0)
+        frame_count = count_frames(video_file)
+        if len(bbox_df) != frame_count:
+            raise ValueError(
+                f'bbox_file has {len(bbox_df)} rows but video has {frame_count} frames'
+            )
 
     trainer = pl.Trainer(
         accelerator="gpu",
@@ -467,6 +484,7 @@ def predict_video(
             model.config.cfg.data.image_resize_dims.height,
             model.config.cfg.data.image_resize_dims.width,
         ],
+        bbox_df=bbox_df,
     )
     # get loader
     predict_loader = vid_pred_class()

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -11,22 +11,19 @@ from tests.fetch_test_data import fetch_test_data_if_needed
 
 
 def _setup_test_model(tmp_path, request, multiview=False) -> Model:
-    # Get the trained model for testing.
+    # get the trained model for testing
     dataset_name = (
         "test_model_mirror_mouse"
         if not multiview
         else "test_model_mirror_mouse_multiview"
     )
     fetch_test_data_if_needed(request.path.parent, dataset_name)
-    # Copy to tmpdir because prediction will create output artifacts in model_dir.
+    # copy to tmpdir because prediction will create output artifacts in model_dir
     tmp_model_dir = tmp_path / dataset_name
     shutil.copytree(request.path.parent / dataset_name, tmp_model_dir)
 
-    # Set up a model object.
     model = Model.from_dir(tmp_model_dir)
 
-    # We're going to use these in tests, so make sure they are correct
-    # before tests just assume they work correctly.
     assert model.model_dir == tmp_model_dir
     assert model.image_preds_dir() == tmp_model_dir / "image_preds"
     assert model.video_preds_dir() == tmp_model_dir / "video_preds"
@@ -34,8 +31,7 @@ def _setup_test_model(tmp_path, request, multiview=False) -> Model:
         model.labeled_videos_dir() == tmp_model_dir / "video_preds" / "labeled_videos"
     )
 
-    # Confirm predictions don't exist yet. If they do, our tests will pass even
-    # if model prediction did nothing.
+    # confirm predictions don't exist yet; if they do, tests pass even if prediction did nothing
     assert not model.image_preds_dir().exists()
     assert not model.video_preds_dir().exists()
     assert not model.labeled_videos_dir().exists()
@@ -43,164 +39,178 @@ def _setup_test_model(tmp_path, request, multiview=False) -> Model:
     return model
 
 
-def test_predict_on_label_csv_singleview(tmp_path, request, toy_data_dir):
-    model = _setup_test_model(tmp_path, request)
+class TestPredictOnLabelCsv:
+    """Test the predict_on_label_csv method."""
 
-    # Test prediction on a CSV file.
-    model.predict_on_label_csv(Path(toy_data_dir) / "CollectedData.csv")
+    def test_predict_on_label_csv_singleview(self, tmp_path, request, toy_data_dir):
+        """Singleview model writes predictions and per-metric error CSVs."""
+        model = _setup_test_model(tmp_path, request)
 
-    assert (model.image_preds_dir() / "CollectedData.csv" / "predictions.csv").is_file()
-    assert (
-        model.image_preds_dir() / "CollectedData.csv" / "predictions_pixel_error.csv"
-    ).is_file()
-    assert (
-        model.image_preds_dir()
-        / "CollectedData.csv"
-        / "predictions_pca_singleview_error.csv"
-    ).is_file()
+        model.predict_on_label_csv(Path(toy_data_dir) / "CollectedData.csv")
 
+        assert (model.image_preds_dir() / "CollectedData.csv" / "predictions.csv").is_file()
+        assert (
+            model.image_preds_dir() / "CollectedData.csv" / "predictions_pixel_error.csv"
+        ).is_file()
+        assert (
+            model.image_preds_dir()
+            / "CollectedData.csv"
+            / "predictions_pca_singleview_error.csv"
+        ).is_file()
 
-def test_predict_on_label_csv_method_multiview_model(tmp_path, request, toy_mdata_dir):
-    model = _setup_test_model(tmp_path, request, multiview=True)
+    def test_predict_on_label_csv_with_multiview_model(self, tmp_path, request, toy_mdata_dir):
+        """Multiview model can predict on a single-view CSV."""
+        model = _setup_test_model(tmp_path, request, multiview=True)
 
-    # Test prediction on a CSV file.
-    model.predict_on_label_csv(Path(toy_mdata_dir) / "top.csv")
+        model.predict_on_label_csv(Path(toy_mdata_dir) / "top.csv")
 
-    assert (model.image_preds_dir() / "top.csv" / "predictions.csv").is_file()
-    assert (
-        model.image_preds_dir() / "top.csv" / "predictions_pixel_error.csv"
-    ).is_file()
+        assert (model.image_preds_dir() / "top.csv" / "predictions.csv").is_file()
+        assert (model.image_preds_dir() / "top.csv" / "predictions_pixel_error.csv").is_file()
 
+    def test_predict_on_label_csv_multiview(self, tmp_path, request, toy_mdata_dir):
+        """predict_on_label_csv_multiview writes predictions for all views."""
+        model = _setup_test_model(tmp_path, request, multiview=True)
 
-def test_predict_on_label_csv_multiview(tmp_path, request, toy_mdata_dir):
-    model = _setup_test_model(tmp_path, request, multiview=True)
+        model.predict_on_label_csv_multiview(
+            [
+                Path(toy_mdata_dir) / "top.csv",
+                Path(toy_mdata_dir) / "bot.csv",
+            ]
+        )
 
-    # Test prediction on CSV files.
-    model.predict_on_label_csv_multiview(
-        [
-            Path(toy_mdata_dir) / "top.csv",
-            Path(toy_mdata_dir) / "bot.csv",
-        ]
-    )
-
-    assert (model.image_preds_dir() / "top.csv" / "predictions.csv").is_file()
-    assert (
-        model.image_preds_dir() / "top.csv" / "predictions_pixel_error.csv"
-    ).is_file()
-
-    assert (model.image_preds_dir() / "bot.csv" / "predictions.csv").is_file()
-    assert (
-        model.image_preds_dir() / "bot.csv" / "predictions_pixel_error.csv"
-    ).is_file()
+        assert (model.image_preds_dir() / "top.csv" / "predictions.csv").is_file()
+        assert (model.image_preds_dir() / "top.csv" / "predictions_pixel_error.csv").is_file()
+        assert (model.image_preds_dir() / "bot.csv" / "predictions.csv").is_file()
+        assert (model.image_preds_dir() / "bot.csv" / "predictions_pixel_error.csv").is_file()
 
 
-def test_predict_on_video_file_singleview(tmp_path, request, toy_data_dir):
-    model = _setup_test_model(tmp_path, request)
+class TestPredictOnVideoFile:
+    """Test the predict_on_video_file method."""
 
-    # Test prediction on a test video.
-    model.predict_on_video_file(Path(toy_data_dir) / "videos" / "test_vid.mp4")
-    assert (model.video_preds_dir() / "test_vid.csv").is_file()
-    assert (model.video_preds_dir() / "test_vid_temporal_norm.csv").is_file()
-    assert (model.video_preds_dir() / "test_vid_pca_singleview_error.csv").is_file()
+    def test_predict_on_video_file_singleview(self, tmp_path, request, toy_data_dir):
+        """Singleview model writes prediction CSVs and optionally a labeled video."""
+        model = _setup_test_model(tmp_path, request)
 
-    # Labeled video generation should have been off by default.
-    assert not model.labeled_videos_dir().exists()
+        model.predict_on_video_file(Path(toy_data_dir) / "videos" / "test_vid.mp4")
 
-    # Test labeled_video generation.
-    model.predict_on_video_file(
-        Path(toy_data_dir) / "videos" / "test_vid.mp4",
-        generate_labeled_video=True,
-    )
-    assert (model.labeled_videos_dir() / "test_vid_labeled.mp4").is_file()
+        assert (model.video_preds_dir() / "test_vid.csv").is_file()
+        assert (model.video_preds_dir() / "test_vid_temporal_norm.csv").is_file()
+        assert (model.video_preds_dir() / "test_vid_pca_singleview_error.csv").is_file()
+        assert not model.labeled_videos_dir().exists()
 
+        model.predict_on_video_file(
+            Path(toy_data_dir) / "videos" / "test_vid.mp4",
+            generate_labeled_video=True,
+        )
+        assert (model.labeled_videos_dir() / "test_vid_labeled.mp4").is_file()
 
-def test_predict_on_video_file_method_multiview_model(tmp_path, request, toy_mdata_dir):
-    model = _setup_test_model(tmp_path, request, multiview=True)
+    def test_predict_on_video_file_with_multiview_model(self, tmp_path, request, toy_mdata_dir):
+        """Multiview model can predict on a single video file."""
+        model = _setup_test_model(tmp_path, request, multiview=True)
 
-    # Test prediction on a test video.
-    model.predict_on_video_file(
-        Path(toy_mdata_dir) / "videos" / "test_vid_top.mp4",
-        generate_labeled_video=True,
-    )
-    assert (model.video_preds_dir() / "test_vid_top.csv").is_file()
-    assert (model.video_preds_dir() / "test_vid_top_temporal_norm.csv").is_file()
-    assert (model.labeled_videos_dir() / "test_vid_top_labeled.mp4").is_file()
-
-
-def test_predict_on_video_file_multiview(tmp_path, request, toy_mdata_dir):
-    model = _setup_test_model(tmp_path, request, multiview=True)
-
-    # Test prediction on a test video.
-    model.predict_on_video_file_multiview(
-        [
+        model.predict_on_video_file(
             Path(toy_mdata_dir) / "videos" / "test_vid_top.mp4",
-            Path(toy_mdata_dir) / "videos" / "test_vid_bot.mp4",
-        ],
-        generate_labeled_video=True,
-    )
-    assert (model.video_preds_dir() / "test_vid_top.csv").is_file()
-    assert (model.video_preds_dir() / "test_vid_top.csv").is_file()
-    assert (model.video_preds_dir() / "test_vid_top_temporal_norm.csv").is_file()
-    assert (model.video_preds_dir() / "test_vid_bot_temporal_norm.csv").is_file()
-    assert (model.labeled_videos_dir() / "test_vid_top_labeled.mp4").is_file()
-    assert (model.labeled_videos_dir() / "test_vid_bot_labeled.mp4").is_file()
+            generate_labeled_video=True,
+        )
+
+        assert (model.video_preds_dir() / "test_vid_top.csv").is_file()
+        assert (model.video_preds_dir() / "test_vid_top_temporal_norm.csv").is_file()
+        assert (model.labeled_videos_dir() / "test_vid_top_labeled.mp4").is_file()
+
+    def test_predict_on_video_file_multiview(self, tmp_path, request, toy_mdata_dir):
+        """predict_on_video_file_multiview writes predictions and labeled videos for all views."""
+        model = _setup_test_model(tmp_path, request, multiview=True)
+
+        model.predict_on_video_file_multiview(
+            [
+                Path(toy_mdata_dir) / "videos" / "test_vid_top.mp4",
+                Path(toy_mdata_dir) / "videos" / "test_vid_bot.mp4",
+            ],
+            generate_labeled_video=True,
+        )
+
+        assert (model.video_preds_dir() / "test_vid_top.csv").is_file()
+        assert (model.video_preds_dir() / "test_vid_top.csv").is_file()
+        assert (model.video_preds_dir() / "test_vid_top_temporal_norm.csv").is_file()
+        assert (model.video_preds_dir() / "test_vid_bot_temporal_norm.csv").is_file()
+        assert (model.labeled_videos_dir() / "test_vid_top_labeled.mp4").is_file()
+        assert (model.labeled_videos_dir() / "test_vid_bot_labeled.mp4").is_file()
 
 
-def test_predict_frame(tmp_path, request):
-    model = _setup_test_model(tmp_path, request)
+class TestPredictFrame:
+    """Test the predict_frame method."""
 
-    # Synthetic RGB frame
-    frame = np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8)
-    result = model.predict_frame(frame)
+    def test_predict_frame_basic(self, tmp_path, request):
+        """predict_frame returns keypoints and confidences for a synthetic RGB frame."""
+        model = _setup_test_model(tmp_path, request)
 
-    assert "keypoints" in result
-    assert "confidence" in result
+        frame = np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8)
+        result = model.predict_frame(frame)
 
-    kp = result["keypoints"]
-    conf = result["confidence"]
+        assert "keypoints" in result
+        assert "confidence" in result
 
-    # Check types and shapes
-    assert kp.dtype == np.float32
-    assert conf.dtype == np.float32
-    assert kp.ndim == 2
-    assert kp.shape[1] == 2
-    assert conf.shape[0] == kp.shape[0]
-    assert kp.shape[0] > 0  # at least one keypoint
+        kp = result["keypoints"]
+        conf = result["confidence"]
 
-    # Confidence must be in [0, 1] (softmax peak intensity)
-    assert np.all(conf >= 0)
-    assert np.all(conf <= 1)
+        assert kp.dtype == np.float32
+        assert conf.dtype == np.float32
+        assert kp.ndim == 2
+        assert kp.shape[1] == 2
+        assert conf.shape[0] == kp.shape[0]
+        assert kp.shape[0] > 0  # at least one keypoint
+        assert np.all(conf >= 0)
+        assert np.all(conf <= 1)
+        # tolerance for subpixel overshoot at frame boundary
+        assert np.all(kp[:, 0] <= 256 + 1)
+        assert np.all(kp[:, 1] <= 256 + 1)
 
-    # Keypoints should be within frame bounds (with tolerance for subpixel overshoot)
-    assert np.all(kp[:, 0] <= 256 + 1)
-    assert np.all(kp[:, 1] <= 256 + 1)
+    def test_predict_frame_with_bbox(self, tmp_path, request):
+        """predict_frame with bbox remaps keypoints to original frame coordinates."""
+        model = _setup_test_model(tmp_path, request)
 
+        frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+        bbox = (100, 50, 200, 150)  # (x, y, w, h)
+        result = model.predict_frame(frame, bbox=bbox)
 
-def test_predict_frame_with_bbox(tmp_path, request):
-    model = _setup_test_model(tmp_path, request)
+        kp = result["keypoints"]
+        conf = result["confidence"]
 
-    frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
-    bbox = (100, 50, 200, 150)  # (x, y, w, h)
-    result = model.predict_frame(frame, bbox=bbox)
+        assert kp.dtype == np.float32
+        assert conf.dtype == np.float32
+        assert kp.ndim == 2
+        assert kp.shape[1] == 2
+        assert conf.shape[0] == kp.shape[0]
+        assert np.all(conf >= 0)
+        assert np.all(conf <= 1)
+        assert np.all(kp[:, 0] >= 0)
+        assert np.all(kp[:, 1] >= 0)
+        assert np.all(kp[:, 0] <= 640 + 1)
+        assert np.all(kp[:, 1] <= 480 + 1)
 
-    kp = result["keypoints"]
-    conf = result["confidence"]
+    def test_predict_frame_bbox_clipping(self, tmp_path, request):
+        """Bbox extending past the frame edge is clipped silently; keypoints stay valid."""
+        model = _setup_test_model(tmp_path, request)
 
-    assert kp.dtype == np.float32
-    assert conf.dtype == np.float32
-    assert kp.ndim == 2
-    assert kp.shape[1] == 2
-    assert conf.shape[0] == kp.shape[0]
+        frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+        # extends 60px past right edge: requested width 200, actual crop width 140
+        bbox = (500, 100, 200, 150)
+        result = model.predict_frame(frame, bbox=bbox)
 
-    # Confidence must be in [0, 1]
-    assert np.all(conf >= 0)
-    assert np.all(conf <= 1)
+        kp = result["keypoints"]
+        conf = result["confidence"]
 
-    # Keypoints should be remapped to original frame coordinates
-    assert np.all(kp[:, 0] >= 0)
-    assert np.all(kp[:, 1] >= 0)
-    assert np.all(kp[:, 0] <= 640 + 1)
-    assert np.all(kp[:, 1] <= 480 + 1)
+        assert kp.dtype == np.float32
+        assert conf.dtype == np.float32
+        assert kp.ndim == 2
+        assert kp.shape[1] == 2
+        assert conf.shape[0] == kp.shape[0]
+        assert np.all(conf >= 0)
+        assert np.all(conf <= 1)
+        assert np.all(kp[:, 0] >= 0)
+        assert np.all(kp[:, 1] >= 0)
+        assert np.all(kp[:, 0] <= 640 + 1)
+        assert np.all(kp[:, 1] <= 480 + 1)
 
 
 class TestModelErrors:
@@ -275,35 +285,6 @@ class TestModelErrors:
         with patch.object(multiview_model, '_load'):
             with pytest.raises(ValueError, match='expected.*video files'):
                 multiview_model.predict_on_video_file_multiview(['only_one.mp4'])
-
-
-def test_predict_frame_bbox_clipping(tmp_path, request):
-    """Bbox extending past frame edge -- numpy clips silently, remap should still be valid."""
-    model = _setup_test_model(tmp_path, request)
-
-    frame = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
-    # Bbox extends 60px past right edge: requested width 200, actual crop width 140
-    bbox = (500, 100, 200, 150)
-    result = model.predict_frame(frame, bbox=bbox)
-
-    kp = result["keypoints"]
-    conf = result["confidence"]
-
-    assert kp.dtype == np.float32
-    assert conf.dtype == np.float32
-    assert kp.ndim == 2
-    assert kp.shape[1] == 2
-    assert conf.shape[0] == kp.shape[0]
-
-    # Confidence in [0, 1]
-    assert np.all(conf >= 0)
-    assert np.all(conf <= 1)
-
-    # Keypoints should remap into the clipped region, not the requested region
-    assert np.all(kp[:, 0] >= 0)
-    assert np.all(kp[:, 1] >= 0)
-    assert np.all(kp[:, 0] <= 640 + 1)
-    assert np.all(kp[:, 1] <= 480 + 1)
 
 
 class TestGetModelClass:

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -1,8 +1,9 @@
 import shutil
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from lightning_pose.api import Model
@@ -116,6 +117,25 @@ class TestPredictOnVideoFile:
         assert (model.video_preds_dir() / "test_vid_top.csv").is_file()
         assert (model.video_preds_dir() / "test_vid_top_temporal_norm.csv").is_file()
         assert (model.labeled_videos_dir() / "test_vid_top_labeled.mp4").is_file()
+
+    def test_predict_on_video_file_bbox_file_forwarded(self, tmp_path):
+        """bbox_file is forwarded to predict_video when provided."""
+        model = Model(tmp_path, MagicMock())
+        bbox_file = tmp_path / 'vid_bbox.csv'
+
+        with (
+            patch.object(model, '_load'),
+            patch(
+                'lightning_pose.api.model.predict_video', return_value=pd.DataFrame(),
+            ) as mock_pv,
+        ):
+            model.predict_on_video_file(
+                video_file=tmp_path / 'vid.mp4',
+                compute_metrics=False,
+                bbox_file=bbox_file,
+            )
+
+        assert mock_pv.call_args.kwargs['bbox_file'] == bbox_file
 
     def test_predict_on_video_file_multiview(self, tmp_path, request, toy_mdata_dir):
         """predict_on_video_file_multiview writes predictions and labeled videos for all views."""

--- a/tests/cli/test_predict.py
+++ b/tests/cli/test_predict.py
@@ -115,8 +115,8 @@ class TestPredictMultiType:
         call_kwargs = mock_model.predict_on_label_csv.call_args.kwargs
         assert call_kwargs['bbox_file'] is None
 
-    def test_mp4_does_not_use_bbox_dir(self, tmp_path, mock_model):
-        """MP4 input ignores bbox_dir (video sub-issue not yet implemented)."""
+    def test_mp4_passes_bbox_file_when_bbox_dir_given(self, tmp_path, mock_model):
+        """MP4 input with bbox_dir passes <bbox_dir>/<stem>_bbox.csv to predict_on_video_file."""
         bbox_dir = tmp_path / 'bboxes'
         video_path = tmp_path / 'vid.mp4'
         _predict_multi_type(
@@ -124,7 +124,16 @@ class TestPredictMultiType:
         )
         mock_model.predict_on_video_file.assert_called_once()
         call_kwargs = mock_model.predict_on_video_file.call_args.kwargs
-        assert 'bbox_file' not in call_kwargs
+        assert call_kwargs['bbox_file'] == bbox_dir / 'vid_bbox.csv'
+
+    def test_mp4_passes_none_bbox_file_when_no_bbox_dir(self, tmp_path, mock_model):
+        """MP4 input without bbox_dir passes bbox_file=None to predict_on_video_file."""
+        video_path = tmp_path / 'vid.mp4'
+        _predict_multi_type(
+            mock_model, video_path, skip_viz=True, skip_existing=False, bbox_dir=None,
+        )
+        call_kwargs = mock_model.predict_on_video_file.call_args.kwargs
+        assert call_kwargs['bbox_file'] is None
 
     def test_directory_input_with_bbox_dir_recurses_into_mp4s(self, tmp_path, mock_model):
         """A directory input with bbox_dir passes through to each recursive mp4 call."""

--- a/tests/data/test_dali.py
+++ b/tests/data/test_dali.py
@@ -400,3 +400,22 @@ class TestLitDaliWrapper:
         )
         result = wrapper._apply_bbox_crop(batch)
         assert torch.equal(result['transforms'], transforms)
+
+    def test_negative_xy_clamped(self):
+        """Negative x/y from edge-frame bbox are clamped to 0; stored bbox reflects actual crop.
+
+        create_bbox computes topleft = centroid - size//2, which goes negative for animals
+        near the frame edge. pytorch slice indices are not clamped — a negative start index
+        counts from the end of the tensor, producing an empty crop.
+        """
+        neg_df = pd.DataFrame({'x': [-10], 'y': [-5], 'h': [50], 'w': [60]})
+        wrapper = self._make_wrapper(neg_df, resize_dims=[64, 64])
+        # frame 100 tall x 120 wide
+        batch = self._make_batch(seq_len=1, h=100, w=120)
+        result = wrapper._apply_bbox_crop(batch)
+
+        # frame must be cropped+resized without error
+        assert result['frames'].shape == (1, 3, 64, 64)
+        # clamped: x1=0, y1=0, x2=min(120,-10+60)=50, y2=min(100,-5+50)=45 → [0,0,45,50]
+        expected_bbox = torch.tensor([0.0, 0.0, 45.0, 50.0])
+        assert torch.allclose(result['bbox'][0], expected_bbox)

--- a/tests/data/test_dali.py
+++ b/tests/data/test_dali.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -254,6 +255,56 @@ class TestPrepareDALI:
                 dali_config=cfg_multiview.dali,
                 resize_dims=[256, 256],
             )
+
+    def test_bbox_df_sets_none_resize_dims_in_predict_pipes(self, cfg, video_list):
+        """When bbox_df is provided, resize_dims is None in both predict pipe arg dicts."""
+        bbox_df = pd.DataFrame({'x': [0], 'y': [0], 'h': [100], 'w': [100]})
+        vid_pred_class = PrepareDALI(
+            train_stage='predict',
+            model_type='base',
+            filenames=video_list,
+            dali_config=cfg.dali,
+            resize_dims=[128, 128],
+            bbox_df=bbox_df,
+        )
+        assert vid_pred_class._pipe_dict['predict']['base']['resize_dims'] is None
+        assert vid_pred_class._pipe_dict['predict']['context']['resize_dims'] is None
+
+    def test_bbox_df_preserves_train_pipe_resize_dims(self, cfg, video_list):
+        """When bbox_df is provided, train pipe resize_dims is unchanged."""
+        resize_dims = [128, 128]
+        bbox_df = pd.DataFrame({'x': [0], 'y': [0], 'h': [100], 'w': [100]})
+        vid_pred_class = PrepareDALI(
+            train_stage='predict',
+            model_type='base',
+            filenames=video_list,
+            dali_config=cfg.dali,
+            resize_dims=resize_dims,
+            bbox_df=bbox_df,
+        )
+        assert vid_pred_class._pipe_dict['train']['base']['resize_dims'] == resize_dims
+        assert vid_pred_class._pipe_dict['train']['context']['resize_dims'] == resize_dims
+
+    def test_bbox_df_forwarded_to_lit_dali_wrapper(self, cfg, video_list):
+        """__call__ passes bbox_df and the original resize_dims to LitDaliWrapper."""
+        resize_dims = [128, 128]
+        bbox_df = pd.DataFrame({'x': [0], 'y': [0], 'h': [100], 'w': [100]})
+        vid_pred_class = PrepareDALI(
+            train_stage='predict',
+            model_type='base',
+            filenames=video_list,
+            dali_config=cfg.dali,
+            resize_dims=resize_dims,
+            bbox_df=bbox_df,
+        )
+        with (
+            patch.object(vid_pred_class, '_get_dali_pipe', return_value=MagicMock()),
+            patch('lightning_pose.data.dali.LitDaliWrapper') as MockWrapper,
+        ):
+            vid_pred_class()
+        call_kwargs = MockWrapper.call_args.kwargs
+        assert call_kwargs['bbox_df'] is bbox_df
+        assert call_kwargs['resize_dims'] == resize_dims
 
 
 class TestLitDaliWrapper:

--- a/tests/data/test_dali.py
+++ b/tests/data/test_dali.py
@@ -4,10 +4,13 @@ import os
 import shutil
 
 import numpy as np
+import pandas as pd
 import pytest
+import torch
 
 from lightning_pose.data import dali as dali_module
-from lightning_pose.data.dali import PrepareDALI, video_pipe
+from lightning_pose.data.dali import LitDaliWrapper, PrepareDALI, video_pipe
+from lightning_pose.data.datatypes import UnlabeledBatchDict
 
 
 class TestVideoPipe:
@@ -251,3 +254,98 @@ class TestPrepareDALI:
                 dali_config=cfg_multiview.dali,
                 resize_dims=[256, 256],
             )
+
+
+class TestLitDaliWrapper:
+    """Test the LitDaliWrapper class."""
+
+    @pytest.fixture
+    def bbox_df(self):
+        """Sample bbox DataFrame with 10 rows."""
+        return pd.DataFrame({
+            'x': [10] * 10,
+            'y': [20] * 10,
+            'h': [50] * 10,
+            'w': [60] * 10,
+        })
+
+    def _make_wrapper(
+        self,
+        bbox_df: pd.DataFrame,
+        resize_dims: list[int],
+        do_context: bool = False,
+        frame_idx: int = 0,
+    ) -> LitDaliWrapper:
+        """Create a LitDaliWrapper without a real DALI pipeline."""
+        wrapper = object.__new__(LitDaliWrapper)
+        wrapper.do_context = do_context
+        wrapper.bbox_df = bbox_df
+        wrapper.resize_dims = resize_dims
+        wrapper._frame_idx = frame_idx
+        return wrapper
+
+    def _make_batch(self, seq_len: int, h: int = 100, w: int = 120) -> UnlabeledBatchDict:
+        """Create a fake single-view UnlabeledBatchDict with random frames."""
+        return UnlabeledBatchDict(
+            frames=torch.rand(seq_len, 3, h, w),
+            transforms=torch.zeros(seq_len, 1),
+            bbox=torch.zeros(seq_len, 4),
+            is_multiview=False,
+        )
+
+    def test_output_frames_shape(self, bbox_df):
+        """Cropped+resized frames have shape (seq_len, 3, *resize_dims)."""
+        resize_dims = [64, 64]
+        wrapper = self._make_wrapper(bbox_df, resize_dims)
+        batch = self._make_batch(seq_len=4)
+        result = wrapper._apply_bbox_crop(batch)
+        assert result['frames'].shape == (4, 3, 64, 64)
+
+    def test_bbox_tensor_values(self, bbox_df):
+        """Output bbox tensor contains [x, y, h, w] values from bbox_df."""
+        wrapper = self._make_wrapper(bbox_df, resize_dims=[64, 64])
+        batch = self._make_batch(seq_len=3)
+        result = wrapper._apply_bbox_crop(batch)
+        expected = torch.tensor([10, 20, 50, 60], dtype=torch.float32)
+        for i in range(3):
+            assert torch.allclose(result['bbox'][i], expected)
+
+    def test_advances_frame_idx_base(self, bbox_df):
+        """_frame_idx advances by seq_len for a base (non-context) model."""
+        wrapper = self._make_wrapper(bbox_df, resize_dims=[64, 64], do_context=False)
+        wrapper._apply_bbox_crop(self._make_batch(seq_len=4))
+        assert wrapper._frame_idx == 4
+
+    def test_advances_frame_idx_context(self, bbox_df):
+        """_frame_idx advances by seq_len - 4 for a context model."""
+        wrapper = self._make_wrapper(bbox_df, resize_dims=[64, 64], do_context=True)
+        wrapper._apply_bbox_crop(self._make_batch(seq_len=5))
+        assert wrapper._frame_idx == 1  # step = seq_len - 4 = 1
+
+    def test_pads_last_partial_batch(self):
+        """Last batch is padded with the final bbox row when fewer rows remain."""
+        two_row_df = pd.DataFrame({
+            'x': [10, 20],
+            'y': [10, 20],
+            'h': [50, 60],
+            'w': [50, 60],
+        })
+        wrapper = self._make_wrapper(two_row_df, resize_dims=[64, 64], frame_idx=1)
+        result = wrapper._apply_bbox_crop(self._make_batch(seq_len=4))
+        assert result['bbox'].shape == (4, 4)
+        expected_last = torch.tensor([20, 20, 60, 60], dtype=torch.float32)
+        for i in range(4):
+            assert torch.allclose(result['bbox'][i], expected_last)
+
+    def test_transforms_preserved(self, bbox_df):
+        """The transforms field from the original batch dict is passed through unchanged."""
+        wrapper = self._make_wrapper(bbox_df, resize_dims=[64, 64])
+        transforms = torch.tensor([[1.0], [2.0], [3.0]])
+        batch = UnlabeledBatchDict(
+            frames=torch.rand(3, 3, 100, 120),
+            transforms=transforms,
+            bbox=torch.zeros(3, 4),
+            is_multiview=False,
+        )
+        result = wrapper._apply_bbox_crop(batch)
+        assert torch.equal(result['transforms'], transforms)

--- a/tests/data/test_dali.py
+++ b/tests/data/test_dali.py
@@ -1,288 +1,253 @@
 """Test dali dataloading functionality."""
 
 import os
+import shutil
 
 import numpy as np
 import pytest
 
-
-def test_video_pipe_single_view(video_list):
-
-    from lightning_pose.data.dali import video_pipe
-
-    batch_size = 2
-    seq_len = 7
-    im_height = 256
-    im_width = 256
-    n_iter = 2
-
-    pipe = video_pipe(
-        filenames=video_list,
-        resize_dims=[im_height, im_width],
-        sequence_length=seq_len,
-        batch_size=batch_size,
-        device_id=0,
-        num_threads=2,
-    )
-    pipe.build()
-    for _ in range(n_iter):
-        pipe_out = pipe.run()
-        assert len(pipe_out) == 3  # frames, transforms, orig_frame_size
-        sequences_out = pipe_out[0].as_cpu().as_array()
-        assert sequences_out.shape == (batch_size, seq_len, 3, im_height, im_width)
-
-    # remove data from gpu; then cache can be cleared
-    del pipe
+from lightning_pose.data import dali as dali_module
+from lightning_pose.data.dali import PrepareDALI, video_pipe
 
 
-def test_video_pipe_multiview(video_list):
+class TestVideoPipe:
+    """Test the video_pipe function."""
 
-    from lightning_pose.data.dali import video_pipe
+    def test_single_view(self, video_list):
+        """Single-view pipeline yields (frames, transforms, frame_size) tuples of correct shape."""
+        batch_size = 2
+        seq_len = 7
+        im_height = 256
+        im_width = 256
+        n_iter = 2
 
-    batch_size = 2
-    seq_len = 7
-    im_height = 256
-    im_width = 256
-    n_iter = 2
-
-    pipe = video_pipe(
-        filenames=[video_list, video_list],
-        resize_dims=[im_height, im_width],
-        sequence_length=seq_len,
-        batch_size=batch_size,
-        device_id=0,
-        num_threads=2,
-    )
-    pipe.build()
-    for _ in range(n_iter):
-        pipe_out = pipe.run()
-        assert len(pipe_out) == 2 * 3  # num_views * (frames, transforms, orig_frame_size)
-        # test sizes of frames from view 0
-        sequences_out_0 = pipe_out[0].as_cpu().as_array()
-        assert sequences_out_0.shape == (batch_size, seq_len, 3, im_height, im_width)
-        # test sizes of frames from view 1
-        sequences_out_1 = pipe_out[1].as_cpu().as_array()
-        assert sequences_out_1.shape == (batch_size, seq_len, 3, im_height, im_width)
-        # make sure frames match (the different "views" correspond to the same video here)
-        assert np.allclose(sequences_out_0[0, 0, 0], sequences_out_1[0, 0, 0])
-        # make sure frames from different indices don't match
-        assert not np.allclose(sequences_out_0[0, 0, 0], sequences_out_0[0, seq_len - 1, 0])
-
-    # remove data from gpu; then cache can be cleared
-    del pipe
-
-
-def test_prepare_dali_single_view(cfg, video_list):
-
-    from lightning_pose.data.dali import PrepareDALI
-
-    im_height = 256
-    im_width = 256
-
-    filenames = video_list
-    assert os.path.isfile(filenames[0])
-
-    # -----------------------
-    # base model
-    # -----------------------
-    vid_pred_class = PrepareDALI(
-        train_stage="predict",
-        model_type="base",
-        filenames=filenames,
-        dali_config=cfg.dali,
-        resize_dims=[im_height, im_width],
-    )
-    loader = vid_pred_class()
-    num_iters = vid_pred_class.num_iters
-
-    # always sequence length should be fixed.
-    batch_idx = -1
-    for _, batch in enumerate(loader):
-        assert batch["frames"].shape == (
-            cfg.dali.base.predict.sequence_length,
-            3,  # channels
-            im_height,
-            im_width,
+        pipe = video_pipe(
+            filenames=video_list,
+            resize_dims=[im_height, im_width],
+            sequence_length=seq_len,
+            batch_size=batch_size,
+            device_id=0,
+            num_threads=2,
         )
-        batch_idx += 1
-    assert batch_idx == num_iters - 1  # we have the right number of batches drawn
+        pipe.build()
+        for _ in range(n_iter):
+            pipe_out = pipe.run()
+            assert len(pipe_out) == 3  # frames, transforms, orig_frame_size
+            sequences_out = pipe_out[0].as_cpu().as_array()
+            assert sequences_out.shape == (batch_size, seq_len, 3, im_height, im_width)
 
-    # -----------------------
-    # context model
-    # -----------------------
-    # different looking batch and shapes
-    vid_pred_class = PrepareDALI(
-        train_stage="predict",
-        model_type="context",
-        filenames=filenames,
-        dali_config=cfg.dali,
-        resize_dims=[im_height, im_width],
-    )
-    loader = vid_pred_class()
-    num_iters = vid_pred_class.num_iters
+        del pipe
 
-    # this one assumes we have only two images in the last batch
-    # NOTE: this is a specific property of this video and the context!
-    batch_idx = -1
-    for _i, batch in enumerate(loader):
-        assert batch["frames"].shape == (
-            cfg.dali.context.predict.sequence_length,
-            3,  # channels
-            im_height,
-            im_width,
+    def test_multiview(self, video_list):
+        """Multi-view pipeline yields per-view tuples; identical videos produce matching frames."""
+        batch_size = 2
+        seq_len = 7
+        im_height = 256
+        im_width = 256
+        n_iter = 2
+
+        pipe = video_pipe(
+            filenames=[video_list, video_list],
+            resize_dims=[im_height, im_width],
+            sequence_length=seq_len,
+            batch_size=batch_size,
+            device_id=0,
+            num_threads=2,
         )
-        batch_idx += 1
-    assert batch_idx == num_iters - 1
+        pipe.build()
+        for _ in range(n_iter):
+            pipe_out = pipe.run()
+            assert len(pipe_out) == 2 * 3  # num_views * (frames, transforms, orig_frame_size)
+            sequences_out_0 = pipe_out[0].as_cpu().as_array()
+            assert sequences_out_0.shape == (batch_size, seq_len, 3, im_height, im_width)
+            sequences_out_1 = pipe_out[1].as_cpu().as_array()
+            assert sequences_out_1.shape == (batch_size, seq_len, 3, im_height, im_width)
+            # same source video → same frames across views
+            assert np.allclose(sequences_out_0[0, 0, 0], sequences_out_1[0, 0, 0])
+            # different time indices produce different frames
+            assert not np.allclose(sequences_out_0[0, 0, 0], sequences_out_0[0, seq_len - 1, 0])
 
-    # error is thrown if one of the video files does not exist
-    with pytest.raises(FileNotFoundError):
-        PrepareDALI(
-            train_stage="predict",
-            model_type="base",
-            filenames=[filenames[0] + '_bad-id.mp4'],
+        del pipe
+
+
+class TestPrepareDALI:
+    """Test the PrepareDALI class."""
+
+    def test_single_view_base_predict(self, cfg, video_list):
+        """Base model predict loader yields batches of the configured sequence length and dims."""
+        im_height = 256
+        im_width = 256
+
+        vid_pred_class = PrepareDALI(
+            train_stage='predict',
+            model_type='base',
+            filenames=video_list,
             dali_config=cfg.dali,
             resize_dims=[im_height, im_width],
         )
+        loader = vid_pred_class()
+        num_iters = vid_pred_class.num_iters
 
-    # error is thrown if one of the video files is not a file
-    with pytest.raises(FileNotFoundError):
-        PrepareDALI(
-            train_stage="predict",
-            model_type="base",
-            filenames=[os.path.dirname(filenames[0])],
+        batch_idx = -1
+        for _, batch in enumerate(loader):
+            assert batch['frames'].shape == (
+                cfg.dali.base.predict.sequence_length,
+                3,
+                im_height,
+                im_width,
+            )
+            batch_idx += 1
+        assert batch_idx == num_iters - 1
+
+    def test_single_view_context_predict(self, cfg, video_list):
+        """Context model predict loader yields batches of the context sequence length and dims."""
+        im_height = 256
+        im_width = 256
+
+        vid_pred_class = PrepareDALI(
+            train_stage='predict',
+            model_type='context',
+            filenames=video_list,
             dali_config=cfg.dali,
             resize_dims=[im_height, im_width],
         )
+        loader = vid_pred_class()
+        num_iters = vid_pred_class.num_iters
 
+        batch_idx = -1
+        for _, batch in enumerate(loader):
+            assert batch['frames'].shape == (
+                cfg.dali.context.predict.sequence_length,
+                3,
+                im_height,
+                im_width,
+            )
+            batch_idx += 1
+        assert batch_idx == num_iters - 1
 
-def test_prepare_dali_multiview(cfg_multiview, video_list):
+    def test_single_view_raises_on_nonexistent_file(self, cfg, video_list):
+        """FileNotFoundError is raised when a video path does not exist."""
+        with pytest.raises(FileNotFoundError):
+            PrepareDALI(
+                train_stage='predict',
+                model_type='base',
+                filenames=[video_list[0] + '_bad-id.mp4'],
+                dali_config=cfg.dali,
+                resize_dims=[256, 256],
+            )
 
-    from lightning_pose.data.dali import PrepareDALI
+    def test_single_view_raises_when_path_is_directory(self, cfg, video_list):
+        """FileNotFoundError is raised when a video path points to a directory."""
+        with pytest.raises(FileNotFoundError):
+            PrepareDALI(
+                train_stage='predict',
+                model_type='base',
+                filenames=[os.path.dirname(video_list[0])],
+                dali_config=cfg.dali,
+                resize_dims=[256, 256],
+            )
 
-    im_height = 256
-    im_width = 256
+    def test_multiview_base_train_and_predict(self, cfg_multiview, video_list):
+        """Multi-view base model batches have correct shape for train and predict stages."""
+        im_height = 256
+        im_width = 256
+        num_views = 2
+        filenames = [video_list] * num_views
 
-    num_views = 2
-    filenames = [video_list] * num_views  # really just copies of the same video
+        for train_stage in ['train', 'predict']:
+            vid_pred_class = PrepareDALI(
+                train_stage=train_stage,  # type: ignore[arg-type]
+                model_type='base',
+                filenames=filenames,
+                dali_config=cfg_multiview.dali,
+                resize_dims=[im_height, im_width],
+            )
+            loader = vid_pred_class()
+            batch_size = (
+                cfg_multiview.dali.base.train.sequence_length
+                if train_stage == 'train'
+                else cfg_multiview.dali.base.predict.sequence_length
+            )
+            batch = loader.__next__()
+            assert batch['frames'].shape == (batch_size, num_views, 3, im_height, im_width)
+            assert batch['transforms'].shape == (num_views, 1, 1)
+            assert batch['bbox'].shape == (batch_size, num_views * 4)
 
-    # -----------------------
-    # base model
-    # -----------------------
-    for train_stage in ["train", "predict"]:
+    def test_multiview_context_train_and_predict(self, cfg_multiview, video_list):
+        """Multi-view context model batches have correct shape for train and predict stages."""
+        im_height = 256
+        im_width = 256
+        num_views = 2
+        filenames = [video_list] * num_views
+
+        for train_stage in ['train', 'predict']:
+            vid_pred_class = PrepareDALI(
+                train_stage=train_stage,  # type: ignore[arg-type]
+                model_type='context',
+                filenames=filenames,
+                dali_config=cfg_multiview.dali,
+                resize_dims=[im_height, im_width],
+            )
+            loader = vid_pred_class()
+            batch_size = (
+                cfg_multiview.dali.context.train.batch_size
+                if train_stage == 'train'
+                else cfg_multiview.dali.context.predict.sequence_length
+            )
+            batch = loader.__next__()
+            assert batch['frames'].shape == (batch_size, num_views, 3, im_height, im_width)
+            assert batch['transforms'].shape == (num_views, 1, 1)
+            assert batch['bbox'].shape == (batch_size, num_views * 4)
+
+    def test_multiview_synchronized_frames(self, cfg_multiview, video_list):
+        """Shared reader seed keeps per-view frames synchronized under random shuffle."""
+        num_views = 3
+        filenames = [video_list] * num_views
 
         vid_pred_class = PrepareDALI(
-            train_stage=train_stage,  # type: ignore[arg-type]
-            model_type="base",
+            train_stage='train',
+            model_type='base',
             filenames=filenames,
             dali_config=cfg_multiview.dali,
-            resize_dims=[im_height, im_width],
+            resize_dims=[256, 256],
+            imgaug='default',
         )
         loader = vid_pred_class()
+        for _ in range(4):
+            batch = loader.__next__()
+            frames = batch['frames'].cpu().numpy()
+            for view in range(1, num_views):
+                assert np.allclose(frames[:, 0], frames[:, view])
+            # sanity: shuffled sequences still contain distinct frames, not a static clip
+            assert not np.allclose(frames[:, 0, 0], frames[:, 0, -1])
 
-        # sequence length should be fixed for all batches
-        if train_stage == "train":
-            batch_size = cfg_multiview.dali.base.train.sequence_length
-        else:
-            batch_size = cfg_multiview.dali.base.predict.sequence_length
-        frame_shape = (
-            batch_size,
-            num_views,
-            3,  # channels
-            im_height,
-            im_width,
+    def test_multiview_raises_on_unequal_session_count(self, cfg_multiview, video_list):
+        """ValueError is raised when views have different numbers of sessions."""
+        vid = video_list[0]
+        with pytest.raises(ValueError, match='same number of sessions'):
+            PrepareDALI(
+                train_stage='train',
+                model_type='base',
+                filenames=[[vid, vid], [vid]],
+                dali_config=cfg_multiview.dali,
+                resize_dims=[256, 256],
+            )
+
+    def test_multiview_raises_on_unequal_frame_counts(
+        self, cfg_multiview, video_list, tmp_path, monkeypatch,
+    ):
+        """ValueError is raised when frame counts differ across views for the same session."""
+        vid = video_list[0]
+        vid_copy = str(tmp_path / 'view1_session0.mp4')
+        shutil.copy(vid, vid_copy)
+        monkeypatch.setattr(
+            dali_module, 'count_frames', lambda p: {vid: 100, vid_copy: 90}[p],
         )
-        # just check a single batch
-        batch = loader.__next__()
-        assert batch["frames"].shape == frame_shape
-        assert batch["transforms"].shape == (num_views, 1, 1)
-        assert batch["bbox"].shape == (batch_size, num_views * 4)  # num_views * xyhw
-
-    # -----------------------
-    # context model
-    # -----------------------
-    for train_stage in ["train", "predict"]:
-
-        vid_pred_class = PrepareDALI(
-            train_stage=train_stage,  # type: ignore[arg-type]
-            model_type="context",
-            filenames=filenames,
-            dali_config=cfg_multiview.dali,
-            resize_dims=[im_height, im_width],
-        )
-        loader = vid_pred_class()
-
-        # sequence length should be fixed for all batches
-        if train_stage == "train":
-            batch_size = cfg_multiview.dali.context.train.batch_size
-        else:
-            batch_size = cfg_multiview.dali.context.predict.sequence_length
-        frame_shape = (
-            batch_size,
-            num_views,
-            3,  # channels
-            im_height,
-            im_width,
-        )
-        # just check a single batch
-        batch = loader.__next__()
-        assert batch["frames"].shape == frame_shape
-        assert batch["transforms"].shape == (num_views, 1, 1)
-        assert batch["bbox"].shape == (batch_size, num_views * 4)  # num_views * xyhw
-
-
-def test_prepare_dali_multiview_synchronized(cfg_multiview, video_list, tmp_path, monkeypatch):
-
-    import shutil
-
-    from lightning_pose.data import dali as dali_module
-    from lightning_pose.data.dali import PrepareDALI
-
-    im_height = 256
-    im_width = 256
-
-    num_views = 3
-    filenames = [video_list] * num_views  # really just copies of the same video
-
-    vid_pred_class = PrepareDALI(
-        train_stage="train",  # random_shuffle is True for training
-        model_type="base",
-        filenames=filenames,
-        dali_config=cfg_multiview.dali,
-        resize_dims=[im_height, im_width],
-        imgaug="default",  # no per-view augmentation, so frames are directly comparable
-    )
-
-    # all per-view readers share the same seed, so under random_shuffle every view must read the
-    # exact same frames (same session + timepoints) on every batch
-    loader = vid_pred_class()
-    for _ in range(4):
-        batch = loader.__next__()
-        frames = batch["frames"].cpu().numpy()  # (batch, num_views, channels, height, width)
-        for view in range(1, num_views):
-            assert np.allclose(frames[:, 0], frames[:, view])
-        # sanity: a shuffled sequence still contains distinct frames (not a constant clip)
-        assert not np.allclose(frames[:, 0, 0], frames[:, 0, -1])
-
-    # error is thrown if views have a different number of sessions
-    vid = video_list[0]
-    with pytest.raises(ValueError, match="same number of sessions"):
-        PrepareDALI(
-            train_stage="train",
-            model_type="base",
-            filenames=[[vid, vid], [vid]],
-            dali_config=cfg_multiview.dali,
-            resize_dims=[im_height, im_width],
-        )
-
-    # error is thrown if a session has different frame counts across views
-    vid_copy = str(tmp_path / "view1_session0.mp4")
-    shutil.copy(vid, vid_copy)
-    monkeypatch.setattr(dali_module, "count_frames", lambda p: {vid: 100, vid_copy: 90}[p])
-    with pytest.raises(ValueError, match="frame counts across views"):
-        PrepareDALI(
-            train_stage="train",
-            model_type="base",
-            filenames=[[vid], [vid_copy]],
-            dali_config=cfg_multiview.dali,
-            resize_dims=[im_height, im_width],
-        )
+        with pytest.raises(ValueError, match='frame counts across views'):
+            PrepareDALI(
+                train_stage='train',
+                model_type='base',
+                filenames=[[vid], [vid_copy]],
+                dali_config=cfg_multiview.dali,
+                resize_dims=[256, 256],
+            )

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -152,9 +152,10 @@ class TestPredictVideoBboxFile:
         bbox_file, _ = bbox_csv
         mock_model.config.cfg.data.view_names = ['view0', 'view1']
 
+        video_files = [str(tmp_path / 'view0.mp4'), str(tmp_path / 'view1.mp4')]
         with pytest.raises(ValueError, match='bbox_file is not supported for multiview'):
             predict_video(
-                video_file=[str(tmp_path / 'view0.mp4'), str(tmp_path / 'view1.mp4')],
+                video_file=video_files,  # type: ignore[arg-type]
                 model=mock_model,
                 bbox_file=bbox_file,
             )

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -1,7 +1,7 @@
 """Test the predictions module."""
 
 import copy
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -9,7 +9,7 @@ from omegaconf import OmegaConf
 
 from lightning_pose.losses import get_loss_factories
 from lightning_pose.models import get_model
-from lightning_pose.utils.predictions import make_dlc_pandas_index, predict_dataset
+from lightning_pose.utils.predictions import make_dlc_pandas_index, predict_dataset, predict_video
 
 
 class TestMakeDlcPandasIndex:
@@ -81,3 +81,82 @@ class TestPredictDataset:
             data_module=heatmap_data_module,
             preds_file=str(tmpdir.join('preds.csv')),
         )
+
+
+class TestPredictVideoBboxFile:
+    """Test bbox_file support in predict_video."""
+
+    @pytest.fixture
+    def mock_model(self):
+        """Minimal Model mock compatible with predict_video."""
+        model = MagicMock()
+        model.config.cfg.model.model_type = 'heatmap'
+        model.config.cfg.data.image_resize_dims.height = 256
+        model.config.cfg.data.image_resize_dims.width = 256
+        return model
+
+    @pytest.fixture
+    def bbox_csv(self, tmp_path):
+        """3-row bbox CSV; returns (path, dataframe)."""
+        df = pd.DataFrame({
+            'x': [0, 1, 2],
+            'y': [0, 1, 2],
+            'h': [10, 10, 10],
+            'w': [10, 10, 10],
+        })
+        path = tmp_path / 'bbox.csv'
+        df.to_csv(path)
+        return path, df
+
+    def test_bbox_df_forwarded_to_prepare_dali(self, tmp_path, mock_model, bbox_csv):
+        """PrepareDALI receives the loaded bbox_df when bbox_file is provided."""
+        bbox_file, _ = bbox_csv
+        mock_dali = MagicMock()
+
+        with (
+            patch('lightning_pose.utils.predictions.count_frames', return_value=3),
+            patch('lightning_pose.utils.predictions.PrepareDALI', mock_dali),
+            patch('lightning_pose.utils.predictions.pl.Trainer'),
+            patch('lightning_pose.utils.predictions.PredictionHandler'),
+        ):
+            predict_video(
+                video_file=str(tmp_path / 'vid.mp4'),
+                model=mock_model,
+                bbox_file=bbox_file,
+            )
+
+        call_kwargs = mock_dali.call_args.kwargs
+        assert call_kwargs['bbox_df'] is not None
+        assert list(call_kwargs['bbox_df'].columns) == ['x', 'y', 'h', 'w']
+        assert len(call_kwargs['bbox_df']) == 3
+
+    def test_none_bbox_df_when_bbox_file_not_provided(self, tmp_path, mock_model):
+        """PrepareDALI receives bbox_df=None when bbox_file is not provided."""
+        mock_dali = MagicMock()
+
+        with (
+            patch('lightning_pose.utils.predictions.PrepareDALI', mock_dali),
+            patch('lightning_pose.utils.predictions.pl.Trainer'),
+            patch('lightning_pose.utils.predictions.PredictionHandler'),
+        ):
+            predict_video(
+                video_file=str(tmp_path / 'vid.mp4'),
+                model=mock_model,
+            )
+
+        call_kwargs = mock_dali.call_args.kwargs
+        assert call_kwargs['bbox_df'] is None
+
+    def test_raises_on_frame_count_mismatch(self, tmp_path, mock_model, bbox_csv):
+        """ValueError is raised when bbox_file row count doesn't match video frame count."""
+        bbox_file, _ = bbox_csv  # 3 rows
+
+        with patch('lightning_pose.utils.predictions.count_frames', return_value=10):
+            with pytest.raises(
+                ValueError, match='bbox_file has 3 rows but video has 10 frames',
+            ):
+                predict_video(
+                    video_file=str(tmp_path / 'vid.mp4'),
+                    model=mock_model,
+                    bbox_file=bbox_file,
+                )

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -147,6 +147,18 @@ class TestPredictVideoBboxFile:
         call_kwargs = mock_dali.call_args.kwargs
         assert call_kwargs['bbox_df'] is None
 
+    def test_raises_when_bbox_file_given_for_multiview(self, tmp_path, mock_model, bbox_csv):
+        """ValueError is raised when bbox_file is provided alongside a multiview video list."""
+        bbox_file, _ = bbox_csv
+        mock_model.config.cfg.data.view_names = ['view0', 'view1']
+
+        with pytest.raises(ValueError, match='bbox_file is not supported for multiview'):
+            predict_video(
+                video_file=[str(tmp_path / 'view0.mp4'), str(tmp_path / 'view1.mp4')],
+                model=mock_model,
+                bbox_file=bbox_file,
+            )
+
     def test_raises_on_frame_count_mismatch(self, tmp_path, mock_model, bbox_csv):
         """ValueError is raised when bbox_file row count doesn't match video frame count."""
         bbox_file, _ = bbox_csv  # 3 rows


### PR DESCRIPTION
Skip `litpose crop` command for cropzoom pipeline, which creates intermediate cropped videos before running pose estimation; just use bboxes and frames at original resolution. This PR applies to videos, not labeled frames (already completed in #424).

closes #423 