### PR TITLE
fix breaking change from transformers library

### DIFF
--- a/lightning_pose/models/heatmap_tracker_multiview.py
+++ b/lightning_pose/models/heatmap_tracker_multiview.py
@@ -190,13 +190,20 @@ class HeatmapTrackerMultiviewTransformer(BaseSupervisedTracker):
         )
 
         # push data through vit encoder
-        encoder_outputs = self.backbone.vision_encoder.encoder(  # type: ignore[operator]
-            embedding_output,
-            head_mask=None,
-            output_hidden_states=False,
-            return_dict=None,
-        )
-        sequence_output = encoder_outputs[0]
+        # transformers <5.9 exposes a single callable .encoder; >=5.9 uses .layers (ModuleList)
+        vit = self.backbone.vision_encoder  # type: ignore[operator]
+        if hasattr(vit, 'encoder'):
+            sequence_output = vit.encoder(
+                embedding_output,
+                head_mask=None,
+                output_hidden_states=False,
+                return_dict=None,
+            )[0]
+        else:
+            hidden_states = embedding_output
+            for layer in vit.layers:
+                hidden_states = layer(hidden_states)[0]
+            sequence_output = hidden_states
         outputs = self.backbone.vision_encoder.layernorm(sequence_output)  # type: ignore[operator]
         # shape: (batch, view * num_patches, embedding_dim)
 

--- a/lightning_pose/models/heatmap_tracker_multiview.py
+++ b/lightning_pose/models/heatmap_tracker_multiview.py
@@ -191,7 +191,7 @@ class HeatmapTrackerMultiviewTransformer(BaseSupervisedTracker):
 
         # push data through vit encoder
         # transformers <5.9 exposes a single callable .encoder; >=5.9 uses .layers (ModuleList)
-        vit = self.backbone.vision_encoder  # type: ignore[operator]
+        vit: Any = self.backbone.vision_encoder
         if hasattr(vit, 'encoder'):
             sequence_output = vit.encoder(
                 embedding_output,


### PR DESCRIPTION
  Summary

  - In transformers >= 5.9, ViTModel was refactored: the encoder submodule (a single callable ViTEncoder
  object) was removed and replaced with layers, an nn.ModuleList of ViTLayer instances that must be iterated
  manually
  - The multiview transformer's forward_vit manually decomposes the ViTModel forward pass (to inject view
  embeddings between the patch embedding and transformer layers), so it was directly accessing
  vision_encoder.encoder — causing AttributeError: 'ViTModel' object has no attribute 'encoder' on all
  multiview transformer tests
  - Single-view transformer tests were unaffected because single-view calls ViTModel.forward() as a black box

  Change

  HeatmapTrackerMultiviewTransformer.forward_vit now detects which API is available at runtime: if .encoder
  exists (transformers < 5.9), the original call path is used; otherwise it iterates over .layers (transformers>= 5.9).