### PR TITLE
choose last checkpoint if multiple

### DIFF
--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -3,15 +3,17 @@
 from __future__ import annotations  # python 3.8 compatibility for sphinx
 
 import collections
+import logging
 import os
 import re
-import warnings
 from pathlib import Path
 from typing import overload
 
 import numpy as np
 import pandas as pd
 from omegaconf import DictConfig, ListConfig
+
+logger = logging.getLogger(__name__)
 
 # to ignore imports for sphix-autoapidoc
 __all__ = [
@@ -49,9 +51,6 @@ def ckpt_path_from_base_path(
 
     Returns:
         str: path to model checkpoint, or None if none found.
-
-    Raises:
-        ValueError: If multiple 'best' checkpoint files are found (e.g., from save_top_k > 1).
 
     """
     import glob
@@ -98,18 +97,21 @@ def ckpt_path_from_base_path(
         # Found exactly one 'best' checkpoint
         return best_ckpt_files[0]
     elif len(best_ckpt_files) > 1:
-        # Multiple 'best' checkpoints found (e.g., from save_top_k parameter)
-        raise ValueError(
-            f"Multiple 'best' checkpoint files found in {latest_version_files}. "
-            f"Found {len(best_ckpt_files)} files marked as 'best': {best_ckpt_files}. "
-            "Cannot automatically select from multiple 'best' checkpoints."
+        # Multiple 'best' checkpoints found (e.g., stale file on a network filesystem).
+        # Pick the one with the highest step count.
+        logger.warning(
+            f"Multiple 'best' checkpoint files found: {best_ckpt_files}. "
+            "Selecting the one with the highest step count."
         )
+        def _step(f):
+            m = re.search(r"step=(\d+)", f)
+            return int(m.group(1)) if m else -1
+
+        best_ckpt_files.sort(key=_step)
+        return best_ckpt_files[-1]
     else:
         # No 'best' checkpoint found
-        warnings.warn(
-            "No 'best' checkpoint found, falling back to latest checkpoint.",
-            stacklevel=2,
-        )
+        logger.warning("No 'best' checkpoint found, falling back to latest checkpoint.")
         if len(latest_version_files) == 1:
             # Only one checkpoint file exists, return it
             return latest_version_files[0]

--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -30,16 +30,41 @@ Results are written to teamspace storage and persist after each job ends.
 
 ## Running on Lightning AI
 
+### Studio setup
+
+Create a new studio, then install Lightning Pose from source following
+[Option B in the installation guide](https://lightning-pose.readthedocs.io/en/latest/source/installation_guide.html#option-b-installation-from-source-development).
+Also install `ffmpeg` as described in the docs. No conda environment is needed —
+the studio is a self-contained environment.
+
+### Teamspace storage setup
+
+Sweep results and cached datasets are written to Lightning's managed teamspace
+storage. Create the required folders once before running any sweeps:
+
+1. In your teamspace, click the **Drive** tab (next to Studios)
+2. Click **New Folder** and create a folder named `datasets`
+3. Click **New Folder** again and create a folder named `sweep-results`
+
+These names match the default paths in `sweep_config.yaml`, so no config edits
+are needed.
+
+### From within a studio
+
 > **Note:** `run_sweep.py` must be run from the `hyper-sweep/` directory so it
 > can import `run_single_job.py`. If you need to run it from elsewhere, add
 > `hyper-sweep/` to your `PYTHONPATH` first.
-
-### From within a studio
 
 ```bash
 cd lightning-pose/scripts/hyper-sweep
 python run_sweep.py --config sweep_config.yaml
 ```
+
+### Monitoring jobs
+
+Once launched, each job appears in the **Jobs** panel. You can also click the
+🚀 widget on the right-hand side of the studio — it shows a count of running
+jobs and lets you inspect machine stats and logs for each one.
 
 ### From outside Lightning AI
 
@@ -136,18 +161,6 @@ python run_single_job.py \
 
 To run a local sweep, call `run_single_job.py` in a loop or adapt
 `run_sweep.py` to call it via `subprocess` instead of `Job.run()`.
-
-## Dependencies
-
-```
-lightning-pose    # must be installed; provides the litpose CLI
-lightning_sdk     # pip install lightning_sdk  (orchestrator only)
-huggingface_hub   # pip install huggingface_hub (worker)
-pyyaml            # pip install pyyaml (orchestrator)
-```
-
-High-performance downloads are enabled automatically via `HF_XET_HIGH_PERFORMANCE=1`,
-set at the top of `run_single_job.py` before `huggingface_hub` is imported.
 
 ## Plotting results
 

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -1,5 +1,6 @@
 """Test the io module."""
 
+import logging
 import os
 import shutil
 import textwrap
@@ -113,26 +114,29 @@ def test_ckpt_path_from_base_path_one_best_checkpoint(tmp_path: Path):
     assert result == str(expected_ckpt)
 
 
-def test_ckpt_path_from_base_path_multiple_best_checkpoints(tmp_path: Path):
+def test_ckpt_path_from_base_path_multiple_best_checkpoints(tmp_path: Path, caplog):
     """
     Test Case 3: Multiple "best" checkpoints found in the latest version.
-    Expects ValueError.
+    Expects the checkpoint with the highest step count to be returned.
     """
     base_path = tmp_path / "project"
     model_name = "my_model"
     logging_dir_name = "tb_logs"
 
-    # Create latest version checkpoints with multiple best
     latest_version_path = base_path / logging_dir_name / model_name / "version_1" / "checkpoints"
     latest_version_path.mkdir(parents=True)
     (latest_version_path / "epoch=5-step=50-best.ckpt").touch()
-    (latest_version_path / "epoch=12-step=120-best.ckpt").touch()
+    expected_ckpt = latest_version_path / "epoch=12-step=120-best.ckpt"
+    expected_ckpt.touch()
 
-    with pytest.raises(ValueError, match="Multiple 'best' checkpoint files found"):
-        ckpt_path_from_base_path(str(base_path), model_name, logging_dir_name)
+    with caplog.at_level(logging.WARNING):
+        result = ckpt_path_from_base_path(str(base_path), model_name, logging_dir_name)
+
+    assert result == str(expected_ckpt)
+    assert any("Multiple 'best' checkpoint files found" in r.message for r in caplog.records)
 
 
-def test_ckpt_path_from_base_path_highest_step_count(tmp_path: Path):
+def test_ckpt_path_from_base_path_highest_step_count(tmp_path: Path, caplog):
     """
     Test Case 4: No "best" checkpoint, but multiple checkpoints, pick the one with highest step
     count in latest version.
@@ -155,13 +159,13 @@ def test_ckpt_path_from_base_path_highest_step_count(tmp_path: Path):
     (latest_version_path / "epoch=12-step=120.ckpt").touch()
     (latest_version_path / "epoch=11-step=110.ckpt").touch()
 
-    # Capture warnings as "No 'best' checkpoint found" is expected
-    with pytest.warns(UserWarning, match="No 'best' checkpoint found"):
+    with caplog.at_level(logging.WARNING):
         result = ckpt_path_from_base_path(str(base_path), model_name, logging_dir_name)
     assert result == str(expected_ckpt)
+    assert any("No 'best' checkpoint found" in r.message for r in caplog.records)
 
 
-def test_ckpt_path_from_base_path_single_checkpoint_no_best(tmp_path: Path):
+def test_ckpt_path_from_base_path_single_checkpoint_no_best(tmp_path: Path, caplog):
     """
     Test Case 5: No "best" checkpoint, and only one checkpoint file in the latest version.
     Expects the path to that single checkpoint.
@@ -181,12 +185,13 @@ def test_ckpt_path_from_base_path_single_checkpoint_no_best(tmp_path: Path):
     expected_ckpt = latest_version_path / "epoch=5-step=50.ckpt"
     expected_ckpt.touch()
 
-    with pytest.warns(UserWarning, match="No 'best' checkpoint found"):
+    with caplog.at_level(logging.WARNING):
         result = ckpt_path_from_base_path(str(base_path), model_name, logging_dir_name)
     assert result == str(expected_ckpt)
+    assert any("No 'best' checkpoint found" in r.message for r in caplog.records)
 
 
-def test_ckpt_path_from_base_path_cannot_parse_step(tmp_path: Path):
+def test_ckpt_path_from_base_path_cannot_parse_step(tmp_path: Path, caplog):
     """
     Test Case 6: No "best" checkpoint, multiple checkpoints, but step count cannot be parsed.
     Expects ValueError.
@@ -201,9 +206,10 @@ def test_ckpt_path_from_base_path_cannot_parse_step(tmp_path: Path):
     (latest_version_path / "model_v1_A.ckpt").touch()
     (latest_version_path / "model_v1_B.ckpt").touch()
 
-    with pytest.raises(ValueError, match="cannot parse step counts to determine latest"):
-        with pytest.warns(UserWarning, match="No 'best' checkpoint found"):
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match="cannot parse step counts to determine latest"):
             ckpt_path_from_base_path(str(base_path), model_name, logging_dir_name)
+    assert any("No 'best' checkpoint found" in r.message for r in caplog.records)
 
 
 def test_ckpt_path_from_base_path_custom_logging_dir_name(tmp_path: Path):


### PR DESCRIPTION
Current behavior is to throw an error if there are multiple "best" checkpoints; this fails if saving out multiple checkpoints, or if the filesystem is slow to update (as can happen on Lightning AI) and there are multiple checkpoints upon model completion, even if only one is requested.

This fix just takes the checkpoint with the highest step number, rather than throwing an error.