### PR TITLE
disallow SAM backbones in multiview transformers

### DIFF
--- a/docs/source/directory_structure_reference/model_config_file.rst
+++ b/docs/source/directory_structure_reference/model_config_file.rst
@@ -218,7 +218,7 @@ The following parameters relate to model architecture and unsupervised losses.
     * vitb_dinov2: Vision Transformer (Base) pretrained on ImageNet with DINOv2
     * vitb_dinov3: Vision Transformer (Base) pretrained on ImageNet with DINOv3; note this is a gated repo and you will need a Hugging Face account
     * vitb_imagenet: Vision Transformer (Base) pretrained on ImageNet with MAE loss
-    * vitb_sam: Segment Anything Model (Vision Transformer Base)
+    * vitb_sam: Segment Anything Model (Vision Transformer Base); not supported for ``heatmap_multiview_transformer``
 
   Note: the file size for a single ResNet-50 network is approximately 275 MB.
 

--- a/docs/source/user_guide_multiview/patch_masking_3d_loss.rst
+++ b/docs/source/user_guide_multiview/patch_masking_3d_loss.rst
@@ -19,7 +19,7 @@ specified in the configuration file:
 
 The backbone can be any of the available backbones that start with the string "vit"
 (see options :ref:`here <config_file_model>`),
-indicating Vision Transformer.
+indicating Vision Transformer, with the exception of ``vitb_sam``.
 The "heatmap_multiview_transformer" will then use the specified backbone to process all camera
 view simultaneously.
 

--- a/lightning_pose/models/backbones/__init__.py
+++ b/lightning_pose/models/backbones/__init__.py
@@ -37,3 +37,13 @@ ALLOWED_TRANSFORMER_BACKBONES = Literal[
     "vitb_imagenet",
     "vitb_sam",
 ]
+
+ALLOWED_TRANSFORMER_BACKBONES_MULTIVIEW = Literal[
+    "vits_dino",
+    "vits_dinov2",
+    "vits_dinov3",
+    "vitb_dino",
+    "vitb_dinov2",
+    "vitb_dinov3",
+    "vitb_imagenet",
+]

--- a/lightning_pose/models/heatmap_tracker_multiview.py
+++ b/lightning_pose/models/heatmap_tracker_multiview.py
@@ -22,7 +22,7 @@ from lightning_pose.data.utils import (
 )
 from lightning_pose.losses.factory import LossFactory
 from lightning_pose.losses.losses import RegressionRMSELoss
-from lightning_pose.models.backbones import ALLOWED_TRANSFORMER_BACKBONES
+from lightning_pose.models.backbones import ALLOWED_TRANSFORMER_BACKBONES_MULTIVIEW
 from lightning_pose.models.base import (
     BaseSupervisedTracker,
     SemiSupervisedTrackerMixin,
@@ -45,7 +45,7 @@ class HeatmapTrackerMultiviewTransformer(BaseSupervisedTracker):
         num_keypoints: int,
         num_views: int,
         loss_factory: LossFactory | None = None,
-        backbone: ALLOWED_TRANSFORMER_BACKBONES = "vits_dino",
+        backbone: ALLOWED_TRANSFORMER_BACKBONES_MULTIVIEW = "vits_dino",
         pretrained: bool = True,
         head: Literal["heatmap_cnn"] = "heatmap_cnn",
         downsample_factor: Literal[1, 2, 3] = 2,
@@ -63,7 +63,7 @@ class HeatmapTrackerMultiviewTransformer(BaseSupervisedTracker):
             num_keypoints: number of body parts
             num_views: number of camera views
             loss_factory: object to orchestrate loss computation
-            backbone: transformer variant to be used; cannot use convnets with this model
+            backbone: transformer variant to be used; cannot use convnets or vitb_sam
             pretrained: True to load pretrained imagenet weights
             head: architecture used to project per-view information to 2D heatmaps
                 - heatmap_cnn
@@ -78,17 +78,24 @@ class HeatmapTrackerMultiviewTransformer(BaseSupervisedTracker):
 
         """
 
-        # for reproducible weight initialization
-        self.torch_seed = torch_seed
-        torch.manual_seed(torch_seed)
-
-        self.num_views = num_views
-
         # backwards compatibility
         if "do_context" in kwargs.keys():
             raise ValueError(
                 "HeatmapTrackerMultiviewTransformer does not currently support context frames"
             )
+
+        allowed = list(ALLOWED_TRANSFORMER_BACKBONES_MULTIVIEW.__args__)  # type: ignore[attr-defined]
+        if backbone not in allowed:
+            raise ValueError(
+                f'backbone "{backbone}" is not supported for multiview transformer models; '
+                f'allowed backbones: {allowed}'
+            )
+
+        # for reproducible weight initialization
+        self.torch_seed = torch_seed
+        torch.manual_seed(torch_seed)
+
+        self.num_views = num_views
 
         super().__init__(
             backbone=backbone,
@@ -375,7 +382,7 @@ class SemiSupervisedHeatmapTrackerMultiviewTransformer(
         num_views: int,
         loss_factory: LossFactory | None = None,
         loss_factory_unsupervised: LossFactory | None = None,
-        backbone: ALLOWED_TRANSFORMER_BACKBONES = "vits_dino",
+        backbone: ALLOWED_TRANSFORMER_BACKBONES_MULTIVIEW = "vits_dino",
         pretrained: bool = True,
         head: Literal["heatmap_cnn"] = "heatmap_cnn",
         downsample_factor: Literal[1, 2, 3] = 2,

--- a/tests/models/test_heatmap_tracker_multiview.py
+++ b/tests/models/test_heatmap_tracker_multiview.py
@@ -3,13 +3,14 @@
 import copy
 
 import numpy as np
+import pytest
 import torch
 
 from lightning_pose.data.datasets import MultiviewHeatmapDataset
 from lightning_pose.data.datatypes import MultiviewHeatmapLabeledExampleDict
 
 
-def test_multiview_transformer(
+def test_multiview_transformer_vits_dino(
     cfg_multiview,
     multiview_heatmap_dataset,
     video_dataloader_multiview,
@@ -41,6 +42,102 @@ def test_multiview_transformer(
         video_dataloader=video_dataloader_multiview,
         trainer=trainer,
     )
+
+
+def test_multiview_transformer_vits_dinov2(
+    cfg_multiview,
+    multiview_heatmap_dataset,
+    video_dataloader_multiview,
+    trainer,
+    run_model_test,
+):
+    """Test initialization and training of a multiview model with heatmap head."""
+
+    cfg_tmp = copy.deepcopy(cfg_multiview)
+    cfg_tmp.model.model_type = "heatmap_multiview_transformer"
+    cfg_tmp.model.backbone = "vits_dinov2"
+    cfg_tmp.model.head = "heatmap_cnn"
+    cfg_tmp.model.losses_to_use = []
+
+    # make mock dataset that returns fake camera parameters
+    from lightning_pose.data import get_data_module
+    data_module = get_data_module(
+        cfg_tmp,
+        dataset=MockCameraDatasetWrapper(
+            multiview_heatmap_dataset,
+            num_views=len(cfg_tmp.data.view_names),
+        ),
+        video_dir=None,
+    )
+
+    run_model_test(
+        cfg=cfg_tmp,
+        data_module=data_module,
+        video_dataloader=video_dataloader_multiview,
+        trainer=trainer,
+    )
+
+
+def test_multiview_transformer_vitb_imagenet(
+    cfg_multiview,
+    multiview_heatmap_dataset,
+    video_dataloader_multiview,
+    trainer,
+    run_model_test,
+):
+    """Test initialization and training of a multiview model with heatmap head."""
+
+    cfg_tmp = copy.deepcopy(cfg_multiview)
+    cfg_tmp.model.model_type = "heatmap_multiview_transformer"
+    cfg_tmp.model.backbone = "vitb_imagenet"
+    cfg_tmp.model.head = "heatmap_cnn"
+    cfg_tmp.model.losses_to_use = []
+
+    # make mock dataset that returns fake camera parameters
+    from lightning_pose.data import get_data_module
+    data_module = get_data_module(
+        cfg_tmp,
+        dataset=MockCameraDatasetWrapper(
+            multiview_heatmap_dataset,
+            num_views=len(cfg_tmp.data.view_names),
+        ),
+        video_dir=None,
+    )
+
+    run_model_test(
+        cfg=cfg_tmp,
+        data_module=data_module,
+        video_dataloader=video_dataloader_multiview,
+        trainer=trainer,
+    )
+
+
+def test_multiview_transformer_vitb_sam_raises(
+    cfg_multiview,
+    multiview_heatmap_dataset,
+):
+    """Test that vitb_sam backbone raises ValueError for multiview transformer models."""
+
+    from lightning_pose.data import get_data_module
+    from lightning_pose.models import get_model
+
+    cfg_tmp = copy.deepcopy(cfg_multiview)
+    cfg_tmp.model.model_type = "heatmap_multiview_transformer"
+    cfg_tmp.model.backbone = "vitb_sam"
+    cfg_tmp.model.head = "heatmap_cnn"
+    cfg_tmp.model.losses_to_use = []
+
+    data_module = get_data_module(
+        cfg_tmp,
+        dataset=MockCameraDatasetWrapper(
+            multiview_heatmap_dataset,
+            num_views=len(cfg_tmp.data.view_names),
+        ),
+        video_dir=None,
+    )
+
+    with pytest.raises(ValueError, match='vitb_sam'):
+        get_model(cfg=cfg_tmp, data_module=data_module, loss_factories={'supervised': None})
 
 
 def test_semisupervised_multiview_transformer_temporal(


### PR DESCRIPTION
  SAM's vision encoder is architecturally incompatible with the multiview transformer's forward_vit design. The
  multiview model works by extracting patch embeddings, adding view embeddings, concatenating all views into a
  single sequence (batch, view * num_patches, dim), and running that sequence through transformer layers for
  cross-view attention. SAM breaks this at three points:

  1. The `embeddings` module does not exist in SAM models — patch and positional
  embeddings are separate (patch_embed, pos_embed), and patch output is a 4D NHWC tensor rather than a 1D
  sequence.
  2. SAM's attention layers (SamVisionLayer) operate on spatial NHWC grids with window attention, not on
  arbitrary-length sequences — they cannot accept the concatenated cross-view sequence.
  3. SAM uses a neck projection rather than layernorm as its final encoder step.

  Rather than add a fragile three-part workaround, this PR adds `ALLOWED_TRANSFORMER_BACKBONES_MULTIVIEW`
  (excluding `vitb_sam`) and raises a ValueError at model construction time with a clear message. A regression
  test verifies the error is raised early and mentions the offending backbone name.