### PR TITLE
hyperparameter sweep infrastructure

### DIFF
--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -82,6 +82,17 @@ Edit `sweep_config.yaml` before running. Key fields:
 | `output.base_dir` | Root path for results on teamspace storage |
 | `debug` | `true` for a 3-epoch smoke test |
 
+### Dataset caching
+
+Downloaded datasets are cached in `output.dataset_cache_dir` (default:
+`/teamspace/lightning_storage/datasets`). On first use a dataset is downloaded
+there; subsequent jobs find the cache and skip the download entirely, avoiding
+HuggingFace rate limits during large sweeps.
+
+For local runs, set `output.dataset_cache_dir` in `sweep_config.yaml` to a
+local path, or pass `--dataset_cache_dir /your/path` directly to
+`run_single_job.py`.
+
 ### Video download gating
 
 To avoid downloading large video files unnecessarily:

--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -30,6 +30,10 @@ Results are written to teamspace storage and persist after each job ends.
 
 ## Running on Lightning AI
 
+> **Note:** `run_sweep.py` must be run from the `hyper-sweep/` directory so it
+> can import `run_single_job.py`. If you need to run it from elsewhere, add
+> `hyper-sweep/` to your `PYTHONPATH` first.
+
 ### From within a studio
 
 ```bash
@@ -85,9 +89,11 @@ Edit `sweep_config.yaml` before running. Key fields:
 ### Dataset caching
 
 Downloaded datasets are cached in `output.dataset_cache_dir` (default:
-`/teamspace/lightning_storage/datasets`). On first use a dataset is downloaded
-there; subsequent jobs find the cache and skip the download entirely, avoiding
-HuggingFace rate limits during large sweeps.
+`/teamspace/lightning_storage/datasets`). Before launching any jobs,
+`run_sweep.py` pre-downloads each unique dataset into the cache. This means
+the download happens exactly once regardless of sweep size, and all jobs find
+the cache already populated — avoiding both HuggingFace rate limits and race
+conditions from simultaneous first-time downloads.
 
 For local runs, set `output.dataset_cache_dir` in `sweep_config.yaml` to a
 local path, or pass `--dataset_cache_dir /your/path` directly to

--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -130,10 +130,8 @@ To run a local sweep, call `run_single_job.py` in a loop or adapt
 lightning-pose    # must be installed; provides the litpose CLI
 lightning_sdk     # pip install lightning_sdk  (orchestrator only)
 huggingface_hub   # pip install huggingface_hub (worker)
-hf_transfer       # pip install hf_transfer    (worker; enables fast parallel downloads)
 pyyaml            # pip install pyyaml (orchestrator)
 ```
 
-`hf_transfer` is optional but strongly recommended — without it, HuggingFace downloads
-are sequential and can be 10–20× slower. It is enabled automatically by `run_single_job.py`
-via `os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"`; the package just needs to be installed.
+High-performance downloads are enabled automatically via `HF_XET_HIGH_PERFORMANCE=1`,
+set at the top of `run_single_job.py` before `huggingface_hub` is imported.

--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -1,0 +1,117 @@
+# Lightning Pose Hyperparameter Sweep
+
+Scripts for running parallel Lightning Pose training sweeps, either on
+[Lightning AI](https://lightning.ai) or locally.
+
+## How it works
+
+`run_sweep.py` builds the cartesian product of all sweep dimensions defined in
+`sweep_config.yaml` and launches one Lightning AI Job per combination.
+Each job runs `run_single_job.py`, which:
+
+1. Downloads the dataset from HuggingFace (selectively — videos only when needed)
+2. Calls `litpose train` with the appropriate config and overrides
+3. Deletes model weights (`.ckpt`) to save storage
+4. Cleans up the downloaded dataset
+
+Results are written to teamspace storage and persist after each job ends.
+
+## Output structure
+
+```
+<output.base_dir>/
+└── <dataset>/
+    └── <backbone>/
+        └── <losses>/          # "supervised", "temporal", "pca_singleview+temporal", …
+            └── tf<N>/         # train_frames
+                └── seed<N>/   # rng seed
+                    └── <LP training outputs, no .ckpt files>
+```
+
+## Running on Lightning AI
+
+### From within a studio
+
+```bash
+cd lightning-pose/scripts/hyper-sweep
+python run_sweep.py --config sweep_config.yaml
+```
+
+### From outside Lightning AI
+
+Set your API key, then run the same command:
+
+```bash
+export LIGHTNING_API_KEY=<your_key>
+python run_sweep.py --config sweep_config.yaml
+```
+
+The script uses `Studio()` to attach to the currently active studio.
+
+### Dry run
+
+Print all job names and commands without launching anything:
+
+```bash
+python run_sweep.py --dry_run
+```
+
+### Skip existing runs
+
+Skip any combination whose output directory already exists (useful for
+resuming a partially completed sweep):
+
+```bash
+python run_sweep.py --skip_existing
+```
+
+## Configuration
+
+Edit `sweep_config.yaml` before running. Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `sweep.datasets` | HuggingFace repo IDs to train on |
+| `sweep.backbones` | LP backbone names |
+| `sweep.train_frames` | Labeled frame counts |
+| `sweep.seeds` | RNG seeds (`training.rng_seed_data_pt`) |
+| `sweep.losses_to_use` | List of loss combinations (each entry is a list) |
+| `sweep.model_type` | `heatmap`, `context`, or `regression` |
+| `sweep.predict_vids_after_training` | Run video prediction after training |
+| `lightning.machine` | GPU type (`T4_SMALL`, `T4`, `A10G`, `A100`) |
+| `output.base_dir` | Root path for results on teamspace storage |
+| `debug` | `true` for a 3-epoch smoke test |
+
+### Video download gating
+
+To avoid downloading large video files unnecessarily:
+
+- `videos/` (InD) — only downloaded when `losses_to_use` contains at least one
+  unsupervised loss (i.e., any non-empty entry in the list)
+- `videos_test/` (OOD) — only downloaded when `predict_vids_after_training: true`
+- `videos-for-each-labeled-frame/` — never downloaded (used for post-hoc smoothing only)
+
+## Running locally (no Lightning AI)
+
+Call `run_single_job.py` directly. Example:
+
+```bash
+python run_single_job.py \
+    --dataset_repo paninski-lab/mirror-mouse-fused \
+    --backbone resnet50_animal_ap10k \
+    --train_frames 1 \
+    --seed 0 \
+    --output_dir /path/to/results/mirror-mouse-fused/resnet50_animal_ap10k/supervised/tf1/seed0
+```
+
+To run a local sweep, call `run_single_job.py` in a loop or adapt
+`run_sweep.py` to call it via `subprocess` instead of `Job.run()`.
+
+## Dependencies
+
+```
+lightning-pose    # must be installed; provides the litpose CLI
+lightning_sdk     # pip install lightning_sdk  (orchestrator only)
+huggingface_hub   # pip install huggingface_hub (worker)
+pyyaml            # pip install pyyaml (orchestrator)
+```

--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -113,5 +113,10 @@ To run a local sweep, call `run_single_job.py` in a loop or adapt
 lightning-pose    # must be installed; provides the litpose CLI
 lightning_sdk     # pip install lightning_sdk  (orchestrator only)
 huggingface_hub   # pip install huggingface_hub (worker)
+hf_transfer       # pip install hf_transfer    (worker; enables fast parallel downloads)
 pyyaml            # pip install pyyaml (orchestrator)
 ```
+
+`hf_transfer` is optional but strongly recommended — without it, HuggingFace downloads
+are sequential and can be 10–20× slower. It is enabled automatically by `run_single_job.py`
+via `os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"`; the package just needs to be installed.

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -12,9 +12,13 @@ Can also be called directly for local sweeps (no Lightning AI required):
 """
 
 import argparse
+import os
 import shutil
 import subprocess
 from pathlib import Path
+
+# must be set before huggingface_hub is imported
+os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 
 
 def parse_args():

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -17,7 +17,7 @@ import subprocess
 from pathlib import Path
 
 # must be set before huggingface_hub is imported
-os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+os.environ["HF_XET_HIGH_PERFORMANCE"] = "1"
 
 DEFAULT_DATASET_CACHE_DIR = "/teamspace/lightning_storage/datasets"
 
@@ -75,12 +75,24 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
 
     print(f"Downloading {dataset_repo} -> {cache_path}")
     print(f"  ignore_patterns: {ignore_patterns}")
-    snapshot_download(
-        repo_id=dataset_repo,
-        repo_type="dataset",
-        local_dir=str(cache_path),
-        ignore_patterns=ignore_patterns,
-    )
+
+    import time
+    max_retries = 5
+    for attempt in range(1, max_retries + 1):
+        try:
+            snapshot_download(
+                repo_id=dataset_repo,
+                repo_type="dataset",
+                local_dir=str(cache_path),
+                ignore_patterns=ignore_patterns,
+            )
+            break
+        except Exception as e:
+            if attempt == max_retries:
+                raise
+            wait = 60 * attempt  # 60s, 120s, 180s, 240s
+            print(f"  Download attempt {attempt} failed ({e}); retrying in {wait}s...")
+            time.sleep(wait)
 
     # LP asserts video_dir exists even when not using videos
     (cache_path / "videos").mkdir(exist_ok=True)

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -53,16 +53,58 @@ def parse_args():
     return p.parse_args()
 
 
-def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
-    """Return path to dataset, downloading from HuggingFace only if not cached."""
+def _snapshot_worker(repo_id, repo_type, local_dir, ignore_patterns):
+    """Runs snapshot_download in a child process so it can be hard-killed on stall."""
     from huggingface_hub import snapshot_download
+    snapshot_download(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        local_dir=local_dir,
+        ignore_patterns=ignore_patterns,
+    )
+
+
+def _watchdog(process, cache_path, stall_timeout, check_interval=30):
+    """Monitors download progress; terminates process if no bytes land for stall_timeout seconds."""
+    import time
+
+    def dir_size():
+        try:
+            return sum(f.stat().st_size for f in Path(cache_path).rglob("*") if f.is_file())
+        except Exception:
+            return 0
+
+    last_size = dir_size()
+    last_progress = time.time()
+
+    while process.is_alive():
+        time.sleep(check_interval)
+        size = dir_size()
+        if size > last_size:
+            last_size = size
+            last_progress = time.time()
+        elif time.time() - last_progress > stall_timeout:
+            print(f"  No download progress for {stall_timeout}s — terminating stalled download.")
+            process.terminate()
+            return
+
+
+def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
+    """Return path to dataset, downloading from HuggingFace only if not cached.
+
+    Runs the download in a subprocess watched by a progress monitor. If no bytes
+    land for stall_timeout seconds the download is killed and retried, allowing
+    arbitrarily large/slow downloads while still catching rate-limit hangs.
+    """
+    import multiprocessing
+    import threading
+    import time
 
     dataset_name = dataset_repo.split("/")[-1]
     cache_path = Path(cache_dir) / dataset_name
 
     if cache_path.exists():
         print(f"Using cached dataset at {cache_path}")
-        # ensure videos/ exists even if it wasn't downloaded
         (cache_path / "videos").mkdir(exist_ok=True)
         return cache_path
 
@@ -76,23 +118,32 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
     print(f"Downloading {dataset_repo} -> {cache_path}")
     print(f"  ignore_patterns: {ignore_patterns}")
 
-    import time
     max_retries = 5
+    stall_timeout = 5 * 60  # kill if no bytes received for 5 minutes
+    retry_wait = 90          # pause before retrying to let rate limit window reset
+
     for attempt in range(1, max_retries + 1):
-        try:
-            snapshot_download(
-                repo_id=dataset_repo,
-                repo_type="dataset",
-                local_dir=str(cache_path),
-                ignore_patterns=ignore_patterns,
-            )
-            break
-        except Exception as e:
-            if attempt == max_retries:
-                raise
-            wait = 60 * attempt  # 60s, 120s, 180s, 240s
-            print(f"  Download attempt {attempt} failed ({e}); retrying in {wait}s...")
-            time.sleep(wait)
+        p = multiprocessing.Process(
+            target=_snapshot_worker,
+            args=(dataset_repo, "dataset", str(cache_path), ignore_patterns),
+        )
+        p.start()
+
+        watcher = threading.Thread(
+            target=_watchdog, args=(p, cache_path, stall_timeout), daemon=True
+        )
+        watcher.start()
+        p.join()
+
+        if p.exitcode == 0:
+            break  # success
+
+        msg = "stalled" if not p.is_alive() else f"exited with code {p.exitcode}"
+        if attempt == max_retries:
+            raise RuntimeError(f"Failed to download {dataset_repo} after {max_retries} attempts ({msg})")
+
+        print(f"  Download attempt {attempt}/{max_retries} {msg}; retrying in {retry_wait}s...")
+        time.sleep(retry_wait)
 
     # LP asserts video_dir exists even when not using videos
     (cache_path / "videos").mkdir(exist_ok=True)

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -1,8 +1,8 @@
 """
 Worker script: runs inside a single Lightning AI job.
 
-Downloads a dataset from HuggingFace, trains one Lightning Pose model
-via `litpose train`, deletes model weights, and cleans up the dataset.
+Downloads a dataset from HuggingFace (or uses a teamspace cache), trains one
+Lightning Pose model via `litpose train`, and deletes model weights.
 Results land in --output_dir (a path on teamspace storage).
 
 Can also be called directly for local sweeps (no Lightning AI required):
@@ -13,12 +13,13 @@ Can also be called directly for local sweeps (no Lightning AI required):
 
 import argparse
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
 # must be set before huggingface_hub is imported
 os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
+
+DEFAULT_DATASET_CACHE_DIR = "/teamspace/lightning_storage/datasets"
 
 
 def parse_args():
@@ -26,6 +27,10 @@ def parse_args():
     p.add_argument(
         "--dataset_repo", required=True,
         help="HuggingFace repo ID, e.g. paninski-lab/mirror-mouse-fused",
+    )
+    p.add_argument(
+        "--dataset_cache_dir", default=DEFAULT_DATASET_CACHE_DIR,
+        help="Directory where datasets are cached; set to a local path when running outside Lightning AI",
     )
     p.add_argument("--backbone", required=True)
     p.add_argument("--train_frames", type=int, required=True)
@@ -48,39 +53,54 @@ def parse_args():
     return p.parse_args()
 
 
-def main():
-    args = parse_args()
-    dataset_name = args.dataset_repo.split("/")[-1]
-    data_dir = f"/tmp/datasets/{dataset_name}"
-
-    # -------------------------------------------------------------------------
-    # 1. Download dataset from HuggingFace
-    # -------------------------------------------------------------------------
+def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
+    """Return path to dataset, downloading from HuggingFace only if not cached."""
     from huggingface_hub import snapshot_download
+
+    dataset_name = dataset_repo.split("/")[-1]
+    cache_path = Path(cache_dir) / dataset_name
+
+    if cache_path.exists():
+        print(f"Using cached dataset at {cache_path}")
+        # ensure videos/ exists even if it wasn't downloaded
+        (cache_path / "videos").mkdir(exist_ok=True)
+        return cache_path
 
     # videos-for-each-labeled-frame is only needed for post-hoc smoothing, never for training
     ignore_patterns = ["videos-for-each-labeled-frame/*"]
-    if not args.download_videos:
+    if not download_videos:
         ignore_patterns.append("videos/*")
-    if not args.predict_vids:
+    if not predict_vids:
         ignore_patterns.append("videos_test/*")
 
-    print(f"Downloading {args.dataset_repo} -> {data_dir}")
+    print(f"Downloading {dataset_repo} -> {cache_path}")
     print(f"  ignore_patterns: {ignore_patterns}")
     snapshot_download(
-        repo_id=args.dataset_repo,
+        repo_id=dataset_repo,
         repo_type="dataset",
-        local_dir=data_dir,
+        local_dir=str(cache_path),
         ignore_patterns=ignore_patterns,
     )
 
     # LP asserts video_dir exists even when not using videos
-    Path(data_dir, "videos").mkdir(exist_ok=True)
+    (cache_path / "videos").mkdir(exist_ok=True)
+
+    return cache_path
+
+
+def main():
+    args = parse_args()
+    dataset_name = args.dataset_repo.split("/")[-1]
+
+    # -------------------------------------------------------------------------
+    # 1. Get dataset (from cache or HuggingFace)
+    # -------------------------------------------------------------------------
+    data_dir = get_dataset(args.dataset_repo, args.dataset_cache_dir, args.download_videos, args.predict_vids)
 
     # -------------------------------------------------------------------------
     # 2. Build and run litpose train
     # -------------------------------------------------------------------------
-    config_file = str(Path(data_dir) / f"config_{dataset_name}.yaml")
+    config_file = str(data_dir / f"config_{dataset_name}.yaml")
 
     losses = [l for l in args.losses_to_use.split(",") if l]
     losses_hydra = f"[{','.join(losses)}]"
@@ -123,11 +143,6 @@ def main():
         ckpt.unlink()
         n_deleted += 1
     print(f"Deleted {n_deleted} checkpoint file(s)")
-
-    # -------------------------------------------------------------------------
-    # 4. Clean up downloaded dataset
-    # -------------------------------------------------------------------------
-    shutil.rmtree(data_dir, ignore_errors=True)
     print(f"Done. Results at {args.output_dir}")
 
 

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -1,0 +1,128 @@
+"""
+Worker script: runs inside a single Lightning AI job.
+
+Downloads a dataset from HuggingFace, trains one Lightning Pose model
+via `litpose train`, deletes model weights, and cleans up the dataset.
+Results land in --output_dir (a path on teamspace storage).
+
+Can also be called directly for local sweeps (no Lightning AI required):
+    python run_single_job.py --dataset_repo paninski-lab/mirror-mouse-fused \\
+        --backbone resnet50_animal_ap10k --train_frames 1 --seed 0 \\
+        --output_dir /some/local/path
+"""
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--dataset_repo", required=True,
+        help="HuggingFace repo ID, e.g. paninski-lab/mirror-mouse-fused",
+    )
+    p.add_argument("--backbone", required=True)
+    p.add_argument("--train_frames", type=int, required=True)
+    p.add_argument("--seed", type=int, required=True)
+    p.add_argument(
+        "--losses_to_use", default="",
+        help="Comma-separated loss names; empty string = supervised only",
+    )
+    p.add_argument("--model_type", default="heatmap")
+    p.add_argument("--output_dir", required=True, help="Absolute path for training outputs")
+    p.add_argument(
+        "--download_videos", action="store_true",
+        help="Download InD videos/ directory (required for unsupervised losses)",
+    )
+    p.add_argument(
+        "--predict_vids", action="store_true",
+        help="Run video prediction after training; also downloads videos_test/",
+    )
+    p.add_argument("--debug", action="store_true", help="Short smoke-test run (3 epochs)")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    dataset_name = args.dataset_repo.split("/")[-1]
+    data_dir = f"/tmp/datasets/{dataset_name}"
+
+    # -------------------------------------------------------------------------
+    # 1. Download dataset from HuggingFace
+    # -------------------------------------------------------------------------
+    from huggingface_hub import snapshot_download
+
+    # videos-for-each-labeled-frame is only needed for post-hoc smoothing, never for training
+    ignore_patterns = ["videos-for-each-labeled-frame*"]
+    if not args.download_videos:
+        ignore_patterns.append("videos/*")
+    if not args.predict_vids:
+        ignore_patterns.append("videos_test/*")
+
+    print(f"Downloading {args.dataset_repo} -> {data_dir}")
+    print(f"  ignore_patterns: {ignore_patterns}")
+    snapshot_download(
+        repo_id=args.dataset_repo,
+        repo_type="dataset",
+        local_dir=data_dir,
+        ignore_patterns=ignore_patterns,
+    )
+
+    # -------------------------------------------------------------------------
+    # 2. Build and run litpose train
+    # -------------------------------------------------------------------------
+    config_file = str(Path(data_dir) / f"config_{dataset_name}.yaml")
+
+    losses = [l for l in args.losses_to_use.split(",") if l]
+    losses_hydra = f"[{','.join(losses)}]"
+
+    # ViT backbones need a lower learning rate
+    lr = 5e-5 if "vit" in args.backbone else 1e-3
+
+    overrides = [
+        f"data.data_dir={data_dir}",
+        f"model.model_type={args.model_type}",
+        f"model.backbone={args.backbone}",
+        f"model.losses_to_use={losses_hydra}",
+        f"training.train_frames={args.train_frames}",
+        f"training.rng_seed_data_pt={args.seed}",
+        f"training.optimizer_params.learning_rate={lr}",
+        f"eval.predict_vids_after_training={'true' if args.predict_vids else 'false'}",
+    ]
+
+    # vitb_sam OOMs above batch size 16 on T4
+    if "vitb_sam" in args.backbone:
+        overrides.append("training.train_batch_size=16")
+
+    if args.debug:
+        overrides += [
+            "training.check_val_every_n_epoch=1",
+            "training.max_epochs=3",
+            "training.unfreezing_epoch=1",
+            "eval.predict_vids_after_training=false",
+        ]
+
+    cmd = ["litpose", "train", config_file, "--output_dir", args.output_dir, "--overrides"] + overrides
+    print("Running:", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+    # -------------------------------------------------------------------------
+    # 3. Delete model weights to save storage
+    # -------------------------------------------------------------------------
+    n_deleted = 0
+    for ckpt in Path(args.output_dir).rglob("*.ckpt"):
+        ckpt.unlink()
+        n_deleted += 1
+    print(f"Deleted {n_deleted} checkpoint file(s)")
+
+    # -------------------------------------------------------------------------
+    # 4. Clean up downloaded dataset
+    # -------------------------------------------------------------------------
+    shutil.rmtree(data_dir, ignore_errors=True)
+    print(f"Done. Results at {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -59,7 +59,7 @@ def main():
     from huggingface_hub import snapshot_download
 
     # videos-for-each-labeled-frame is only needed for post-hoc smoothing, never for training
-    ignore_patterns = ["videos-for-each-labeled-frame*"]
+    ignore_patterns = ["videos-for-each-labeled-frame/*"]
     if not args.download_videos:
         ignore_patterns.append("videos/*")
     if not args.predict_vids:

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -74,6 +74,9 @@ def main():
         ignore_patterns=ignore_patterns,
     )
 
+    # LP asserts video_dir exists even when not using videos
+    Path(data_dir, "videos").mkdir(exist_ok=True)
+
     # -------------------------------------------------------------------------
     # 2. Build and run litpose train
     # -------------------------------------------------------------------------

--- a/scripts/hyper-sweep/run_sweep.py
+++ b/scripts/hyper-sweep/run_sweep.py
@@ -128,6 +128,15 @@ def main():
             print(f"\n{name}:\n  {cmd}")
         return
 
+    # pre-download each unique dataset before launching jobs to avoid a race
+    # condition where many jobs simultaneously attempt to populate an empty cache
+    from run_single_job import get_dataset
+    cache_dir = cfg["output"].get("dataset_cache_dir", "/teamspace/lightning_storage/datasets")
+    download_videos = any(len(l) > 0 for l in sweep.get("losses_to_use", [[]]))
+    predict_vids = sweep.get("predict_vids_after_training", False)
+    for dataset_repo in set(sweep["datasets"]):
+        get_dataset(dataset_repo, cache_dir, download_videos, predict_vids)
+
     from lightning_sdk import Job, Machine, Studio
 
     machine = getattr(Machine, li.get("machine", "T4_SMALL"))

--- a/scripts/hyper-sweep/run_sweep.py
+++ b/scripts/hyper-sweep/run_sweep.py
@@ -12,11 +12,15 @@ Output is written to:
 """
 
 import argparse
+import os
 import time
 from itertools import product
 from pathlib import Path
 
 import yaml
+
+# must be set before huggingface_hub is imported
+os.environ["HF_XET_HIGH_PERFORMANCE"] = "1"
 
 
 def load_config(path: str) -> dict:

--- a/scripts/hyper-sweep/run_sweep.py
+++ b/scripts/hyper-sweep/run_sweep.py
@@ -69,6 +69,7 @@ def make_worker_command(combo, cfg, worker_script) -> str:
     parts = [
         "python", str(worker_script),
         f"--dataset_repo={dataset_repo}",
+        f"--dataset_cache_dir={cfg['output'].get('dataset_cache_dir', '/teamspace/lightning_storage/datasets')}",
         f"--backbone={backbone}",
         f"--train_frames={train_frames}",
         f"--seed={seed}",

--- a/scripts/hyper-sweep/run_sweep.py
+++ b/scripts/hyper-sweep/run_sweep.py
@@ -1,0 +1,164 @@
+"""
+Orchestrate a Lightning Pose hyperparameter sweep on Lightning AI.
+
+Run from within a Lightning AI studio:
+    python run_sweep.py [--config sweep_config.yaml] [--dry_run]
+
+Run from outside Lightning AI (set LIGHTNING_API_KEY env var first):
+    LIGHTNING_API_KEY=<key> python run_sweep.py [--config sweep_config.yaml]
+
+Output is written to:
+    <output.base_dir>/<dataset>/<backbone>/<losses>/<tf{N}>/seed{N}/
+"""
+
+import argparse
+import time
+from itertools import product
+from pathlib import Path
+
+import yaml
+
+
+def load_config(path: str) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def losses_str(losses: tuple) -> str:
+    """Canonical directory name for a losses_to_use combination."""
+    return "supervised" if not losses else "+".join(sorted(losses))
+
+
+def sanitize(s: str) -> str:
+    return str(s).replace("/", "_").replace(".", "_")
+
+
+def dataset_shortname(repo_id: str) -> str:
+    return repo_id.split("/")[-1]
+
+
+def make_job_name(dataset_repo, backbone, train_frames, seed, losses) -> str:
+    return "__".join([
+        sanitize(dataset_shortname(dataset_repo)),
+        sanitize(backbone),
+        losses_str(losses),
+        f"tf{train_frames}",
+        f"s{seed}",
+    ])
+
+
+def make_output_dir(base_dir, dataset_repo, backbone, train_frames, seed, losses) -> str:
+    return str(
+        Path(base_dir)
+        / dataset_shortname(dataset_repo)
+        / sanitize(backbone)
+        / losses_str(losses)
+        / f"tf{train_frames}"
+        / f"seed{seed}"
+    )
+
+
+def make_worker_command(combo, cfg, worker_script) -> str:
+    dataset_repo, backbone, train_frames, seed, losses = combo
+    out_dir = make_output_dir(
+        cfg["output"]["base_dir"], dataset_repo, backbone, train_frames, seed, losses
+    )
+    predict_vids = cfg["sweep"].get("predict_vids_after_training", False)
+    download_videos = len(losses) > 0
+
+    parts = [
+        "python", str(worker_script),
+        f"--dataset_repo={dataset_repo}",
+        f"--backbone={backbone}",
+        f"--train_frames={train_frames}",
+        f"--seed={seed}",
+        f"--losses_to_use={','.join(losses)}",
+        f"--model_type={cfg['sweep'].get('model_type', 'heatmap')}",
+        f"--output_dir={out_dir}",
+    ]
+    if download_videos:
+        parts.append("--download_videos")
+    if predict_vids:
+        parts.append("--predict_vids")
+    if cfg.get("debug", False):
+        parts.append("--debug")
+    return " ".join(parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch a Lightning Pose hyperparameter sweep")
+    parser.add_argument("--config", default="sweep_config.yaml", help="Path to sweep config YAML")
+    parser.add_argument("--dry_run", action="store_true", help="Print jobs without launching")
+    parser.add_argument(
+        "--skip_existing", action="store_true",
+        help="Skip combos whose output directory already exists",
+    )
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    sweep = cfg["sweep"]
+    li = cfg["lightning"]
+
+    worker_script = Path(__file__).parent / "run_single_job.py"
+
+    # build cartesian product; losses_to_use entries become tuples for hashing
+    combos = list(product(
+        sweep["datasets"],
+        sweep["backbones"],
+        sweep["train_frames"],
+        sweep["seeds"],
+        [tuple(l) for l in sweep.get("losses_to_use", [[]])],
+    ))
+    print(f"Total jobs: {len(combos)}")
+
+    if args.skip_existing:
+        base_dir = cfg["output"]["base_dir"]
+        combos = [
+            c for c in combos
+            if not Path(make_output_dir(base_dir, *c)).exists()
+        ]
+        print(f"After skipping existing: {len(combos)} jobs remaining")
+
+    if args.dry_run:
+        print("\n--- Job list ---")
+        for combo in combos:
+            name = make_job_name(*combo)
+            cmd = make_worker_command(combo, cfg, worker_script)
+            print(f"\n{name}:\n  {cmd}")
+        return
+
+    from lightning_sdk import Job, Machine, Studio
+
+    machine = getattr(Machine, li.get("machine", "T4_SMALL"))
+    studio = Studio()
+
+    jobs = {}
+    for combo in combos:
+        name = make_job_name(*combo)
+        cmd = make_worker_command(combo, cfg, worker_script)
+        print(f"Launching: {name}")
+        job = Job.run(command=cmd, name=name, machine=machine, studio=studio)
+        jobs[name] = job
+        time.sleep(2)
+
+    print(f"\nMonitoring {len(jobs)} jobs...")
+    while True:
+        statuses: dict[str, int] = {}
+        for j in jobs.values():
+            s = str(j.status)
+            statuses[s] = statuses.get(s, 0) + 1
+        print(f"  {statuses}")
+        if not any(s in ("Running", "Pending") for s in statuses):
+            break
+        time.sleep(30)
+
+    failed = [n for n, j in jobs.items() if str(j.status) == "Failed"]
+    print(f"\nComplete: {len(jobs) - len(failed)}/{len(jobs)} succeeded.")
+    if failed:
+        print("Failed jobs:")
+        for n in failed:
+            print(f"  {n}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hyper-sweep/sweep_config.yaml
+++ b/scripts/hyper-sweep/sweep_config.yaml
@@ -1,0 +1,56 @@
+# =============================================================================
+# Sweep dimensions — cartesian product of all lists
+# =============================================================================
+sweep:
+
+  # HuggingFace repo IDs (org/dataset-name)
+  datasets:
+    - paninski-lab/mirror-mouse-fused
+
+  backbones:
+    - resnet50_animal_ap10k
+
+  # Number of labeled frames used for training
+  train_frames:
+    - 1
+
+  # Data/model random seeds
+  seeds:
+    - 0
+    - 1
+    - 2
+
+  # Each entry is one loss combination to sweep over.
+  # Empty list = supervised only; add names for unsupervised losses.
+  # Downloading InD videos (videos/) is gated on any non-empty entry here.
+  losses_to_use:
+    - []
+    # - [temporal]
+    # - [pca_singleview, temporal]
+
+  # heatmap | context | regression
+  model_type: heatmap
+
+  # Run LP video prediction after training.
+  # Also gates downloading of OOD videos (videos_test/).
+  predict_vids_after_training: false
+
+# =============================================================================
+# Lightning AI infrastructure
+# =============================================================================
+lightning:
+  # GPU machine type: T4_SMALL | T4 | A10G | A100
+  machine: T4_SMALL
+
+# =============================================================================
+# Output
+# =============================================================================
+output:
+  # Root directory on teamspace storage; <dataset-name> is appended automatically
+  base_dir: /teamspace/lightning_storage/sweep-results
+
+# =============================================================================
+# Misc
+# =============================================================================
+# Set to true for fast smoke-test runs (3 epochs, no video prediction)
+debug: false

--- a/scripts/hyper-sweep/sweep_config.yaml
+++ b/scripts/hyper-sweep/sweep_config.yaml
@@ -6,6 +6,8 @@ sweep:
   # HuggingFace repo IDs (org/dataset-name)
   datasets:
     - paninski-lab/mirror-mouse-fused
+    # - paninski-lab/mirror-fish
+    # - paninski-lab/crim13
 
   backbones:
     - resnet50_animal_ap10k

--- a/scripts/hyper-sweep/sweep_config.yaml
+++ b/scripts/hyper-sweep/sweep_config.yaml
@@ -11,6 +11,10 @@ sweep:
 
   backbones:
     - resnet50_animal_ap10k
+    # - vits_dino
+    # - vits_dinov2
+    # - vitb_dino
+    # - vitb_dinov2
 
   # Number of labeled frames used for training
   train_frames:

--- a/scripts/hyper-sweep/sweep_config.yaml
+++ b/scripts/hyper-sweep/sweep_config.yaml
@@ -48,6 +48,8 @@ lightning:
 output:
   # Root directory on teamspace storage; <dataset-name> is appended automatically
   base_dir: /teamspace/lightning_storage/sweep-results
+  # Where downloaded datasets are cached; override for local runs
+  dataset_cache_dir: /teamspace/lightning_storage/datasets
 
 # =============================================================================
 # Misc


### PR DESCRIPTION
 ## Summary
  
  Adds a hyperparameter sweep system under scripts/hyper-sweep/ for running parallel Lightning Pose training
  jobs on Lightning AI.

  - sweep_config.yaml — defines the sweep dimensions (datasets, backbones, train frames, seeds, loss
  combinations) and infrastructure settings (machine type, output paths)
  - run_sweep.py — orchestrator: builds the cartesian product of all sweep dimensions, pre-downloads datasets,
  and launches one Lightning AI Job per combination via the lightning_sdk
  - run_single_job.py — worker: runs inside each job; handles dataset retrieval, calls litpose train with the
  appropriate overrides, and deletes model weights after training
  - README.md — documents setup, configuration, and local usage

##  Coupling with HuggingFace datasets

  This infrastructure is designed around datasets hosted at huggingface.co/paninski-lab. Each dataset repo
  includes a config_{dataset}.yaml that the worker script uses directly as the litpose train config. Datasets
  are downloaded to a persistent teamspace cache on first use, so the HuggingFace download happens exactly once
  per dataset regardless of sweep size.

##  Key design decisions

  - Progress-based stall detection: downloads run in a subprocess monitored by a watchdog thread; the download
  is killed and retried only if no bytes land for 5 consecutive minutes, allowing arbitrarily large datasets
  while catching rate-limit hangs
  - Nested output structure: results are written to <base_dir>/<dataset>/<backbone>/<losses>/tf<N>/seed<N>/ for
  easy programmatic querying without a database
  - --skip_existing: re-running the orchestrator skips combinations whose output directory already exists,
  making it safe to extend a sweep incrementally
  - Local use: run_single_job.py can be called directly without Lightning AI; set --dataset_cache_dir to a
  local path
