### PR TITLE
add visibility column to labels csv

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,24 +261,34 @@ Label CSV files support an optional `visible` column after each `x, y` pair
 | 1 | occluded | uniform (encourages low-confidence output) |
 | 2 | visible | Gaussian (standard supervised target) |
 
-**Detection**: `io_utils.has_visibility_column(csv_file, header_rows)` returns `True` when
-the `coords` header row contains a `visible` entry. Only the `[0, 1, 2]` (DLC) header format
-is supported; all other formats return `False`.
+**Detection**: inline in `parse_label_csv` — the `coords` header row is checked for a `visible`
+entry. Only the `[0, 1, 2]` (DLC) header format is supported; all other formats are treated as
+having no visibility column.
 
 **Parsing** (`BaseTrackingDataset.__init__`): when detected, the raw CSV is reshaped to
 `(N, K, 3)` and split into `self.keypoints (N, K, 2)` (x, y) and
-`self.visibility (N, K)` `int64` tensor. When absent, `self.visibility = None` and the legacy
-`uniform_heatmaps_for_nan_keypoints` config flag governs behavior.
+`self.visibility (N, K)` `int64` tensor. When absent, `self.visibility = None`.
+
+**Synthesis** (`HeatmapDataset.__init__`): when `self.visibility is None` after the base class
+init, visibility is synthesized from NaN positions: NaN keypoints get `vis=1` (uniform) if the
+`uniform_heatmaps_for_nan_keypoints` config flag is set, else `vis=0` (zero); valid keypoints
+get `vis=2`. This ensures `self.visibility` is always populated before training.
+
+**`BaseLabeledExampleDict`**: always contains a `visibility` key. When
+`BaseTrackingDataset.visibility is None`, the value is an empty tensor
+`torch.zeros(0, dtype=torch.long)` (sentinel that collates cleanly); otherwise a `(K,)` int64
+tensor. `compute_heatmap` checks `numel() > 0` to distinguish the two cases.
 
 **Heatmap generation** (`generate_heatmaps` in `lightning_pose/data/utils.py`): accepts an
 optional `visibility: Int[Tensor, "batch K"]` parameter. The Gaussian computation and
-normalization are unchanged; only the 8-line filler block at the end branches on visibility.
-`visibility=None` is bit-for-bit identical to the legacy path.
+normalization are unchanged; only the filler block at the end branches on visibility.
+`visibility=None` → OOB/NaN keypoints produce zeros (safe for loss callers, which never pass
+NaN-coordinate predictions).
 
-**Propagation**: `HeatmapDataset.compute_heatmap` reads `example_dict["idxs"]` (already
-present in every batch dict) to index `self.visibility` and pass a `(1, K)` slice to
-`generate_heatmaps`. No changes to loss functions are needed — zero heatmaps are already
-filtered by `HeatmapLoss.remove_nans`, and uniform heatmaps are already included.
+**Propagation**: `HeatmapDataset.compute_heatmap` reads `example_dict["visibility"]` directly
+(set by `BaseTrackingDataset.__getitem__`) and passes it to `generate_heatmaps`. No changes to
+loss functions are needed — zero heatmaps are already filtered by `HeatmapLoss.remove_nans`,
+and uniform heatmaps are already included.
 
 **Warnings**: a `logger.warning` is emitted if vis=1 keypoints have non-NaN coordinates
 (the visibility flag wins; coordinates are ignored).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,41 @@ frame. The index column is ignored on read.
 `model.predict_on_video_file(bbox_file=...)` → `predict_video(bbox_file=...)` →
 `PrepareDALI(bbox_df=...)` → `LitDaliWrapper._apply_bbox_crop`.
 
+### Per-keypoint visibility (`lightning_pose/data/`)
+
+Label CSV files support an optional `visible` column after each `x, y` pair
+(`x, y, visible, x, y, visible, …`), following the COCO keypoint convention:
+
+| Value | Meaning | Heatmap target |
+|-------|---------|----------------|
+| 0 | not labeled | all-zeros (excluded from loss) |
+| 1 | occluded | uniform (encourages low-confidence output) |
+| 2 | visible | Gaussian (standard supervised target) |
+
+**Detection**: `io_utils.has_visibility_column(csv_file, header_rows)` returns `True` when
+the `coords` header row contains a `visible` entry. Only the `[0, 1, 2]` (DLC) header format
+is supported; all other formats return `False`.
+
+**Parsing** (`BaseTrackingDataset.__init__`): when detected, the raw CSV is reshaped to
+`(N, K, 3)` and split into `self.keypoints (N, K, 2)` (x, y) and
+`self.visibility (N, K)` `int64` tensor. When absent, `self.visibility = None` and the legacy
+`uniform_heatmaps_for_nan_keypoints` config flag governs behavior.
+
+**Heatmap generation** (`generate_heatmaps` in `lightning_pose/data/utils.py`): accepts an
+optional `visibility: Int[Tensor, "batch K"]` parameter. The Gaussian computation and
+normalization are unchanged; only the 8-line filler block at the end branches on visibility.
+`visibility=None` is bit-for-bit identical to the legacy path.
+
+**Propagation**: `HeatmapDataset.compute_heatmap` reads `example_dict["idxs"]` (already
+present in every batch dict) to index `self.visibility` and pass a `(1, K)` slice to
+`generate_heatmaps`. No changes to loss functions are needed — zero heatmaps are already
+filtered by `HeatmapLoss.remove_nans`, and uniform heatmaps are already included.
+
+**Warnings**: a `logger.warning` is emitted if vis=1 keypoints have non-NaN coordinates
+(the visibility flag wins; coordinates are ignored).
+
+**Validation**: raises `ValueError` if any visibility value is outside `{0, 1, 2}`.
+
 ### Post-training evaluation (`lightning_pose/train.py`)
 
 After training, `train()` calls `_evaluate_on_training_dataset(model, suffix=...)` three times:

--- a/docs/source/directory_structure_reference/changelog.rst
+++ b/docs/source/directory_structure_reference/changelog.rst
@@ -10,6 +10,18 @@ over time.
    :depth: 2
 
 
+v2.1.2 | June 11, 2026
+------------------------------------
+
+* Label CSV files now support an optional ``visible`` column after each ``x, y`` pair
+  (columns become ``x, y, visible, x, y, visible, …``).
+  Values: **0** = not labeled (exclude from loss), **1** = occluded (uniform heatmap target),
+  **2** = visible (Gaussian heatmap target).
+  This allows mixing visibility behaviors within a single dataset.
+  When the column is absent, behavior is unchanged and is controlled by
+  ``training.uniform_heatmaps_for_nan_keypoints``.
+  See :ref:`label_csv_file_format` for full details.
+
 v2.1.1 | May 15, 2026
 ------------------------------------
 

--- a/docs/source/directory_structure_reference/label_csv_file_format.rst
+++ b/docs/source/directory_structure_reference/label_csv_file_format.rst
@@ -9,6 +9,59 @@ for an example of the expected format of our label files.
 For multiview projects, each view has its own label file. The label files are
 aligned across views: the Nth row represents the same frame across files.
 
+Standard format (x, y only)
+-----------------------------
+
+The standard format uses two columns per keypoint — ``x`` and ``y``.
+Missing (unlabeled) keypoints are left as empty cells, which pandas reads as ``NaN``.
+The training behavior for these unlabeled keypoints is controlled by
+:ref:`training.uniform_heatmaps_for_nan_keypoints <config_file>`.
+
+.. code-block:: text
+
+    scorer,    scorer,  scorer,  scorer,  scorer
+    bodyparts, kp1,     kp1,     kp2,     kp2
+    coords,    x,       y,       x,       y
+    img01.png, 77.25,   36.25,   ,
+    img02.png, 37.25,   110.75,  12.5,    88.0
+
+Extended format with per-keypoint visibility
+---------------------------------------------
+
+An optional third column ``visible`` can be added after each ``x, y`` pair to specify
+per-keypoint visibility flags. The flag values follow the
+`COCO keypoint format <https://cocodataset.org/#keypoints-eval>`_:
+
+* **0** — keypoint is not labeled; it is excluded from the loss (same as leaving the cell empty
+  when ``training.uniform_heatmaps_for_nan_keypoints: false``).
+* **1** — keypoint is occluded; a uniform heatmap is used as the training target, which
+  encourages the model to output low-confidence predictions (same as
+  ``training.uniform_heatmaps_for_nan_keypoints: true``).
+* **2** — keypoint is visible; a Gaussian heatmap is used as the training target (standard
+  supervised training).
+
+.. code-block:: text
+
+    scorer,    scorer,  scorer,  scorer,  scorer,  scorer,  scorer
+    bodyparts, kp1,     kp1,     kp1,     kp2,     kp2,     kp2
+    coords,    x,       y,       visible, x,       y,       visible
+    img01.png, 77.25,   36.25,   2,       ,        ,        0
+    img02.png, 37.25,   110.75,  2,       ,        ,        1
+
+The extended format allows you to mix visibility behaviors within a single dataset —
+some keypoints can be excluded from the loss, others can encourage uncertainty, and others
+can receive normal supervised targets, all in the same training run.
+
+When the ``visible`` column is present it takes precedence over
+``training.uniform_heatmaps_for_nan_keypoints``, which serves only as a fallback for
+CSVs that omit the visibility column.
+
+.. note::
+
+   If a keypoint is marked ``visible=1`` (occluded) but ``x, y`` coordinates are also
+   provided in the CSV, a warning is logged and the coordinates are ignored — the uniform
+   heatmap is used regardless.
+
 Manipulating label files
 -------------------------
 

--- a/docs/source/directory_structure_reference/model_config_file.rst
+++ b/docs/source/directory_structure_reference/model_config_file.rst
@@ -156,7 +156,7 @@ See the :ref:`FAQs <faq_oom>` for more information on memory management.
   rate; gamma: factor by which to multiply learning rate at each milestone
 
 * ``training.uniform_heatmaps_for_nan_keypoints`` (*bool, default: true*): how to treat missing
-  hand labels.
+  hand labels in CSVs that do **not** include a ``visible`` column.
   Setting this to true will encourage the model to output uniform heatmaps for keypoints that do
   not have ground truth labels; this will generally lead to low-confidence predictions when a
   keypoint is occluded.
@@ -164,6 +164,8 @@ See the :ref:`FAQs <faq_oom>` for more information on memory management.
   encouraging uniform heatmaps. This generally leads to high confidence predictions even when a
   keypoint is occluded. Using false may be preferrable if occulsions are brief in time and you want
   the network to guess where the keypoint should be (rather than signaling uncertainty).
+  This flag is ignored for any keypoint that has an explicit ``visible`` value in the CSV;
+  see :ref:`label_csv_file_format` for the per-keypoint visibility column format.
 
 * ``training.accumulate_grad_batches`` (*int, default: 1*): (experimental) number of batches to
   accumulate gradients for before updating weights. Simulates larger batch sizes with

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -309,8 +309,11 @@ class HeatmapDataset(BaseTrackingDataset):
                 sophisticated augmentations before resizing (e.g. 3d augmentations). Note that when
                 this is False, it is up to the child class to perform this resizing on both images
                 and keypoints before returning a batch of data.
-            uniform_heatmaps: True to force the model to output uniform heatmaps for missing data;
-                False will output all-zero heatmaps
+            uniform_heatmaps: when the CSV has no ``visible`` column, controls the target
+                heatmap for NaN (unlabeled) keypoints. True generates a uniform heatmap
+                (visibility=1, encourages low-confidence predictions); False generates an
+                all-zero heatmap (visibility=0, excluded from loss). Ignored when the CSV
+                provides explicit visibility flags.
             bbox_path: path to csv file that contains bounding box information; rows must be in
                 same order as csv file
 
@@ -336,9 +339,18 @@ class HeatmapDataset(BaseTrackingDataset):
 
         self.downsample_factor: Literal[1, 2, 3] = downsample_factor
         self.output_sigma = 1.25  # should be sigma/2 ^downsample factor
-        self.uniform_heatmaps = uniform_heatmaps
         self.num_targets = torch.numel(self.keypoints[0])
         self.num_keypoints = self.num_targets // 2
+
+        # synthesize visibility for CSVs that don't provide a visible column
+        if self.visibility is None:
+            nan_mask = torch.isnan(self.keypoints[:, :, 0])
+            vis_for_nan = 1 if uniform_heatmaps else 0
+            self.visibility = torch.where(
+                nan_mask,
+                torch.full_like(nan_mask, vis_for_nan, dtype=torch.long),
+                torch.full_like(nan_mask, 2, dtype=torch.long),
+            )
 
     @property
     def output_shape(self) -> tuple:
@@ -388,7 +400,6 @@ class HeatmapDataset(BaseTrackingDataset):
             width=self.width,
             output_shape=self.output_shape,
             sigma=self.output_sigma,
-            uniform_heatmaps=self.uniform_heatmaps,
             visibility=vis,
         )
 

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -115,31 +115,14 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             csv_file = csv_path
         else:
             csv_file = os.path.join(root_directory, csv_path)
-        if not os.path.exists(csv_file):
-            raise FileNotFoundError(f"Could not find csv file at {csv_file}!")
 
-        csv_data = pd.read_csv(csv_file, header=header_rows, index_col=0)
-        csv_data = io_utils.fix_empty_first_row(csv_data)
-        self.keypoint_names = io_utils.get_keypoint_names(
-            csv_file=csv_file, header_rows=header_rows,
-        )
-        self.image_names = list(csv_data.index)
-        has_vis = io_utils.has_visibility_column(csv_file, header_rows=header_rows)
-        if has_vis:
-            raw = torch.tensor(csv_data.to_numpy(), dtype=torch.float32)
-            # columns are ordered x, y, visible, x, y, visible, ...
-            raw = raw.reshape(raw.shape[0], -1, 3)
-            self.keypoints = raw[:, :, :2].contiguous()  # (N, K, 2)
-            vis_float = raw[:, :, 2]  # (N, K)
-            valid_vals = {0.0, 1.0, 2.0}
-            unique_vals = set(vis_float[~torch.isnan(vis_float)].unique().tolist())
-            invalid_vals = unique_vals - valid_vals
-            if invalid_vals:
-                raise ValueError(
-                    f'visibility column contains invalid values {invalid_vals}; '
-                    'expected values in {0, 1, 2}'
-                )
-            self.visibility: torch.Tensor | None = vis_float.long()  # (N, K)
+        labeled_data = io_utils.parse_label_csv(csv_file, header_rows=header_rows)
+        self.keypoint_names = labeled_data.keypoint_names
+        self.image_names = labeled_data.image_names
+        self.keypoints = labeled_data.keypoints
+        self.visibility: torch.Tensor | None = labeled_data.visibility
+
+        if self.visibility is not None:
             occluded_with_coords = (
                 (self.visibility == 1) & ~torch.isnan(self.keypoints[:, :, 0])
             )
@@ -149,11 +132,6 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
                     'coordinates; the visibility flag takes precedence and a uniform heatmap '
                     'will be generated for these keypoints'
                 )
-        else:
-            self.keypoints = torch.tensor(csv_data.to_numpy(), dtype=torch.float32)
-            # convert to x,y coordinates
-            self.keypoints = self.keypoints.reshape(self.keypoints.shape[0], -1, 2)
-            self.visibility = None
 
         # send image to tensor and normalize
         pytorch_transform_list = [
@@ -177,10 +155,10 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             if not os.path.exists(bbox_file):
                 raise FileNotFoundError(f"Could not find bbox file at {bbox_file}!")
             bboxes_df = pd.read_csv(bbox_file, header=[0], index_col=0)
-            assert bboxes_df.index.equals(csv_data.index)
+            assert bboxes_df.index.tolist() == self.image_names
             bboxes = bboxes_df.to_numpy()
         else:
-            bboxes = [None] * len(csv_data)
+            bboxes = [None] * len(self.image_names)
         self.bboxes = bboxes
 
     @property

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -263,6 +263,11 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             keypoints=torch.from_numpy(transformed_keypoints),  # shape (n_targets,)
             idxs=idx,
             bbox=bbox,
+            visibility=(
+                self.visibility[idx]
+                if self.visibility is not None
+                else torch.zeros(0, dtype=torch.long)
+            ),
         )
 
 
@@ -371,8 +376,11 @@ class HeatmapDataset(BaseTrackingDataset):
             )
             keypoints[new_nans, :] = torch.nan
 
-        idx = example_dict["idxs"]
-        vis = self.visibility[idx].unsqueeze(0) if self.visibility is not None else None
+        vis = (
+            example_dict["visibility"].unsqueeze(0)
+            if example_dict["visibility"].numel() > 0
+            else None
+        )
 
         y_heatmap = generate_heatmaps(
             keypoints=keypoints.unsqueeze(0),  # add batch dim
@@ -942,6 +950,7 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
                 keypoints=keypoints_2d_aug_resize[idx_view],
                 bbox=data_dict[view]["bbox"],
                 idxs=data_dict[view]["idxs"],
+                visibility=data_dict[view]["visibility"],
             )
             example_dict["heatmaps"] = self.dataset[view].compute_heatmap(example_dict)  # type: ignore[typeddict-unknown-key]
             data_dict_aug[view] = example_dict

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -124,9 +124,36 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             csv_file=csv_file, header_rows=header_rows,
         )
         self.image_names = list(csv_data.index)
-        self.keypoints = torch.tensor(csv_data.to_numpy(), dtype=torch.float32)
-        # convert to x,y coordinates
-        self.keypoints = self.keypoints.reshape(self.keypoints.shape[0], -1, 2)
+        has_vis = io_utils.has_visibility_column(csv_file, header_rows=header_rows)
+        if has_vis:
+            raw = torch.tensor(csv_data.to_numpy(), dtype=torch.float32)
+            # columns are ordered x, y, visible, x, y, visible, ...
+            raw = raw.reshape(raw.shape[0], -1, 3)
+            self.keypoints = raw[:, :, :2].contiguous()  # (N, K, 2)
+            vis_float = raw[:, :, 2]  # (N, K)
+            valid_vals = {0.0, 1.0, 2.0}
+            unique_vals = set(vis_float[~torch.isnan(vis_float)].unique().tolist())
+            invalid_vals = unique_vals - valid_vals
+            if invalid_vals:
+                raise ValueError(
+                    f'visibility column contains invalid values {invalid_vals}; '
+                    'expected values in {0, 1, 2}'
+                )
+            self.visibility: torch.Tensor | None = vis_float.long()  # (N, K)
+            occluded_with_coords = (
+                (self.visibility == 1) & ~torch.isnan(self.keypoints[:, :, 0])
+            )
+            if occluded_with_coords.any():
+                logger.warning(
+                    'found keypoints with visible=1 (occluded) that have non-NaN x,y '
+                    'coordinates; the visibility flag takes precedence and a uniform heatmap '
+                    'will be generated for these keypoints'
+                )
+        else:
+            self.keypoints = torch.tensor(csv_data.to_numpy(), dtype=torch.float32)
+            # convert to x,y coordinates
+            self.keypoints = self.keypoints.reshape(self.keypoints.shape[0], -1, 2)
+            self.visibility = None
 
         # send image to tensor and normalize
         pytorch_transform_list = [
@@ -366,6 +393,9 @@ class HeatmapDataset(BaseTrackingDataset):
             )
             keypoints[new_nans, :] = torch.nan
 
+        idx = example_dict["idxs"]
+        vis = self.visibility[idx].unsqueeze(0) if self.visibility is not None else None
+
         y_heatmap = generate_heatmaps(
             keypoints=keypoints.unsqueeze(0),  # add batch dim
             height=self.height,
@@ -373,6 +403,7 @@ class HeatmapDataset(BaseTrackingDataset):
             output_shape=self.output_shape,
             sigma=self.output_sigma,
             uniform_heatmaps=self.uniform_heatmaps,
+            visibility=vis,
         )
 
         return y_heatmap[0]

--- a/lightning_pose/data/datatypes.py
+++ b/lightning_pose/data/datatypes.py
@@ -116,6 +116,7 @@ class BaseLabeledExampleDict(TypedDict):
     keypoints: Float[torch.Tensor, "num_targets"]
     bbox: Float[torch.Tensor, "xyhw"]
     idxs: int
+    visibility: Int[torch.Tensor, "num_keypoints"]
 
 
 class HeatmapLabeledExampleDict(BaseLabeledExampleDict):

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -165,7 +165,6 @@ def generate_heatmaps(
     width: int,
     output_shape: tuple[int, int],
     sigma: float = 1.25,
-    uniform_heatmaps: bool = False,
     keep_gradients: bool = False,
     visibility: Int[torch.Tensor, "batch num_keypoints"] | None = None,
 ) -> Float[torch.Tensor, "batch num_keypoints height width"]:
@@ -177,12 +176,10 @@ def generate_heatmaps(
         width: width of reshaped image (pixels, e.g., 128, 256, 512...)
         output_shape: dimensions of downsampled heatmap, (height, width)
         sigma: control spread of gaussian
-        uniform_heatmaps: output uniform heatmaps if missing ground truth label, rather than skip;
-            ignored when ``visibility`` is provided
         keep_gradients: True to not detach gradients from keypoints before creating heatmaps
-        visibility: optional per-keypoint visibility flags with values 0 (not labeled → zero
-            heatmap), 1 (occluded → uniform heatmap), or 2 (visible → Gaussian heatmap). When
-            None, falls back to NaN detection combined with the ``uniform_heatmaps`` flag.
+        visibility: per-keypoint visibility flags with values 0 (not labeled → zero heatmap),
+            1 (occluded → uniform heatmap), or 2 (visible → Gaussian heatmap). When None,
+            NaN/out-of-bounds keypoints produce zero heatmaps.
 
     Returns:
         batch of 2D heatmaps
@@ -196,20 +193,15 @@ def generate_heatmaps(
     out_width = output_shape[1]
     keypoints[:, :, 1] *= out_height / height
     keypoints[:, :, 0] *= out_width / width
-    # nan_idxs = torch.isnan(keypoints)[:, :, 0]
-    # Mark as invalid: NaN keypoints OR out-of-bounds keypoints
     nan_idxs = (
-        torch.isnan(keypoints)[:, :, 0]  # Original NaN check
-        | (keypoints[:, :, 0] < -1)  # x < -1
-        | (keypoints[:, :, 0] > out_width + 1)  # x > width + 1
-        | (keypoints[:, :, 1] < -1)  # y < -1
-        | (keypoints[:, :, 1] > out_height + 1)  # y > height + 1
+        torch.isnan(keypoints)[:, :, 0]
+        | (keypoints[:, :, 0] < -1)
+        | (keypoints[:, :, 0] > out_width + 1)
+        | (keypoints[:, :, 1] < -1)
+        | (keypoints[:, :, 1] > out_height + 1)
     )
 
-    # Clamp keypoints to prevent extreme Gaussian computations
-    # Use a reasonable buffer around the image bounds
-    # keypoints[:, :, 0] = torch.clamp(keypoints[:, :, 0], -margin, out_width + margin)
-    # keypoints[:, :, 1] = torch.clamp(keypoints[:, :, 1], -margin, out_height + margin)
+    # clamp keypoints to prevent extreme Gaussian computations
     clamped_x = torch.clamp(keypoints[:, :, 0], -1, out_width + 1)
     clamped_y = torch.clamp(keypoints[:, :, 1], -1, out_height + 1)
     keypoints = torch.stack([clamped_x, clamped_y], dim=2)
@@ -237,13 +229,10 @@ def generate_heatmaps(
     ) / (out_height * out_width)
 
     if visibility is None:
-        # backward-compat: NaN/OOB keypoints get a uniform or zero filler based on the flag
-        # (all-zeros heatmaps are ignored in the supervised heatmap loss)
-        heatmaps[nan_idxs] = uniform_heatmap if uniform_heatmaps else zero_heatmap
+        heatmaps[nan_idxs] = zero_heatmap
     else:
-        heatmaps[visibility == 0] = zero_heatmap    # not labeled: ignore in loss
+        heatmaps[visibility == 0] = zero_heatmap     # not labeled; ignore in loss
         heatmaps[visibility == 1] = uniform_heatmap  # occluded: encourage low confidence
-        # visible keypoints with NaN/OOB coords fall back to zero (defensive)
         heatmaps[(visibility == 2) & nan_idxs] = zero_heatmap
 
     return heatmaps

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -6,7 +6,7 @@ import os
 
 import numpy as np
 import torch
-from jaxtyping import Float
+from jaxtyping import Float, Int
 
 from lightning_pose.data.datatypes import (
     HeatmapLabeledBatchDict,
@@ -167,6 +167,7 @@ def generate_heatmaps(
     sigma: float = 1.25,
     uniform_heatmaps: bool = False,
     keep_gradients: bool = False,
+    visibility: Int[torch.Tensor, "batch num_keypoints"] | None = None,
 ) -> Float[torch.Tensor, "batch num_keypoints height width"]:
     """Generate 2D Gaussian heatmaps from mean and sigma.
 
@@ -176,8 +177,12 @@ def generate_heatmaps(
         width: width of reshaped image (pixels, e.g., 128, 256, 512...)
         output_shape: dimensions of downsampled heatmap, (height, width)
         sigma: control spread of gaussian
-        uniform_heatmaps: output uniform heatmaps if missing ground truth label, rather than skip
+        uniform_heatmaps: output uniform heatmaps if missing ground truth label, rather than skip;
+            ignored when ``visibility`` is provided
         keep_gradients: True to not detach gradients from keypoints before creating heatmaps
+        visibility: optional per-keypoint visibility flags with values 0 (not labeled → zero
+            heatmap), 1 (occluded → uniform heatmap), or 2 (visible → Gaussian heatmap). When
+            None, falls back to NaN detection combined with the ``uniform_heatmaps`` flag.
 
     Returns:
         batch of 2D heatmaps
@@ -226,16 +231,21 @@ def generate_heatmaps(
     heatmaps = torch.exp(heatmaps)
     # normalize all heatmaps to one
     heatmaps = heatmaps / torch.sum(heatmaps, dim=(2, 3), keepdim=True)
-    # replace nans with zeros heatmaps
-    # (all zeros heatmaps are ignored in the supervised heatmap loss)
-    if uniform_heatmaps:
-        filler_heatmap = torch.ones(
-            (out_height, out_width), device=keypoints.device
-        ) / (out_height * out_width)
-    else:
-        filler_heatmap = torch.zeros((out_height, out_width), device=keypoints.device)
+    zero_heatmap = torch.zeros((out_height, out_width), device=keypoints.device)
+    uniform_heatmap = torch.ones(
+        (out_height, out_width), device=keypoints.device
+    ) / (out_height * out_width)
 
-    heatmaps[nan_idxs] = filler_heatmap
+    if visibility is None:
+        # backward-compat: NaN/OOB keypoints get a uniform or zero filler based on the flag
+        # (all-zeros heatmaps are ignored in the supervised heatmap loss)
+        heatmaps[nan_idxs] = uniform_heatmap if uniform_heatmaps else zero_heatmap
+    else:
+        heatmaps[visibility == 0] = zero_heatmap    # not labeled: ignore in loss
+        heatmaps[visibility == 1] = uniform_heatmap  # occluded: encourage low confidence
+        # visible keypoints with NaN/OOB coords fall back to zero (defensive)
+        heatmaps[(visibility == 2) & nan_idxs] = zero_heatmap
+
     return heatmaps
 
 

--- a/lightning_pose/losses/factory.py
+++ b/lightning_pose/losses/factory.py
@@ -148,10 +148,6 @@ def get_loss_factories(
                 #     height_ds
                 # )
                 # loss_params_dict['unsupervised'][loss_name]['downsampled_image_width'] = width_ds
-                # if loss_name[:8] == 'unimodal':
-                #     loss_params_dict['unsupervised'][loss_name]['uniform_heatmaps'] = (
-                #         cfg.training.get('uniform_heatmaps_for_nan_keypoints', False)
-                #     )
             elif loss_name == 'pca_multiview':
                 if cfg.data.get('view_names', None) and len(cfg.data.view_names) > 1:
                     num_keypoints = cfg.data.num_keypoints

--- a/lightning_pose/losses/losses.py
+++ b/lightning_pose/losses/losses.py
@@ -863,7 +863,6 @@ class UnimodalLoss(Loss):
         data_module: BaseDataModule | UnlabeledDataModule | None = None,
         prob_threshold: float = 0.0,
         log_weight: float = 0.0,
-        uniform_heatmaps: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize UnimodalLoss.
@@ -885,8 +884,6 @@ class UnimodalLoss(Loss):
                 the loss computation.
             log_weight: final weight in front of the loss term in the objective function is
                 computed as ``1.0 / (2.0 * exp(log_weight))``.
-            uniform_heatmaps: if ``True``, generate uniform (flat) target heatmaps for NaN
-                ground truth keypoints instead of ignoring them in the loss.
 
         """
 
@@ -900,7 +897,6 @@ class UnimodalLoss(Loss):
         self.original_image_width = original_image_width
         self.downsampled_image_height = downsampled_image_height
         self.downsampled_image_width = downsampled_image_width
-        self.uniform_heatmaps = uniform_heatmaps
 
         self.prob_threshold = torch.tensor(prob_threshold, dtype=torch.float)
 
@@ -992,7 +988,6 @@ class UnimodalLoss(Loss):
             height=self.original_image_height,
             width=self.original_image_width,
             output_shape=(self.downsampled_image_height, self.downsampled_image_width),
-            uniform_heatmaps=self.uniform_heatmaps,
         )
 
         # remove invisible keypoints according to confidences
@@ -1286,7 +1281,6 @@ class ReprojectionHeatmapLoss(Loss):
         downsampled_image_height: int,
         downsampled_image_width: int,
         log_weight: float = 0.0,
-        uniform_heatmaps: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initialize ReprojectionHeatmapLoss.
@@ -1302,8 +1296,6 @@ class ReprojectionHeatmapLoss(Loss):
             downsampled_image_width: width of the heatmap output.
             log_weight: final weight in front of the loss term in the objective function is
                 computed as ``1.0 / (2.0 * exp(log_weight))``.
-            uniform_heatmaps: if ``True``, generate uniform (flat) target heatmaps for NaN
-                ground truth keypoints instead of ignoring them in the loss.
 
         """
         super().__init__(log_weight=log_weight)
@@ -1311,7 +1303,6 @@ class ReprojectionHeatmapLoss(Loss):
         self.original_image_width = original_image_width
         self.downsampled_image_height = downsampled_image_height
         self.downsampled_image_width = downsampled_image_width
-        self.uniform_heatmaps = uniform_heatmaps
 
     def remove_nans(
         self,
@@ -1400,7 +1391,6 @@ class ReprojectionHeatmapLoss(Loss):
             height=self.original_image_height,
             width=self.original_image_width,
             output_shape=(self.downsampled_image_height, self.downsampled_image_width),
-            uniform_heatmaps=self.uniform_heatmaps,
             keep_gradients=True,
         )
 

--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -6,11 +6,14 @@ import collections
 import logging
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import overload
 
 import numpy as np
 import pandas as pd
+import torch
+from jaxtyping import Float, Int
 from omegaconf import DictConfig, ListConfig
 
 logger = logging.getLogger(__name__)
@@ -20,6 +23,8 @@ __all__ = [
     "ckpt_path_from_base_path",
     "get_keypoint_names",
     "has_visibility_column",
+    "LabeledData",
+    "parse_label_csv",
     "return_absolute_path",
     "return_absolute_data_paths",
     "extract_session_name_from_video",
@@ -207,6 +212,98 @@ def has_visibility_column(
         return False
     csv_data = pd.read_csv(csv_file, header=header_rows, nrows=1)
     return any(b[2] == 'visible' for b in csv_data.columns)
+
+
+@dataclass
+class LabeledData:
+    """Result of parsing a label CSV file.
+
+    Attributes:
+        keypoint_names: ordered list of keypoint name strings
+        image_names: ordered list of image path strings (relative to the project root)
+        keypoints: ``(N, K, 2)`` float tensor of ``(x, y)`` coordinates; NaN where unlabeled
+        visibility: ``(N, K)`` int64 tensor of per-keypoint visibility flags (0, 1, or 2),
+            or ``None`` when the CSV does not contain a ``visible`` column
+    """
+
+    keypoint_names: list[str]
+    image_names: list[str]
+    keypoints: Float[torch.Tensor, 'num_frames num_keypoints 2']
+    visibility: Int[torch.Tensor, 'num_frames num_keypoints'] | None
+
+
+def parse_label_csv(
+    csv_file: str,
+    header_rows: list[int] | None = None,
+) -> LabeledData:
+    """Parse a label CSV file into a :class:`LabeledData` object in a single read.
+
+    Reads the file exactly once and returns keypoint names, image names, coordinates,
+    and per-keypoint visibility flags.  When the file contains a ``visible`` column per
+    keypoint (detected via :func:`has_visibility_column`), visibility flags are returned
+    as an int64 tensor; otherwise ``visibility`` is ``None``.
+
+    This function is the single entry point for reading label files.  A future
+    ``parse_label_json`` function for COCO ``.json`` format should return the same
+    :class:`LabeledData` type, allowing callers to remain format-agnostic.
+
+    Args:
+        csv_file: path to the label CSV file
+        header_rows: row indices that form the MultiIndex header; defaults to ``[0, 1, 2]``
+
+    Returns:
+        :class:`LabeledData` containing all label information
+
+    Raises:
+        FileNotFoundError: if ``csv_file`` does not exist
+        ValueError: if any visibility value is outside ``{0, 1, 2}``
+    """
+    if header_rows is None:
+        header_rows = [0, 1, 2]
+    if not os.path.exists(csv_file):
+        raise FileNotFoundError(f'could not find csv file at {csv_file}')
+
+    csv_data = pd.read_csv(csv_file, header=header_rows, index_col=0)
+    csv_data = fix_empty_first_row(csv_data)
+
+    # extract keypoint names from the MultiIndex header
+    if header_rows in ([1, 2], [0, 1]):
+        keypoint_names = [b[0] for b in csv_data.columns if b[1] == 'x']
+    else:
+        keypoint_names = [b[1] for b in csv_data.columns if b[2] == 'x']
+
+    image_names = list(csv_data.index)
+
+    # detect visibility column and split raw data accordingly
+    has_vis = (
+        header_rows == [0, 1, 2]
+        and any(b[2] == 'visible' for b in csv_data.columns)
+    )
+    if has_vis:
+        raw = torch.tensor(csv_data.to_numpy(), dtype=torch.float32)
+        raw = raw.reshape(raw.shape[0], -1, 3)
+        keypoints = raw[:, :, :2].contiguous()
+        vis_float = raw[:, :, 2]
+        valid_vals = {0.0, 1.0, 2.0}
+        unique_vals = set(vis_float[~torch.isnan(vis_float)].unique().tolist())
+        invalid_vals = unique_vals - valid_vals
+        if invalid_vals:
+            raise ValueError(
+                f'visibility column contains invalid values {invalid_vals}; '
+                'expected values in {{0, 1, 2}}'
+            )
+        visibility: Int[torch.Tensor, 'num_frames num_keypoints'] | None = vis_float.long()
+    else:
+        raw = torch.tensor(csv_data.to_numpy(), dtype=torch.float32)
+        keypoints = raw.reshape(raw.shape[0], -1, 2)
+        visibility = None
+
+    return LabeledData(
+        keypoint_names=keypoint_names,
+        image_names=image_names,
+        keypoints=keypoints,
+        visibility=visibility,
+    )
 
 
 # --------------------------------------------------------------------------------------

--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -22,7 +22,6 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "ckpt_path_from_base_path",
     "get_keypoint_names",
-
     "LabeledData",
     "parse_label_csv",
     "return_absolute_path",
@@ -186,7 +185,6 @@ def get_keypoint_names(
         assert cfg is not None, 'cfg must be provided when csv_file is not given'
         keypoint_names = [f"bp_{n}" for n in range(cfg.data.num_targets // 2)]
     return keypoint_names
-
 
 
 @dataclass

--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "ckpt_path_from_base_path",
     "get_keypoint_names",
-    "has_visibility_column",
+
     "LabeledData",
     "parse_label_csv",
     "return_absolute_path",
@@ -188,31 +188,6 @@ def get_keypoint_names(
     return keypoint_names
 
 
-def has_visibility_column(
-    csv_file: str,
-    header_rows: list[int] | None = None,
-) -> bool:
-    """Return True if the CSV has a ``visible`` column per keypoint in the coords row.
-
-    Only the standard DLC format (``header_rows=[0, 1, 2]``) is supported; all other
-    formats return False without reading the file.
-
-    Args:
-        csv_file: path to a labeled CSV file
-        header_rows: row indices that form the MultiIndex header; defaults to ``[0, 1, 2]``
-
-    Returns:
-        True if the CSV contains ``visible`` columns in the coords row, False otherwise
-    """
-    if header_rows is None:
-        header_rows = [0, 1, 2]
-    if header_rows != [0, 1, 2]:
-        return False
-    if not os.path.exists(csv_file):
-        return False
-    csv_data = pd.read_csv(csv_file, header=header_rows, nrows=1)
-    return any(b[2] == 'visible' for b in csv_data.columns)
-
 
 @dataclass
 class LabeledData:
@@ -240,8 +215,8 @@ def parse_label_csv(
 
     Reads the file exactly once and returns keypoint names, image names, coordinates,
     and per-keypoint visibility flags.  When the file contains a ``visible`` column per
-    keypoint (detected via :func:`has_visibility_column`), visibility flags are returned
-    as an int64 tensor; otherwise ``visibility`` is ``None``.
+    keypoint, visibility flags are returned as an int64 tensor; otherwise ``visibility``
+    is ``None``.
 
     This function is the single entry point for reading label files.  A future
     ``parse_label_json`` function for COCO ``.json`` format should return the same

--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "ckpt_path_from_base_path",
     "get_keypoint_names",
+    "has_visibility_column",
     "return_absolute_path",
     "return_absolute_data_paths",
     "extract_session_name_from_video",
@@ -180,6 +181,32 @@ def get_keypoint_names(
         assert cfg is not None, 'cfg must be provided when csv_file is not given'
         keypoint_names = [f"bp_{n}" for n in range(cfg.data.num_targets // 2)]
     return keypoint_names
+
+
+def has_visibility_column(
+    csv_file: str,
+    header_rows: list[int] | None = None,
+) -> bool:
+    """Return True if the CSV has a ``visible`` column per keypoint in the coords row.
+
+    Only the standard DLC format (``header_rows=[0, 1, 2]``) is supported; all other
+    formats return False without reading the file.
+
+    Args:
+        csv_file: path to a labeled CSV file
+        header_rows: row indices that form the MultiIndex header; defaults to ``[0, 1, 2]``
+
+    Returns:
+        True if the CSV contains ``visible`` columns in the coords row, False otherwise
+    """
+    if header_rows is None:
+        header_rows = [0, 1, 2]
+    if header_rows != [0, 1, 2]:
+        return False
+    if not os.path.exists(csv_file):
+        return False
+    csv_data = pd.read_csv(csv_file, header=header_rows, nrows=1)
+    return any(b[2] == 'visible' for b in csv_data.columns)
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/data/test_datamodules.py
+++ b/tests/data/test_datamodules.py
@@ -289,7 +289,7 @@ def test_heatmap_data_module_combined(cfg, heatmap_data_module_combined):
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
     assert list(batch["labeled"].keys()) == [
-        "images", "keypoints", "idxs", "bbox", "heatmaps", "visibility",
+        "images", "keypoints", "idxs", "bbox", "visibility", "heatmaps",
     ]
     assert list(batch["unlabeled"].keys()) == ["frames", "transforms", "bbox", "is_multiview"]
     assert batch["labeled"]["images"].shape == (train_size_labeled, 3, im_height, im_width)
@@ -365,7 +365,7 @@ def test_heatmap_data_module_combined_context(cfg, heatmap_data_module_combined_
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
     assert list(batch["labeled"].keys()) == [
-        "images", "keypoints", "idxs", "bbox", "heatmaps", "visibility",
+        "images", "keypoints", "idxs", "bbox", "visibility", "heatmaps",
     ]
     assert list(batch["unlabeled"].keys()) == ["frames", "transforms", "bbox", "is_multiview"]
     assert batch["labeled"]["images"].shape == (

--- a/tests/data/test_datamodules.py
+++ b/tests/data/test_datamodules.py
@@ -250,7 +250,7 @@ def test_base_data_module_combined(cfg, base_data_module_combined):
     batch = batch[0] if isinstance(batch, tuple) else batch
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
-    assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "bbox"]
+    assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "bbox", "visibility"]
     assert list(batch["unlabeled"].keys()) == ["frames", "transforms", "bbox", "is_multiview"]
     assert batch["labeled"]["images"].shape == (train_size_labeled, 3, im_height, im_width)
     assert batch["labeled"]["keypoints"].shape == (train_size_labeled, num_targets)
@@ -288,7 +288,9 @@ def test_heatmap_data_module_combined(cfg, heatmap_data_module_combined):
     batch = batch[0] if isinstance(batch, tuple) else batch
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
-    assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "bbox", "heatmaps"]
+    assert list(batch["labeled"].keys()) == [
+        "images", "keypoints", "idxs", "bbox", "heatmaps", "visibility",
+    ]
     assert list(batch["unlabeled"].keys()) == ["frames", "transforms", "bbox", "is_multiview"]
     assert batch["labeled"]["images"].shape == (train_size_labeled, 3, im_height, im_width)
     assert batch["labeled"]["keypoints"].shape == (train_size_labeled, num_targets)
@@ -362,7 +364,9 @@ def test_heatmap_data_module_combined_context(cfg, heatmap_data_module_combined_
     batch = batch[0] if isinstance(batch, tuple) else batch
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
-    assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "bbox", "heatmaps"]
+    assert list(batch["labeled"].keys()) == [
+        "images", "keypoints", "idxs", "bbox", "heatmaps", "visibility",
+    ]
     assert list(batch["unlabeled"].keys()) == ["frames", "transforms", "bbox", "is_multiview"]
     assert batch["labeled"]["images"].shape == (
         train_size_labeled, num_context, 3, im_height, im_width,

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1189,7 +1189,7 @@ class TestBaseTrackingDatasetVisibility:
         return str(p)
 
     @pytest.fixture
-    def imgaug(self) -> 'iaa.Sequential':
+    def imgaug(self):
         import imgaug.augmenters as iaa
         return iaa.Sequential([])
 

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1300,7 +1300,7 @@ class TestBaseTrackingDatasetVisibility:
         assert torch.equal(ex1['visibility'], torch.tensor([2, 0], dtype=torch.long))
 
     def test_heatmap_dataset_getitem_no_visibility(self, standard_csv, tmp_path, imgaug):
-        """__getitem__ sets 'visibility' to an empty tensor for a CSV without a visible column."""
+        """HeatmapDataset synthesizes visibility=2 for all valid keypoints in a standard CSV."""
         import os
 
         from PIL import Image
@@ -1312,8 +1312,11 @@ class TestBaseTrackingDatasetVisibility:
             ).save(os.path.join(str(tmp_path), name))
 
         ds = self._make_heatmap_dataset(standard_csv, tmp_path, imgaug)
+        # standard CSV → synthesis sets vis=2 for all labeled (non-NaN) keypoints
+        assert ds.visibility is not None
+        assert (ds.visibility == 2).all()
         ex = BaseTrackingDataset.__getitem__(ds, 0)
-        assert ex['visibility'].numel() == 0
+        assert torch.equal(ex['visibility'], torch.tensor([2, 2], dtype=torch.long))
 
     def test_heatmap_dataset_compute_heatmap_uses_visibility(
         self, visibility_csv, tmp_path, imgaug,

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1277,41 +1277,96 @@ class TestBaseTrackingDatasetVisibility:
             )
         assert any('visible=1' in record.message for record in caplog.records)
 
+    def test_heatmap_dataset_getitem_populates_visibility(self, visibility_csv, tmp_path, imgaug):
+        """__getitem__ populates the 'visibility' key from self.visibility[idx]."""
+        import os
+
+        from PIL import Image
+
+        from lightning_pose.data.datasets import BaseTrackingDataset
+        for name in ('img01.png', 'img02.png'):
+            Image.fromarray(
+                (128 * torch.ones(128, 128, 3)).byte().numpy()
+            ).save(os.path.join(str(tmp_path), name))
+
+        ds = self._make_heatmap_dataset(visibility_csv, tmp_path, imgaug)
+
+        ex0 = BaseTrackingDataset.__getitem__(ds, 0)
+        assert ex0['visibility'] is not None
+        assert torch.equal(ex0['visibility'], torch.tensor([2, 1], dtype=torch.long))
+
+        ex1 = BaseTrackingDataset.__getitem__(ds, 1)
+        assert ex1['visibility'] is not None
+        assert torch.equal(ex1['visibility'], torch.tensor([2, 0], dtype=torch.long))
+
+    def test_heatmap_dataset_getitem_no_visibility(self, standard_csv, tmp_path, imgaug):
+        """__getitem__ sets 'visibility' to an empty tensor for a CSV without a visible column."""
+        import os
+
+        from PIL import Image
+
+        from lightning_pose.data.datasets import BaseTrackingDataset
+        for name in ('img01.png', 'img02.png'):
+            Image.fromarray(
+                (128 * torch.ones(128, 128, 3)).byte().numpy()
+            ).save(os.path.join(str(tmp_path), name))
+
+        ds = self._make_heatmap_dataset(standard_csv, tmp_path, imgaug)
+        ex = BaseTrackingDataset.__getitem__(ds, 0)
+        assert ex['visibility'].numel() == 0
+
     def test_heatmap_dataset_compute_heatmap_uses_visibility(
         self, visibility_csv, tmp_path, imgaug,
     ):
-        """compute_heatmap produces zero heatmap for vis=0 and uniform for vis=1."""
+        """compute_heatmap reads visibility from example_dict, not self.visibility[idx]."""
 
         ds = self._make_heatmap_dataset(visibility_csv, tmp_path, imgaug)
         H, W = ds.output_shape
 
-        # Frame 0: kp1=vis2, kp2=vis1; supply kp1 at center, kp2 as NaN
+        uniform_heatmap = torch.ones(H, W) / (H * W)
+        zero_heatmap = torch.zeros(H, W)
+
+        # Frame 0: kp1=vis2 with valid coords, kp2=vis1 with NaN coords
         example_dict = {
             'images': torch.zeros(3, 128, 128),
             'keypoints': torch.tensor([64.0, 64.0, float('nan'), float('nan')]),
             'bbox': torch.tensor([0, 0, 128, 128]),
             'idxs': 0,
+            'visibility': torch.tensor([2, 1], dtype=torch.long),
         }
         heatmaps = ds.compute_heatmap(example_dict, ignore_nans=True)  # type: ignore[arg-type]
 
-        uniform_heatmap = torch.ones(H, W) / (H * W)
-        zero_heatmap = torch.zeros(H, W)
-
-        # kp1 (vis=2): Gaussian — non-zero, sums to 1
+        # kp1 (vis=2): Gaussian — non-zero, sums to ~1
         assert not torch.allclose(heatmaps[0], zero_heatmap)
         assert torch.isclose(heatmaps[0].sum(), torch.tensor(1.0))
         # kp2 (vis=1): uniform
         assert torch.allclose(heatmaps[1], uniform_heatmap)
 
-        # Frame 1: kp2=vis0 — zero heatmap
+        # Frame 1: kp2=vis0 — zero heatmap; visibility from example_dict, not self.visibility[1]
         example_dict_1 = {
             'images': torch.zeros(3, 128, 128),
             'keypoints': torch.tensor([32.0, 96.0, float('nan'), float('nan')]),
             'bbox': torch.tensor([0, 0, 128, 128]),
             'idxs': 1,
+            'visibility': torch.tensor([2, 0], dtype=torch.long),
         }
         heatmaps_1 = ds.compute_heatmap(example_dict_1, ignore_nans=True)  # type: ignore[arg-type]
         assert torch.allclose(heatmaps_1[1], zero_heatmap)
+
+        # Verify compute_heatmap uses example_dict["visibility"], not self.visibility[idx]:
+        # pass a different visibility tensor than what self.visibility[0] would return
+        example_dict_override = {
+            'images': torch.zeros(3, 128, 128),
+            'keypoints': torch.tensor([64.0, 64.0, float('nan'), float('nan')]),
+            'bbox': torch.tensor([0, 0, 128, 128]),
+            'idxs': 0,
+            # override kp1 to vis=0 — should produce zero heatmap despite kp1 having coords
+            'visibility': torch.tensor([0, 1], dtype=torch.long),
+        }
+        heatmaps_override = ds.compute_heatmap(
+            example_dict_override, ignore_nans=True,  # type: ignore[arg-type]
+        )
+        assert torch.allclose(heatmaps_override[0], zero_heatmap)
 
 
 def test_equal_return_sizes(base_dataset, heatmap_dataset):

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1155,6 +1155,165 @@ class TestDiscoverCamParamsFromImagePaths:
             self._discover(fake_ds)
 
 
+class TestBaseTrackingDatasetVisibility:
+    """Test visibility column parsing in BaseTrackingDataset and HeatmapDataset."""
+
+    @pytest.fixture
+    def visibility_csv(self, tmp_path) -> str:
+        """DLC-format CSV with a visible column; two keypoints, two frames."""
+        content = (
+            'scorer,scorer,scorer,scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp1,kp2,kp2,kp2\n'
+            'coords,x,y,visible,x,y,visible\n'
+            # frame 0: kp1 visible (2) with valid coords; kp2 occluded (1) with NaN coords
+            'img01.png,64.0,64.0,2,,,1\n'
+            # frame 1: kp1 visible (2); kp2 not labeled (0) with NaN coords
+            'img02.png,32.0,96.0,2,,,0\n'
+        )
+        p = tmp_path / 'labels.csv'
+        p.write_text(content)
+        return str(p)
+
+    @pytest.fixture
+    def standard_csv(self, tmp_path) -> str:
+        """Standard DLC-format CSV without visibility columns."""
+        content = (
+            'scorer,scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp2,kp2\n'
+            'coords,x,y,x,y\n'
+            'img01.png,64.0,64.0,32.0,96.0\n'
+            'img02.png,10.0,20.0,30.0,40.0\n'
+        )
+        p = tmp_path / 'labels_standard.csv'
+        p.write_text(content)
+        return str(p)
+
+    @pytest.fixture
+    def imgaug(self) -> 'iaa.Sequential':
+        import imgaug.augmenters as iaa
+        return iaa.Sequential([])
+
+    def _make_base_dataset(self, csv_path, tmp_path, imgaug):
+        from lightning_pose.data.datasets import BaseTrackingDataset
+        return BaseTrackingDataset(
+            root_directory=str(tmp_path),
+            csv_path=csv_path,
+            image_resize_height=128,
+            image_resize_width=128,
+            imgaug_transform=imgaug,
+        )
+
+    def _make_heatmap_dataset(self, csv_path, tmp_path, imgaug):
+        from lightning_pose.data.datasets import HeatmapDataset
+        return HeatmapDataset(
+            root_directory=str(tmp_path),
+            csv_path=csv_path,
+            image_resize_height=128,
+            image_resize_width=128,
+            imgaug_transform=imgaug,
+        )
+
+    def test_base_tracking_dataset_visibility_parsed(self, visibility_csv, tmp_path, imgaug):
+        """visibility tensor is populated with correct int values from the CSV."""
+        ds = self._make_base_dataset(visibility_csv, tmp_path, imgaug)
+
+        assert ds.visibility is not None
+        assert ds.visibility.shape == (2, 2)  # (N=2 frames, K=2 keypoints)
+        assert ds.visibility.dtype == torch.long
+        # frame 0: kp1=visible(2), kp2=occluded(1)
+        assert ds.visibility[0, 0] == 2
+        assert ds.visibility[0, 1] == 1
+        # frame 1: kp1=visible(2), kp2=not_labeled(0)
+        assert ds.visibility[1, 0] == 2
+        assert ds.visibility[1, 1] == 0
+
+    def test_base_tracking_dataset_no_visibility(self, standard_csv, tmp_path, imgaug):
+        """visibility is None for a standard CSV without visible column."""
+        ds = self._make_base_dataset(standard_csv, tmp_path, imgaug)
+        assert ds.visibility is None
+
+    def test_base_tracking_dataset_invalid_visibility_raises(self, tmp_path, imgaug):
+        """ValueError is raised when the visibility column contains values outside {0, 1, 2}."""
+        content = (
+            'scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp1\n'
+            'coords,x,y,visible\n'
+            'img01.png,64.0,64.0,9\n'
+        )
+        bad_csv = tmp_path / 'bad.csv'
+        bad_csv.write_text(content)
+        with pytest.raises(ValueError, match='visibility column contains invalid values'):
+            from lightning_pose.data.datasets import BaseTrackingDataset
+            BaseTrackingDataset(
+                root_directory=str(tmp_path),
+                csv_path=str(bad_csv),
+                image_resize_height=128,
+                image_resize_width=128,
+                imgaug_transform=imgaug,
+            )
+
+    def test_base_tracking_dataset_occluded_with_coords_warns(
+        self, tmp_path, imgaug, caplog,
+    ):
+        """A warning is logged when vis=1 keypoints have non-NaN x,y coordinates."""
+        import logging
+        content = (
+            'scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp1\n'
+            'coords,x,y,visible\n'
+            # kp1 has coordinates but is marked occluded (vis=1)
+            'img01.png,64.0,64.0,1\n'
+        )
+        p = tmp_path / 'occluded_with_coords.csv'
+        p.write_text(content)
+        with caplog.at_level(logging.WARNING, logger='lightning_pose.data.datasets'):
+            from lightning_pose.data.datasets import BaseTrackingDataset
+            BaseTrackingDataset(
+                root_directory=str(tmp_path),
+                csv_path=str(p),
+                image_resize_height=128,
+                image_resize_width=128,
+                imgaug_transform=imgaug,
+            )
+        assert any('visible=1' in record.message for record in caplog.records)
+
+    def test_heatmap_dataset_compute_heatmap_uses_visibility(
+        self, visibility_csv, tmp_path, imgaug,
+    ):
+        """compute_heatmap produces zero heatmap for vis=0 and uniform for vis=1."""
+
+        ds = self._make_heatmap_dataset(visibility_csv, tmp_path, imgaug)
+        H, W = ds.output_shape
+
+        # Frame 0: kp1=vis2, kp2=vis1; supply kp1 at center, kp2 as NaN
+        example_dict = {
+            'images': torch.zeros(3, 128, 128),
+            'keypoints': torch.tensor([64.0, 64.0, float('nan'), float('nan')]),
+            'bbox': torch.tensor([0, 0, 128, 128]),
+            'idxs': 0,
+        }
+        heatmaps = ds.compute_heatmap(example_dict, ignore_nans=True)  # type: ignore[arg-type]
+
+        uniform_heatmap = torch.ones(H, W) / (H * W)
+        zero_heatmap = torch.zeros(H, W)
+
+        # kp1 (vis=2): Gaussian — non-zero, sums to 1
+        assert not torch.allclose(heatmaps[0], zero_heatmap)
+        assert torch.isclose(heatmaps[0].sum(), torch.tensor(1.0))
+        # kp2 (vis=1): uniform
+        assert torch.allclose(heatmaps[1], uniform_heatmap)
+
+        # Frame 1: kp2=vis0 — zero heatmap
+        example_dict_1 = {
+            'images': torch.zeros(3, 128, 128),
+            'keypoints': torch.tensor([32.0, 96.0, float('nan'), float('nan')]),
+            'bbox': torch.tensor([0, 0, 128, 128]),
+            'idxs': 1,
+        }
+        heatmaps_1 = ds.compute_heatmap(example_dict_1, ignore_nans=True)  # type: ignore[arg-type]
+        assert torch.allclose(heatmaps_1[1], zero_heatmap)
+
+
 def test_equal_return_sizes(base_dataset, heatmap_dataset):
     # can only assert the batches are the same if not using imgaug pipeline
     assert base_dataset[0]["images"].shape == heatmap_dataset[0]["images"].shape

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -164,15 +164,14 @@ class TestGenerateHeatmaps:
         torch.cuda.empty_cache()  # remove tensors from gpu
 
     def test_uniform_heatmaps(self, cfg, toy_data_dir):
+        """uniform_heatmaps=True: dataset heatmaps match generate_heatmaps with synthesized vis."""
 
         from lightning_pose.data import get_dataset, get_imgaug_transform
 
-        # update config
         cfg_tmp = copy.deepcopy(cfg)
         cfg_tmp.model.model_type = "heatmap"
         cfg_tmp.training.uniform_heatmaps_for_nan_keypoints = True
 
-        # build dataset with these new image dimensions
         imgaug_transform = get_imgaug_transform(cfg_tmp)
         heatmap_dataset = get_dataset(
             cfg_tmp,
@@ -186,36 +185,28 @@ class TestGenerateHeatmaps:
         batch = heatmap_dataset.__getitem__(idx=0)
         heatmap_gt = batch["heatmaps"].unsqueeze(0)  # type: ignore[typeddict-item]
         keypts_gt = batch["keypoints"].unsqueeze(0).reshape(1, -1, 2)
+        vis = heatmap_dataset.visibility[0].unsqueeze(0)  # (1, K) synthesized visibility
 
         heatmap_uniform_torch = generate_heatmaps(
             keypts_gt,
             height=im_height,
             width=im_width,
             output_shape=(heatmap_gt.shape[2], heatmap_gt.shape[3]),
-            uniform_heatmaps=True,
+            visibility=vis,
         )
 
-        # find soft argmax and confidence of ground truth heatmap
         softmaxes_gt = spatial_softmax2d(heatmap_gt, temperature=torch.tensor(100))
         preds_gt = spatial_expectation2d(softmaxes_gt, normalized_coordinates=False)
         confidences_gt = torch.amax(softmaxes_gt, dim=(2, 3))
 
-        # find soft argmax and confidence of generated heatmap
-        softmaxes_torch = spatial_softmax2d(
-            heatmap_uniform_torch, temperature=torch.tensor(100)
-        )
+        softmaxes_torch = spatial_softmax2d(heatmap_uniform_torch, temperature=torch.tensor(100))
         preds_torch = spatial_expectation2d(softmaxes_torch, normalized_coordinates=False)
         confidences_torch = torch.amax(softmaxes_torch, dim=(2, 3))
 
         assert (preds_gt == preds_torch).all()
         assert (confidences_gt == confidences_torch).all()
 
-        # cleanup
-        del batch
-        del heatmap_gt, keypts_gt
-        del softmaxes_gt, preds_gt, confidences_gt
-        del softmaxes_torch, preds_torch, confidences_torch
-        torch.cuda.empty_cache()  # remove tensors from gpu
+        torch.cuda.empty_cache()
 
     def test_weird_shape(self, cfg, toy_data_dir):
 
@@ -315,7 +306,8 @@ class TestGenerateHeatmaps:
             keep_gradients=False,
         )
 
-        # Check that the heatmap doesn't require gradients (computation graph is detached)
+        # Check that the heatmap doesn't require test_uniform_heatmapsgradients
+        # (computation graph is detached)
         assert not heatmap_no_grad.requires_grad, \
             "Heatmap should not require gradients when keep_gradients=False"
 
@@ -325,87 +317,84 @@ class TestGenerateHeatmaps:
         assert keypts_no_grad.grad is None, "Original keypoints should have no gradients yet"
 
     def test_out_of_bounds_nan_indices(self):
-        """Out-of-bounds keypoints are marked as NaN and filled with appropriate heatmaps."""
+        """OOB/NaN keypoints produce zero, uniform, or Gaussian heatmaps depending on vis."""
 
-        # Create mock data with some out-of-bounds keypoints
         im_height = 256
         im_width = 256
         output_height = 64
         output_width = 64
 
+        # batch=2, 4 keypoints each — mix of valid, OOB, and explicit NaN
         keypoints = torch.tensor([
             [
-                [32.0, 32.0],  # valid keypoint
-                [-10.0, 50.0],  # x out of bounds (< -1 after scaling)
-                [500.0, 32.0],  # x out of bounds (> width + 1 after scaling)
-                [32.0, 500.0]  # y out of bounds (> height + 1 after scaling)
+                [32.0, 32.0],    # valid
+                [-10.0, 50.0],   # x OOB (< -1 after scaling)
+                [500.0, 32.0],   # x OOB (> width + 1 after scaling)
+                [32.0, 500.0],   # y OOB (> height + 1 after scaling)
             ],
             [
-                [32.0, -10.0],  # y out of bounds (< -1 after scaling)
-                [64.0, 64.0],  # valid keypoint
+                [32.0, -10.0],   # y OOB (< -1 after scaling)
+                [64.0, 64.0],    # valid
                 [float('nan'), 32.0],  # explicit NaN
-                [128.0, 128.0]  # valid keypoint
-            ]
+                [128.0, 128.0],  # valid
+            ],
         ], dtype=torch.float32)
 
-        # Test with uniform_heatmaps=False (zeros for invalid)
-        heatmaps = generate_heatmaps(
-            keypoints,
-            height=im_height,
-            width=im_width,
-            output_shape=(output_height, output_width),
-            uniform_heatmaps=False,
-        )
+        zeros = torch.zeros(output_height, output_width)
+        uniform = torch.ones(output_height, output_width) / (output_height * output_width)
 
-        # Check that out-of-bounds keypoints result in zero heatmaps
-        zeros_heatmap = torch.zeros(output_height, output_width)
-        assert torch.allclose(heatmaps[0, 1], zeros_heatmap)  # x < -1
-        assert torch.allclose(heatmaps[0, 2], zeros_heatmap)  # x > width+1
-        assert torch.allclose(heatmaps[0, 3], zeros_heatmap)  # y > height+1
-        assert torch.allclose(heatmaps[1, 0], zeros_heatmap)  # y < -1
-        assert torch.allclose(heatmaps[1, 2], zeros_heatmap)  # explicit NaN
+        kwargs = dict(height=im_height, width=im_width, output_shape=(output_height, output_width))
 
-        # Check that valid keypoints result in non-zero heatmaps
-        assert not torch.allclose(heatmaps[0, 0], zeros_heatmap)  # valid
-        assert not torch.allclose(heatmaps[1, 1], zeros_heatmap)  # valid
-        assert not torch.allclose(heatmaps[1, 3], zeros_heatmap)  # valid
+        # visibility=None: OOB and NaN → zeros; valid → Gaussian
+        heatmaps = generate_heatmaps(keypoints, **kwargs)
+        assert torch.allclose(heatmaps[0, 1], zeros)  # x OOB
+        assert torch.allclose(heatmaps[0, 2], zeros)  # x OOB
+        assert torch.allclose(heatmaps[0, 3], zeros)  # y OOB
+        assert torch.allclose(heatmaps[1, 0], zeros)  # y OOB
+        assert torch.allclose(heatmaps[1, 2], zeros)  # explicit NaN
+        assert not torch.allclose(heatmaps[0, 0], zeros)  # valid
+        assert not torch.allclose(heatmaps[1, 1], zeros)  # valid
+        assert not torch.allclose(heatmaps[1, 3], zeros)  # valid
 
-        # Test with uniform_heatmaps=True
-        heatmaps_uniform = generate_heatmaps(
-            keypoints,
-            height=im_height,
-            width=im_width,
-            output_shape=(output_height, output_width),
-            uniform_heatmaps=True,
-        )
+        # vis=1 (occluded): all keypoints → uniform, regardless of OOB or NaN
+        vis1 = torch.ones(2, 4, dtype=torch.long)
+        heatmaps_v1 = generate_heatmaps(keypoints, **kwargs, visibility=vis1)
+        assert torch.allclose(heatmaps_v1[0, 1], uniform)  # x OOB → uniform
+        assert torch.allclose(heatmaps_v1[1, 2], uniform)  # NaN → uniform
 
-        # Check that out-of-bounds keypoints result in uniform heatmaps
-        uniform_heatmap = torch.ones(output_height, output_width) / (output_height * output_width)
-        assert torch.allclose(heatmaps_uniform[0, 1], uniform_heatmap)  # x < -1
-        assert torch.allclose(heatmaps_uniform[0, 2], uniform_heatmap)  # x > width+1
-        assert torch.allclose(heatmaps_uniform[1, 2], uniform_heatmap)  # explicit NaN
+        # vis=0 (not labeled): all keypoints → zeros, including valid ones
+        vis0 = torch.zeros(2, 4, dtype=torch.long)
+        heatmaps_v0 = generate_heatmaps(keypoints, **kwargs, visibility=vis0)
+        assert torch.allclose(heatmaps_v0[0, 0], zeros)  # valid kp → zeros when vis=0
+        assert torch.allclose(heatmaps_v0[1, 1], zeros)  # valid kp → zeros when vis=0
+
+        # vis=2 (visible) + OOB/NaN → zeros (defensive); vis=2 + valid → Gaussian
+        vis2 = torch.full((2, 4), 2, dtype=torch.long)
+        heatmaps_v2 = generate_heatmaps(keypoints, **kwargs, visibility=vis2)
+        assert torch.allclose(heatmaps_v2[0, 1], zeros)    # x OOB → zero despite vis=2
+        assert torch.allclose(heatmaps_v2[1, 2], zeros)    # NaN → zero despite vis=2
+        assert not torch.allclose(heatmaps_v2[0, 0], zeros)  # valid → Gaussian
+        assert not torch.allclose(heatmaps_v2[1, 1], zeros)  # valid → Gaussian
 
     def test_extreme_keypoint_clamping(self):
-        """Test that extreme keypoint values are clamped to prevent numerical issues."""
+        """Extreme OOB keypoints are clamped; visibility flags still control heatmap type."""
 
-        # Create keypoints with extreme values
-        batch_size = 1
-        num_keypoints = 4
         im_height = 256
         im_width = 256
         output_height = 64
         output_width = 64
 
+        # batch=1, four keypoints all with extreme (way OOB) coordinates
         extreme_keypoints = torch.tensor([
             [
-                [-100000000.0, 32.0],  # extremely negative x
-                [100000000.0, 32.0],  # extremely positive x
-                [32.0, -100000000.0],  # extremely negative y
-                [32.0, 100000000.0]  # extremely positive y
+                [-100000000.0, 32.0],   # extremely negative x
+                [100000000.0, 32.0],    # extremely positive x
+                [32.0, -100000000.0],   # extremely negative y
+                [32.0, 100000000.0],    # extremely positive y
             ]
         ], dtype=torch.float32, requires_grad=True)
 
-        # Function should not crash and should produce finite heatmaps
+        # --- gradients and finiteness (visibility=None path) ---
         heatmaps = generate_heatmaps(
             extreme_keypoints,
             height=im_height,
@@ -413,44 +402,58 @@ class TestGenerateHeatmaps:
             output_shape=(output_height, output_width),
             keep_gradients=True,
         )
-
-        # Check that all heatmaps are finite (no NaN or inf values from extreme computations)
-        assert torch.isfinite(heatmaps).all(), "Heatmaps contain NaN or inf values"
-
-        # Check that heatmaps have correct shape
-        assert heatmaps.shape == (batch_size, num_keypoints, output_height, output_width)
-
-        # Check that gradients can flow through (no numerical issues)
-        loss = torch.sum(heatmaps)
+        assert torch.isfinite(heatmaps).all()
+        assert heatmaps.shape == (1, 4, output_height, output_width)
+        loss = heatmaps.sum()
         loss.backward()
         assert extreme_keypoints.grad is not None
-        assert torch.isfinite(extreme_keypoints.grad).all(), "Gradients contain NaN or inf values"
+        assert torch.isfinite(extreme_keypoints.grad).all()
 
-        # Verify clamping behavior: extreme values should be treated as out-of-bounds
-        # and filled with zeros (since uniform_heatmaps=False by default)
-        expected_zero = torch.zeros(output_height, output_width)
-        assert torch.allclose(heatmaps[0, 0], expected_zero)  # extreme negative x
-        assert torch.allclose(heatmaps[0, 1], expected_zero)  # extreme positive x
-        assert torch.allclose(heatmaps[0, 2], expected_zero)  # extreme negative y
-        assert torch.allclose(heatmaps[0, 3], expected_zero)  # extreme positive y
+        # visibility=None: OOB → zeros
+        zero = torch.zeros(output_height, output_width)
+        assert torch.allclose(heatmaps[0, 0], zero)
+        assert torch.allclose(heatmaps[0, 1], zero)
+        assert torch.allclose(heatmaps[0, 2], zero)
+        assert torch.allclose(heatmaps[0, 3], zero)
 
-    def test_generate_heatmaps_visibility_none_is_backward_compat(self):
-        """visibility=None produces identical output to the legacy path."""
+        # vis=0: not labeled → zeros regardless of OOB
+        vis0 = torch.zeros(1, 4, dtype=torch.long)
+        heatmaps_v0 = generate_heatmaps(
+            extreme_keypoints.detach(),
+            height=im_height, width=im_width, output_shape=(output_height, output_width),
+            visibility=vis0,
+        )
+        assert torch.allclose(heatmaps_v0[0, 0], zero)
 
-        # Arrange: one valid keypoint, one NaN keypoint (batch=1, K=2)
+        # vis=1: occluded → uniform regardless of OOB
+        uniform = torch.ones(output_height, output_width) / (output_height * output_width)
+        vis1 = torch.ones(1, 4, dtype=torch.long)
+        heatmaps_v1 = generate_heatmaps(
+            extreme_keypoints.detach(),
+            height=im_height, width=im_width, output_shape=(output_height, output_width),
+            visibility=vis1,
+        )
+        assert torch.allclose(heatmaps_v1[0, 0], uniform)
+
+        # vis=2: visible but OOB → zero (defensive fallback)
+        vis2 = torch.full((1, 4), 2, dtype=torch.long)
+        heatmaps_v2 = generate_heatmaps(
+            extreme_keypoints.detach(),
+            height=im_height, width=im_width, output_shape=(output_height, output_width),
+            visibility=vis2,
+        )
+        assert torch.allclose(heatmaps_v2[0, 0], zero)
+
+    def test_generate_heatmaps_visibility_none_nan_produces_zeros(self):
+        """visibility=None: NaN keypoints produce zero heatmaps."""
+
         keypoints = torch.tensor([[[64.0, 64.0], [float('nan'), float('nan')]]])
 
-        # Act
-        legacy = generate_heatmaps(
-            keypoints, height=128, width=128, output_shape=(32, 32), uniform_heatmaps=False,
-        )
-        with_none = generate_heatmaps(
-            keypoints, height=128, width=128, output_shape=(32, 32), uniform_heatmaps=False,
-            visibility=None,
-        )
+        result = generate_heatmaps(keypoints, height=128, width=128, output_shape=(32, 32))
 
-        # Assert
-        assert torch.allclose(legacy, with_none)
+        zero_heatmap = torch.zeros(32, 32)
+        assert not torch.allclose(result[0, 0], zero_heatmap)  # valid keypoint → non-zero
+        assert torch.allclose(result[0, 1], zero_heatmap)       # NaN keypoint → zero
 
     def test_generate_heatmaps_visibility_2_produces_gaussian(self):
         """vis=2 keypoints get a Gaussian heatmap identical to the legacy valid-keypoint path."""

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -434,6 +434,112 @@ class TestGenerateHeatmaps:
         assert torch.allclose(heatmaps[0, 2], expected_zero)  # extreme negative y
         assert torch.allclose(heatmaps[0, 3], expected_zero)  # extreme positive y
 
+    def test_generate_heatmaps_visibility_none_is_backward_compat(self):
+        """visibility=None produces identical output to the legacy path."""
+
+        # Arrange: one valid keypoint, one NaN keypoint (batch=1, K=2)
+        keypoints = torch.tensor([[[64.0, 64.0], [float('nan'), float('nan')]]])
+        kwargs = dict(height=128, width=128, output_shape=(32, 32))
+
+        # Act
+        legacy = generate_heatmaps(keypoints, **kwargs, uniform_heatmaps=False)
+        with_none = generate_heatmaps(keypoints, **kwargs, uniform_heatmaps=False, visibility=None)
+
+        # Assert
+        assert torch.allclose(legacy, with_none)
+
+    def test_generate_heatmaps_visibility_2_produces_gaussian(self):
+        """vis=2 keypoints get a Gaussian heatmap identical to the legacy valid-keypoint path."""
+
+        # Arrange
+        keypoints = torch.tensor([[[64.0, 64.0]]])
+        vis = torch.tensor([[2]])
+        kwargs = dict(height=128, width=128, output_shape=(32, 32))
+
+        # Act
+        expected = generate_heatmaps(keypoints, **kwargs)  # legacy path
+        result = generate_heatmaps(keypoints, **kwargs, visibility=vis)
+
+        # Assert
+        assert torch.allclose(result, expected)
+
+    def test_generate_heatmaps_visibility_1_produces_uniform(self):
+        """vis=1 keypoints get a uniform heatmap regardless of coordinate values."""
+
+        H, W = 32, 32
+        uniform_heatmap = torch.ones(H, W) / (H * W)
+
+        # Case 1: NaN coordinates with vis=1
+        keypoints_nan = torch.tensor([[[float('nan'), float('nan')]]])
+        vis = torch.tensor([[1]])
+        result_nan = generate_heatmaps(
+            keypoints_nan, height=128, width=128, output_shape=(H, W), visibility=vis,
+        )
+        assert torch.allclose(result_nan[0, 0], uniform_heatmap)
+
+        # Case 2: valid coordinates with vis=1 — coords are ignored, still uniform
+        keypoints_valid = torch.tensor([[[64.0, 64.0]]])
+        result_valid = generate_heatmaps(
+            keypoints_valid, height=128, width=128, output_shape=(H, W), visibility=vis,
+        )
+        assert torch.allclose(result_valid[0, 0], uniform_heatmap)
+
+    def test_generate_heatmaps_visibility_0_produces_zeros(self):
+        """vis=0 keypoints get an all-zero heatmap regardless of coordinate values."""
+
+        H, W = 32, 32
+        zero_heatmap = torch.zeros(H, W)
+
+        # Case 1: NaN coordinates with vis=0
+        keypoints_nan = torch.tensor([[[float('nan'), float('nan')]]])
+        vis = torch.tensor([[0]])
+        result_nan = generate_heatmaps(
+            keypoints_nan, height=128, width=128, output_shape=(H, W), visibility=vis,
+        )
+        assert torch.allclose(result_nan[0, 0], zero_heatmap)
+
+        # Case 2: valid coordinates with vis=0 — coords are ignored, still zeros
+        keypoints_valid = torch.tensor([[[64.0, 64.0]]])
+        result_valid = generate_heatmaps(
+            keypoints_valid, height=128, width=128, output_shape=(H, W), visibility=vis,
+        )
+        assert torch.allclose(result_valid[0, 0], zero_heatmap)
+
+    def test_generate_heatmaps_visibility_mixed(self):
+        """Mixed visibility flags produce per-keypoint correct heatmap types."""
+
+        H, W = 32, 32
+        # batch=1, K=3: vis=2 (visible), vis=1 (occluded), vis=0 (not labeled)
+        keypoints = torch.tensor([[[64.0, 64.0], [float('nan'), float('nan')], [10.0, 10.0]]])
+        vis = torch.tensor([[2, 1, 0]])
+
+        result = generate_heatmaps(
+            keypoints, height=128, width=128, output_shape=(H, W), visibility=vis,
+        )
+
+        zero_heatmap = torch.zeros(H, W)
+        uniform_heatmap = torch.ones(H, W) / (H * W)
+
+        # vis=2: Gaussian (non-zero, sums to 1)
+        assert not torch.allclose(result[0, 0], zero_heatmap)
+        assert torch.isclose(result[0, 0].sum(), torch.tensor(1.0))
+        # vis=1: uniform (every pixel equal, sums to 1)
+        assert torch.allclose(result[0, 1], uniform_heatmap)
+        # vis=0: zeros
+        assert torch.allclose(result[0, 2], zero_heatmap)
+
+    def test_generate_heatmaps_visibility_2_nan_coords_falls_back_to_zeros(self):
+        """vis=2 with NaN coordinates (invalid label) falls back to a zero heatmap."""
+
+        H, W = 32, 32
+        keypoints = torch.tensor([[[float('nan'), float('nan')]]])
+        vis = torch.tensor([[2]])
+
+        result = generate_heatmaps(
+            keypoints, height=128, width=128, output_shape=(H, W), visibility=vis,
+        )
+        assert torch.allclose(result[0, 0], torch.zeros(H, W))
+
 
 def test_evaluate_heatmaps_at_location():
 

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -439,11 +439,15 @@ class TestGenerateHeatmaps:
 
         # Arrange: one valid keypoint, one NaN keypoint (batch=1, K=2)
         keypoints = torch.tensor([[[64.0, 64.0], [float('nan'), float('nan')]]])
-        kwargs = dict(height=128, width=128, output_shape=(32, 32))
 
         # Act
-        legacy = generate_heatmaps(keypoints, **kwargs, uniform_heatmaps=False)
-        with_none = generate_heatmaps(keypoints, **kwargs, uniform_heatmaps=False, visibility=None)
+        legacy = generate_heatmaps(
+            keypoints, height=128, width=128, output_shape=(32, 32), uniform_heatmaps=False,
+        )
+        with_none = generate_heatmaps(
+            keypoints, height=128, width=128, output_shape=(32, 32), uniform_heatmaps=False,
+            visibility=None,
+        )
 
         # Assert
         assert torch.allclose(legacy, with_none)
@@ -454,11 +458,12 @@ class TestGenerateHeatmaps:
         # Arrange
         keypoints = torch.tensor([[[64.0, 64.0]]])
         vis = torch.tensor([[2]])
-        kwargs = dict(height=128, width=128, output_shape=(32, 32))
 
         # Act
-        expected = generate_heatmaps(keypoints, **kwargs)  # legacy path
-        result = generate_heatmaps(keypoints, **kwargs, visibility=vis)
+        expected = generate_heatmaps(keypoints, height=128, width=128, output_shape=(32, 32))
+        result = generate_heatmaps(
+            keypoints, height=128, width=128, output_shape=(32, 32), visibility=vis,
+        )
 
         # Assert
         assert torch.allclose(result, expected)

--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -167,6 +167,7 @@ class TestGenerateHeatmaps:
         """uniform_heatmaps=True: dataset heatmaps match generate_heatmaps with synthesized vis."""
 
         from lightning_pose.data import get_dataset, get_imgaug_transform
+        from lightning_pose.data.datasets import HeatmapDataset
 
         cfg_tmp = copy.deepcopy(cfg)
         cfg_tmp.model.model_type = "heatmap"
@@ -179,12 +180,14 @@ class TestGenerateHeatmaps:
             imgaug_transform=imgaug_transform,
         )
 
+        assert isinstance(heatmap_dataset, HeatmapDataset)
         im_height = cfg.data.image_resize_dims.height
         im_width = cfg.data.image_resize_dims.width
 
         batch = heatmap_dataset.__getitem__(idx=0)
         heatmap_gt = batch["heatmaps"].unsqueeze(0)  # type: ignore[typeddict-item]
         keypts_gt = batch["keypoints"].unsqueeze(0).reshape(1, -1, 2)
+        assert heatmap_dataset.visibility is not None
         vis = heatmap_dataset.visibility[0].unsqueeze(0)  # (1, K) synthesized visibility
 
         heatmap_uniform_torch = generate_heatmaps(
@@ -306,8 +309,7 @@ class TestGenerateHeatmaps:
             keep_gradients=False,
         )
 
-        # Check that the heatmap doesn't require test_uniform_heatmapsgradients
-        # (computation graph is detached)
+        # Check that the heatmap doesn't require gradients (computation graph is detached)
         assert not heatmap_no_grad.requires_grad, \
             "Heatmap should not require gradients when keep_gradients=False"
 
@@ -343,10 +345,13 @@ class TestGenerateHeatmaps:
         zeros = torch.zeros(output_height, output_width)
         uniform = torch.ones(output_height, output_width) / (output_height * output_width)
 
-        kwargs = dict(height=im_height, width=im_width, output_shape=(output_height, output_width))
-
         # visibility=None: OOB and NaN → zeros; valid → Gaussian
-        heatmaps = generate_heatmaps(keypoints, **kwargs)
+        heatmaps = generate_heatmaps(
+            keypoints,
+            height=im_height,
+            width=im_width,
+            output_shape=(output_height, output_width),
+        )
         assert torch.allclose(heatmaps[0, 1], zeros)  # x OOB
         assert torch.allclose(heatmaps[0, 2], zeros)  # x OOB
         assert torch.allclose(heatmaps[0, 3], zeros)  # y OOB
@@ -358,19 +363,37 @@ class TestGenerateHeatmaps:
 
         # vis=1 (occluded): all keypoints → uniform, regardless of OOB or NaN
         vis1 = torch.ones(2, 4, dtype=torch.long)
-        heatmaps_v1 = generate_heatmaps(keypoints, **kwargs, visibility=vis1)
+        heatmaps_v1 = generate_heatmaps(
+            keypoints,
+            height=im_height,
+            width=im_width,
+            output_shape=(output_height, output_width),
+            visibility=vis1,
+        )
         assert torch.allclose(heatmaps_v1[0, 1], uniform)  # x OOB → uniform
         assert torch.allclose(heatmaps_v1[1, 2], uniform)  # NaN → uniform
 
         # vis=0 (not labeled): all keypoints → zeros, including valid ones
         vis0 = torch.zeros(2, 4, dtype=torch.long)
-        heatmaps_v0 = generate_heatmaps(keypoints, **kwargs, visibility=vis0)
+        heatmaps_v0 = generate_heatmaps(
+            keypoints,
+            height=im_height,
+            width=im_width,
+            output_shape=(output_height, output_width),
+            visibility=vis0,
+        )
         assert torch.allclose(heatmaps_v0[0, 0], zeros)  # valid kp → zeros when vis=0
         assert torch.allclose(heatmaps_v0[1, 1], zeros)  # valid kp → zeros when vis=0
 
         # vis=2 (visible) + OOB/NaN → zeros (defensive); vis=2 + valid → Gaussian
         vis2 = torch.full((2, 4), 2, dtype=torch.long)
-        heatmaps_v2 = generate_heatmaps(keypoints, **kwargs, visibility=vis2)
+        heatmaps_v2 = generate_heatmaps(
+            keypoints,
+            height=im_height,
+            width=im_width,
+            output_shape=(output_height, output_width),
+            visibility=vis2,
+        )
         assert torch.allclose(heatmaps_v2[0, 1], zeros)    # x OOB → zero despite vis=2
         assert torch.allclose(heatmaps_v2[1, 2], zeros)    # NaN → zero despite vis=2
         assert not torch.allclose(heatmaps_v2[0, 0], zeros)  # valid → Gaussian

--- a/tests/losses/test_losses.py
+++ b/tests/losses/test_losses.py
@@ -781,7 +781,6 @@ class TestReprojectionHeatmapLoss:
             downsampled_image_height=64,
             downsampled_image_width=64,
             log_weight=np.log(0.5),  # set log_weight so weight=0.5
-            uniform_heatmaps=False,
         )
         return loss
 

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -587,3 +587,58 @@ def test_fix_empty_first_row(tmp_path):
     assert len(fixed_df) == 3
     assert fixed_df.index.name is None
     assert fixed_df.index[0] == "labeled-data/test1.png"
+
+
+class TestHasVisibilityColumn:
+    """Test the has_visibility_column function."""
+
+    @pytest.fixture
+    def visibility_csv(self, tmp_path) -> Path:
+        """Create a DLC-format CSV with a visible column per keypoint."""
+        content = (
+            'scorer,scorer,scorer,scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp1,kp2,kp2,kp2\n'
+            'coords,x,y,visible,x,y,visible\n'
+            'labeled-data/img01.png,10.0,20.0,2,30.0,40.0,1\n'
+        )
+        p = tmp_path / 'visibility.csv'
+        p.write_text(content)
+        return p
+
+    @pytest.fixture
+    def standard_csv(self, tmp_path) -> Path:
+        """Create a standard DLC-format CSV without visibility columns."""
+        content = (
+            'scorer,scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp2,kp2\n'
+            'coords,x,y,x,y\n'
+            'labeled-data/img01.png,10.0,20.0,30.0,40.0\n'
+        )
+        p = tmp_path / 'standard.csv'
+        p.write_text(content)
+        return p
+
+    def test_has_visibility_column_true(self, visibility_csv):
+        """Returns True for a CSV with visible columns."""
+        from lightning_pose.utils.io import has_visibility_column
+        assert has_visibility_column(str(visibility_csv), header_rows=[0, 1, 2])
+
+    def test_has_visibility_column_false_standard_csv(self, standard_csv):
+        """Returns False for a standard DLC CSV without visible column."""
+        from lightning_pose.utils.io import has_visibility_column
+        assert not has_visibility_column(str(standard_csv), header_rows=[0, 1, 2])
+
+    def test_has_visibility_column_false_wrong_header(self, visibility_csv):
+        """Returns False when header_rows is not [0, 1, 2]."""
+        from lightning_pose.utils.io import has_visibility_column
+        assert not has_visibility_column(str(visibility_csv), header_rows=[0, 1])
+
+    def test_has_visibility_column_false_nonexistent_file(self, tmp_path):
+        """Returns False for a path that does not exist."""
+        from lightning_pose.utils.io import has_visibility_column
+        assert not has_visibility_column(str(tmp_path / 'nonexistent.csv'), header_rows=[0, 1, 2])
+
+    def test_has_visibility_column_default_header_treated_as_dlc(self, visibility_csv):
+        """header_rows=None defaults to [0, 1, 2] and detects visible columns."""
+        from lightning_pose.utils.io import has_visibility_column
+        assert has_visibility_column(str(visibility_csv), header_rows=None)

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+import torch
 
 from lightning_pose.utils import io as io_utils
 from lightning_pose.utils.io import (
@@ -642,3 +643,129 @@ class TestHasVisibilityColumn:
         """header_rows=None defaults to [0, 1, 2] and detects visible columns."""
         from lightning_pose.utils.io import has_visibility_column
         assert has_visibility_column(str(visibility_csv), header_rows=None)
+
+
+class TestParseLabelCsv:
+    """Test the parse_label_csv function."""
+
+    @pytest.fixture
+    def standard_csv(self, tmp_path) -> Path:
+        """Two-keypoint standard DLC CSV without visibility; frame 1 has one unlabeled kp."""
+        content = (
+            'scorer,scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp2,kp2\n'
+            'coords,x,y,x,y\n'
+            'labeled-data/img01.png,10.0,20.0,30.0,40.0\n'
+            'labeled-data/img02.png,50.0,60.0,,\n'
+        )
+        p = tmp_path / 'standard.csv'
+        p.write_text(content)
+        return p
+
+    @pytest.fixture
+    def visibility_csv(self, tmp_path) -> Path:
+        """Two-keypoint CSV with visible column; kp1 visible, kp2 occluded/unlabeled."""
+        content = (
+            'scorer,scorer,scorer,scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp1,kp2,kp2,kp2\n'
+            'coords,x,y,visible,x,y,visible\n'
+            'labeled-data/img01.png,10.0,20.0,2,30.0,40.0,1\n'
+            'labeled-data/img02.png,50.0,60.0,2,,,0\n'
+        )
+        p = tmp_path / 'visibility.csv'
+        p.write_text(content)
+        return p
+
+    def test_parse_label_csv_standard_keypoint_names(self, standard_csv):
+        """Keypoint names are extracted from the bodyparts row."""
+        from lightning_pose.utils.io import parse_label_csv
+        result = parse_label_csv(str(standard_csv))
+        assert result.keypoint_names == ['kp1', 'kp2']
+
+    def test_parse_label_csv_standard_image_names(self, standard_csv):
+        """Image names are read from the index column in order."""
+        from lightning_pose.utils.io import parse_label_csv
+        result = parse_label_csv(str(standard_csv))
+        assert result.image_names == ['labeled-data/img01.png', 'labeled-data/img02.png']
+
+    def test_parse_label_csv_standard_keypoints_shape(self, standard_csv):
+        """Keypoints tensor has shape (N, K, 2) for a standard CSV."""
+        from lightning_pose.utils.io import parse_label_csv
+        result = parse_label_csv(str(standard_csv))
+        assert result.keypoints.shape == (2, 2, 2)
+
+    def test_parse_label_csv_standard_keypoint_values(self, standard_csv):
+        """Labeled coordinates are parsed correctly; unlabeled become NaN."""
+        from lightning_pose.utils.io import parse_label_csv
+        result = parse_label_csv(str(standard_csv))
+        assert result.keypoints[0, 0, 0] == 10.0
+        assert result.keypoints[0, 0, 1] == 20.0
+        assert torch.isnan(result.keypoints[1, 1, 0])
+        assert torch.isnan(result.keypoints[1, 1, 1])
+
+    def test_parse_label_csv_standard_no_visibility(self, standard_csv):
+        """visibility is None for a standard CSV without a visible column."""
+        from lightning_pose.utils.io import parse_label_csv
+        result = parse_label_csv(str(standard_csv))
+        assert result.visibility is None
+
+    def test_parse_label_csv_visibility_tensor_shape(self, visibility_csv):
+        """visibility tensor has shape (N, K) and dtype int64 when column is present."""
+        from lightning_pose.utils.io import parse_label_csv
+        result = parse_label_csv(str(visibility_csv))
+        assert result.visibility is not None
+        assert result.visibility.shape == (2, 2)
+        assert result.visibility.dtype == torch.long
+
+    def test_parse_label_csv_visibility_values(self, visibility_csv):
+        """visibility values match the CSV contents."""
+        from lightning_pose.utils.io import parse_label_csv
+        result = parse_label_csv(str(visibility_csv))
+        assert result.visibility is not None
+        assert result.visibility[0, 0] == 2  # kp1 frame 0: visible
+        assert result.visibility[0, 1] == 1  # kp2 frame 0: occluded
+        assert result.visibility[1, 0] == 2  # kp1 frame 1: visible
+        assert result.visibility[1, 1] == 0  # kp2 frame 1: not labeled
+
+    def test_parse_label_csv_visibility_keypoints_shape(self, visibility_csv):
+        """keypoints tensor is (N, K, 2) — visibility column is stripped."""
+        from lightning_pose.utils.io import parse_label_csv
+        result = parse_label_csv(str(visibility_csv))
+        assert result.keypoints.shape == (2, 2, 2)
+
+    def test_parse_label_csv_nonexistent_file_raises(self, tmp_path):
+        """FileNotFoundError is raised for a path that does not exist."""
+        from lightning_pose.utils.io import parse_label_csv
+        with pytest.raises(FileNotFoundError):
+            parse_label_csv(str(tmp_path / 'nonexistent.csv'))
+
+    def test_parse_label_csv_invalid_visibility_raises(self, tmp_path):
+        """ValueError is raised when the visible column contains a value outside {0, 1, 2}."""
+        content = (
+            'scorer,scorer,scorer,scorer\n'
+            'bodyparts,kp1,kp1,kp1\n'
+            'coords,x,y,visible\n'
+            'labeled-data/img01.png,10.0,20.0,9\n'
+        )
+        p = tmp_path / 'bad.csv'
+        p.write_text(content)
+        from lightning_pose.utils.io import parse_label_csv
+        with pytest.raises(ValueError, match='invalid values'):
+            parse_label_csv(str(p))
+
+    def test_parse_label_csv_single_read(self, standard_csv, monkeypatch):
+        """The CSV file is read exactly once."""
+        import pandas as pd
+
+        from lightning_pose.utils.io import parse_label_csv
+        read_count = 0
+        original_read_csv = pd.read_csv
+
+        def counting_read_csv(*args, **kwargs):
+            nonlocal read_count
+            read_count += 1
+            return original_read_csv(*args, **kwargs)
+
+        monkeypatch.setattr(pd, 'read_csv', counting_read_csv)
+        parse_label_csv(str(standard_csv))
+        assert read_count == 1

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -590,60 +590,6 @@ def test_fix_empty_first_row(tmp_path):
     assert fixed_df.index[0] == "labeled-data/test1.png"
 
 
-class TestHasVisibilityColumn:
-    """Test the has_visibility_column function."""
-
-    @pytest.fixture
-    def visibility_csv(self, tmp_path) -> Path:
-        """Create a DLC-format CSV with a visible column per keypoint."""
-        content = (
-            'scorer,scorer,scorer,scorer,scorer,scorer,scorer\n'
-            'bodyparts,kp1,kp1,kp1,kp2,kp2,kp2\n'
-            'coords,x,y,visible,x,y,visible\n'
-            'labeled-data/img01.png,10.0,20.0,2,30.0,40.0,1\n'
-        )
-        p = tmp_path / 'visibility.csv'
-        p.write_text(content)
-        return p
-
-    @pytest.fixture
-    def standard_csv(self, tmp_path) -> Path:
-        """Create a standard DLC-format CSV without visibility columns."""
-        content = (
-            'scorer,scorer,scorer,scorer,scorer\n'
-            'bodyparts,kp1,kp1,kp2,kp2\n'
-            'coords,x,y,x,y\n'
-            'labeled-data/img01.png,10.0,20.0,30.0,40.0\n'
-        )
-        p = tmp_path / 'standard.csv'
-        p.write_text(content)
-        return p
-
-    def test_has_visibility_column_true(self, visibility_csv):
-        """Returns True for a CSV with visible columns."""
-        from lightning_pose.utils.io import has_visibility_column
-        assert has_visibility_column(str(visibility_csv), header_rows=[0, 1, 2])
-
-    def test_has_visibility_column_false_standard_csv(self, standard_csv):
-        """Returns False for a standard DLC CSV without visible column."""
-        from lightning_pose.utils.io import has_visibility_column
-        assert not has_visibility_column(str(standard_csv), header_rows=[0, 1, 2])
-
-    def test_has_visibility_column_false_wrong_header(self, visibility_csv):
-        """Returns False when header_rows is not [0, 1, 2]."""
-        from lightning_pose.utils.io import has_visibility_column
-        assert not has_visibility_column(str(visibility_csv), header_rows=[0, 1])
-
-    def test_has_visibility_column_false_nonexistent_file(self, tmp_path):
-        """Returns False for a path that does not exist."""
-        from lightning_pose.utils.io import has_visibility_column
-        assert not has_visibility_column(str(tmp_path / 'nonexistent.csv'), header_rows=[0, 1, 2])
-
-    def test_has_visibility_column_default_header_treated_as_dlc(self, visibility_csv):
-        """header_rows=None defaults to [0, 1, 2] and detects visible columns."""
-        from lightning_pose.utils.io import has_visibility_column
-        assert has_visibility_column(str(visibility_csv), header_rows=None)
-
 
 class TestParseLabelCsv:
     """Test the parse_label_csv function."""


### PR DESCRIPTION
Add per-keypoint visibility flags to label CSV format, and refactor the CSV parsing and heatmap generation pipeline to propagate visibility cleanly.

## Visibility column

Label CSVs now support an optional visible column after each x, y pair (x, y, visible, x, y, visible, …), following the COCO keypoint convention:

* 0: not labeled -- all-zeros (excluded from loss)
* 1: occluded -- uniform (encourages low-confidence output)
* 2: visible -- Gaussian (standard supervised target)

  Detection is inline in parse_label_csv; only the [0, 1, 2] (DLC) header format is supported.

## Refactors

utils/io.py — consolidated CSV parsing into parse_label_csv. Removed has_visibility_column (fully superseded by inline detection). get_keypoint_names is retained; it operates on predictions CSVs (with likelihood column) and has a config fallback, so it serves a different purpose.

data/datatypes.py — BaseLabeledExampleDict now always carries a visibility key: a (K,) int64 tensor when the CSV has a visible column, or torch.zeros(0, dtype=torch.long) (empty-tensor sentinel) when it does not. The sentinel collates cleanly through PyTorch's default_collate.

data/datasets.py — HeatmapDataset.__init__ synthesizes visibility when the CSV has no visible column: NaN keypoints → vis=1 (uniform) or vis=0 (zero) based on the uniform_heatmaps_for_nan_keypoints config flag; valid keypoints → vis=2. This means self.visibility is always populated after init. compute_heatmap now reads visibility directly from example_dict["visibility"] rather than indexing self.visibility by sample index.

data/utils.py — removed uniform_heatmaps parameter from generate_heatmaps; visibility is now encoded permanently in the dataset tensor and passed via example_dict. The visibility=None path (used by loss functions that never pass NaN-coordinate predictions) is unchanged.

losses/losses.py — removed uniform_heatmaps parameter from UnimodalLoss and ReprojectionHeatmapLoss (was already always False at call sites).

## Tests

37 new or updated tests across tests/utils/test_io.py, tests/data/test_utils.py, tests/data/test_datasets.py, and tests/losses/test_losses.py. Coverage includes all four visibility modes (None, vis=0/1/2) for OOB, NaN, and valid keypoints.
