### PR TITLE
expand post-train eval to `_new` and `_tests` label files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,3 +215,19 @@ frame. The index column is ignored on read.
 **Data flow**: `litpose predict --bbox_dir` → `_predict_multi_type` →
 `model.predict_on_video_file(bbox_file=...)` → `predict_video(bbox_file=...)` →
 `PrepareDALI(bbox_df=...)` → `LitDaliWrapper._apply_bbox_crop`.
+
+### Post-training evaluation (`lightning_pose/train.py`)
+
+After training, `train()` calls `_evaluate_on_training_dataset(model, suffix=...)` three times:
+
+1. `suffix=None` — runs inference on the base training CSV (`data.csv_file`). Passes
+   `add_train_val_test_set=True` so metrics are split by train/val/test set membership.
+2. `suffix='_new'` — looks for `{csv_stem}_new.csv`; intended for OOD labeled frames added after
+   training.
+3. `suffix='_test'` — looks for `{csv_stem}_test.csv`; intended for a held-out test set.
+
+Calls with a suffix are silently skipped when the suffixed file does not exist.
+
+**Output**: prediction CSVs are written under `image_preds/{csv_filename}/predictions*.csv` by
+`model.predict_on_label_csv`, then copied to `model_dir/predictions[_{view}][{metric_suffix}][{suffix}].csv`
+for backward compatibility.

--- a/lightning_pose/train.py
+++ b/lightning_pose/train.py
@@ -109,7 +109,8 @@ def train(
 
     if not skip_evaluation:
         _evaluate_on_training_dataset(model)
-        _evaluate_on_training_dataset(model, ood_mode=True)
+        _evaluate_on_training_dataset(model, suffix='_new')
+        _evaluate_on_training_dataset(model, suffix='_test')
         _predict_test_videos(model)
 
     # Update status file to COMPLETED
@@ -142,30 +143,38 @@ def _absolute_csv_file(csv_file: str | Path, data_dir: str | Path) -> Path:
     return csv_file
 
 
-def _evaluate_on_training_dataset(model: Model, ood_mode: bool = False) -> None:
-    """Arguments:
-    ood_mode: look for "_new"-suffixed versions of the training csv file"""
+def _evaluate_on_training_dataset(model: Model, suffix: str | None = None) -> None:
+    """Run inference on a labeled CSV dataset after training.
+
+    Args:
+        model: trained model used for prediction.
+        suffix: if provided, appends this string to the training CSV stem before looking for the
+            file (e.g. ``'_new'`` or ``'_test'``). When ``None``, uses the original training CSV.
+            When a suffix is given the call is silently skipped if the file does not exist.
+    """
     if model.config.is_single_view():
         csv_file = _absolute_csv_file(
             model.config.cfg.data.csv_file, model.config.cfg.data.data_dir
         )
-        if ood_mode:
-            csv_file = csv_file.with_stem(csv_file.stem + "_new")
+        if suffix:
+            csv_file = csv_file.with_stem(csv_file.stem + suffix)
         csv_files = [csv_file]
     else:
         csv_files = []
         for csv_file in model.config.cfg.data.csv_file:
             csv_file = _absolute_csv_file(csv_file, model.config.cfg.data.data_dir)
-            if ood_mode:
-                csv_file = csv_file.with_stem(csv_file.stem + "_new")
+            if suffix:
+                csv_file = csv_file.with_stem(csv_file.stem + suffix)
             csv_files.append(csv_file)
         if model.config.cfg.data.get("camera_params_file"):
             camera_params_file = _absolute_csv_file(
                 model.config.cfg.data.camera_params_file,
                 model.config.cfg.data.data_dir,
             )
-            if ood_mode:
-                camera_params_file = camera_params_file.with_stem(camera_params_file.stem + "_new")
+            if suffix:
+                camera_params_file = camera_params_file.with_stem(
+                    camera_params_file.stem + suffix
+                )
         else:
             camera_params_file = None
 
@@ -180,19 +189,18 @@ def _evaluate_on_training_dataset(model: Model, ood_mode: bool = False) -> None:
         #     bbox_files = []
         #     for bbox_file in model.config.cfg.data.bbox_file:
         #         bbox_file = _absolute_csv_file(bbox_file, model.config.cfg.data.data_dir)
-        #         if ood_mode:
-        #             bbox_file = bbox_file.with_stem(bbox_file.stem + "_new")
+        #         if suffix:
+        #             bbox_file = bbox_file.with_stem(bbox_file.stem + suffix)
         #         bbox_files.append(bbox_file)
         # else:
         #     bbox_files = None
 
-    # ood mode: skip prediction when _new files don't exist.
-    if ood_mode and not csv_files[0].exists():
+    # skip silently when the suffixed file does not exist.
+    if suffix and not csv_files[0].exists():
         return
 
-    # Print a custom message when in OOD mode.
-    if ood_mode:
-        pretty_print_str("Predicting OOD images...")
+    if suffix:
+        pretty_print_str(f"Predicting {suffix.lstrip('_')} images...")
     else:
         pretty_print_str("Predicting train/val/test images...")
 
@@ -204,7 +212,7 @@ def _evaluate_on_training_dataset(model: Model, ood_mode: bool = False) -> None:
             camera_params_file=camera_params_file,
             data_dir=model.config.cfg.data.data_dir,
             compute_metrics=True,
-            add_train_val_test_set=(not ood_mode),
+            add_train_val_test_set=(suffix is None),
         )
     else:
         csv_file = csv_files[0]
@@ -212,7 +220,7 @@ def _evaluate_on_training_dataset(model: Model, ood_mode: bool = False) -> None:
             csv_file=csv_file,
             data_dir=model.config.cfg.data.data_dir,
             compute_metrics=True,
-            add_train_val_test_set=(not ood_mode),
+            add_train_val_test_set=(suffix is None),
         )
 
     # Copy prediction files to legacy location in model dir.
@@ -229,8 +237,8 @@ def _evaluate_on_training_dataset(model: Model, ood_mode: bool = False) -> None:
                 out_file += "_" + view_name
             if metric_suffix:
                 out_file += metric_suffix
-            if ood_mode:
-                out_file += "_new"
+            if suffix:
+                out_file += suffix
             out_file += ".csv"
             out_file = model.model_dir / out_file
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -2,13 +2,15 @@ import contextlib
 import copy
 import os
 import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import torch
 from omegaconf import OmegaConf, open_dict
 
 from lightning_pose.data import get_data_module
-from lightning_pose.train import calculate_steps_per_epoch, train
+from lightning_pose.train import _evaluate_on_training_dataset, calculate_steps_per_epoch, train
 
 
 # TODO: Replace with contextlib.chdir in python 3.11.
@@ -216,6 +218,141 @@ def test_train_multi_gpu_unsupervised(cfg, tmp_path, pytestconfig):
     cfg.model.losses_to_use = ["pca_singleview", "pca_multiview", "temporal"]
 
     _execute_multi_gpu_test(cfg, tmp_path, pytestconfig)
+
+
+class TestEvaluateOnTrainingDataset:
+    """Test the _evaluate_on_training_dataset function."""
+
+    def _make_model(self, tmp_path: Path, csv_stem: str = 'CollectedData') -> MagicMock:
+        """Build a minimal single-view model mock."""
+        model = MagicMock()
+        model.config.is_single_view.return_value = True
+        model.config.is_multi_view.return_value = False
+        model.config.cfg.data.csv_file = f'{csv_stem}.csv'
+        model.config.cfg.data.data_dir = str(tmp_path)
+        model.model_dir = tmp_path
+        model.image_preds_dir.return_value = tmp_path / 'image_preds'
+        return model
+
+    def _make_model_multiview(self, tmp_path: Path, csv_stem: str = 'CollectedData') -> MagicMock:
+        """Build a minimal multi-view model mock."""
+        model = MagicMock()
+        model.config.is_single_view.return_value = False
+        model.config.is_multi_view.return_value = True
+        model.config.cfg.data.csv_file = [
+            f'{csv_stem}_top.csv',
+            f'{csv_stem}_bot.csv',
+        ]
+        model.config.cfg.data.data_dir = str(tmp_path)
+        model.config.cfg.data.view_names = ['top', 'bot']
+        model.config.cfg.data.get.return_value = None
+        model.model_dir = tmp_path
+        model.image_preds_dir.return_value = tmp_path / 'image_preds'
+        return model
+
+    def test_evaluate_on_training_dataset_no_suffix(self, tmp_path: Path) -> None:
+        """No suffix: calls predict on the base CSV and copies output files."""
+        model = self._make_model(tmp_path)
+        csv_file = tmp_path / 'CollectedData.csv'
+        csv_file.touch()
+        image_preds_dir = tmp_path / 'image_preds' / 'CollectedData.csv'
+        image_preds_dir.mkdir(parents=True)
+        pred_file = image_preds_dir / 'predictions.csv'
+        pred_file.write_text('data')
+
+        _evaluate_on_training_dataset(model)
+
+        model.predict_on_label_csv.assert_called_once_with(
+            csv_file=csv_file,
+            data_dir=str(tmp_path),
+            compute_metrics=True,
+            add_train_val_test_set=True,
+        )
+        assert (tmp_path / 'predictions.csv').exists()
+
+    def test_evaluate_on_training_dataset_suffix_new(self, tmp_path: Path) -> None:
+        """suffix='_new': calls predict on the _new CSV and copies with _new suffix."""
+        model = self._make_model(tmp_path)
+        csv_file = tmp_path / 'CollectedData_new.csv'
+        csv_file.touch()
+        image_preds_dir = tmp_path / 'image_preds' / 'CollectedData_new.csv'
+        image_preds_dir.mkdir(parents=True)
+        pred_file = image_preds_dir / 'predictions.csv'
+        pred_file.write_text('data')
+
+        _evaluate_on_training_dataset(model, suffix='_new')
+
+        model.predict_on_label_csv.assert_called_once_with(
+            csv_file=csv_file,
+            data_dir=str(tmp_path),
+            compute_metrics=True,
+            add_train_val_test_set=False,
+        )
+        assert (tmp_path / 'predictions_new.csv').exists()
+
+    def test_evaluate_on_training_dataset_suffix_test(self, tmp_path: Path) -> None:
+        """suffix='_test': calls predict on the _test CSV and copies with _test suffix."""
+        model = self._make_model(tmp_path)
+        csv_file = tmp_path / 'CollectedData_test.csv'
+        csv_file.touch()
+        image_preds_dir = tmp_path / 'image_preds' / 'CollectedData_test.csv'
+        image_preds_dir.mkdir(parents=True)
+        pred_file = image_preds_dir / 'predictions.csv'
+        pred_file.write_text('data')
+
+        _evaluate_on_training_dataset(model, suffix='_test')
+
+        model.predict_on_label_csv.assert_called_once_with(
+            csv_file=csv_file,
+            data_dir=str(tmp_path),
+            compute_metrics=True,
+            add_train_val_test_set=False,
+        )
+        assert (tmp_path / 'predictions_test.csv').exists()
+
+    def test_evaluate_on_training_dataset_suffix_missing_file(self, tmp_path: Path) -> None:
+        """suffix given but file absent: returns early without calling predict."""
+        model = self._make_model(tmp_path)
+        # do NOT create CollectedData_new.csv or CollectedData_test.csv
+
+        for suffix in ('_new', '_test'):
+            model.predict_on_label_csv.reset_mock()
+            _evaluate_on_training_dataset(model, suffix=suffix)
+            model.predict_on_label_csv.assert_not_called()
+
+    def test_evaluate_on_training_dataset_multiview_no_suffix(self, tmp_path: Path) -> None:
+        """Multi-view, no suffix: calls predict_on_label_csv_multiview."""
+        model = self._make_model_multiview(tmp_path)
+        for stem in ('CollectedData_top', 'CollectedData_bot'):
+            (tmp_path / f'{stem}.csv').touch()
+            preds_dir = tmp_path / 'image_preds' / f'{stem}.csv'
+            preds_dir.mkdir(parents=True)
+            (preds_dir / 'predictions.csv').write_text('data')
+
+        _evaluate_on_training_dataset(model)
+
+        model.predict_on_label_csv_multiview.assert_called_once()
+        call_kwargs = model.predict_on_label_csv_multiview.call_args.kwargs
+        assert call_kwargs['add_train_val_test_set'] is True
+        assert (tmp_path / 'predictions_top.csv').exists()
+        assert (tmp_path / 'predictions_bot.csv').exists()
+
+    def test_evaluate_on_training_dataset_multiview_suffix_test(self, tmp_path: Path) -> None:
+        """Multi-view, suffix='_test': uses _test CSV files and copies with _test suffix."""
+        model = self._make_model_multiview(tmp_path)
+        for stem in ('CollectedData_top_test', 'CollectedData_bot_test'):
+            (tmp_path / f'{stem}.csv').touch()
+            preds_dir = tmp_path / 'image_preds' / f'{stem}.csv'
+            preds_dir.mkdir(parents=True)
+            (preds_dir / 'predictions.csv').write_text('data')
+
+        _evaluate_on_training_dataset(model, suffix='_test')
+
+        model.predict_on_label_csv_multiview.assert_called_once()
+        call_kwargs = model.predict_on_label_csv_multiview.call_args.kwargs
+        assert call_kwargs['add_train_val_test_set'] is False
+        assert (tmp_path / 'predictions_top_test.csv').exists()
+        assert (tmp_path / 'predictions_bot_test.csv').exists()
 
 
 class TestCalculateStepsPerEpoch:


### PR DESCRIPTION
  Add _test.csv inference pass after training
  
  After training, the model now runs inference on {data.csv_file}_test.csv in addition to the existing
  {data.csv_file}_new.csv. Like the _new pass, it is silently skipped if the file does not exist.

  Implementation: replaced the ood_mode: bool parameter on _evaluate_on_training_dataset with suffix: str | 
  None, which generalises the pattern to any suffix without duplicating logic. The legacy _new behavior is
  preserved exactly — output files still land as predictions_new.csv / predictions_new_<metric>.csv. Test
  output lands as predictions_test.csv / predictions_test_<metric>.csv.

  Tests: added TestEvaluateOnTrainingDataset in tests/test_train.py covering no-suffix, _new, _test,
  missing-file skip, and both single-view and multi-view paths.

  Docs: added a Post-training evaluation section to CLAUDE.md describing the three call sites, suffix
  semantics, and output file locations.
