### PR TITLE
standardize package APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,18 @@ def function_name(
 
 ## Architecture
 
+### Module docstring conventions
+
+Every subpackage that contains both an `__init__.py` and a `factory.py` observes a strict
+separation of concerns in their module docstrings:
+
+- **`__init__.py`** — user-facing package map: what classes/functions are exported, how they
+  relate, and where to find them.  No contributor recipes.
+- **`factory.py`** — contributor guide: describes the dispatch logic and includes an explicit
+  "Adding a new X" step-by-step recipe so extensions don't require reverse-engineering.
+
+This applies to `data/`, `losses/`, `models/`, and `models/backbones/`.
+
 ### Backbone package (`lightning_pose/models/backbones/`)
 
 **Package layout**:

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -35,7 +35,8 @@ from lightning_pose.utils.predictions import (
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["Model", "get_model_class", "load_model_from_checkpoint"]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def load_model_from_checkpoint(

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -25,7 +25,7 @@ from lightning_pose.data.bboxes import model_to_frame_batch
 from lightning_pose.data.datamodules import BaseDataModule, UnlabeledDataModule
 from lightning_pose.data.datatypes import MultiviewPredictionResult, PredictionResult
 from lightning_pose.metrics import compute_metrics_single
-from lightning_pose.models import ALLOWED_MODEL_TYPES, ALLOWED_MODELS
+from lightning_pose.models import ALLOWED_MODELS, get_model_class
 from lightning_pose.utils import io as io_utils
 from lightning_pose.utils.predictions import generate_labeled_video as generate_labeled_video_fn
 from lightning_pose.utils.predictions import (
@@ -36,52 +36,6 @@ from lightning_pose.utils.predictions import (
 logger = logging.getLogger(__name__)
 
 __all__ = ["Model", "get_model_class", "load_model_from_checkpoint"]
-
-
-def get_model_class(map_type: ALLOWED_MODEL_TYPES, semi_supervised: bool) -> type[ALLOWED_MODELS]:
-    """Return the model class for the given model type and supervision mode.
-
-    Args:
-        map_type: one of ``"regression"``, ``"heatmap"``, ``"heatmap_mhcrnn"``,
-            ``"heatmap_multiview_transformer"``.
-        semi_supervised: True to return the semi-supervised variant.
-
-    Returns:
-        model class (not an instance).
-
-    Raises:
-        NotImplementedError: if ``map_type`` is not recognised.
-
-    """
-    if not semi_supervised:
-        if map_type == 'regression':
-            from lightning_pose.models import RegressionTracker as ModelClass
-        elif map_type == 'heatmap':
-            from lightning_pose.models import HeatmapTracker as ModelClass
-        elif map_type == 'heatmap_mhcrnn':
-            from lightning_pose.models import HeatmapTrackerMHCRNN as ModelClass
-        elif map_type == 'heatmap_multiview_transformer':
-            from lightning_pose.models import HeatmapTrackerMultiviewTransformer as ModelClass
-        else:
-            raise NotImplementedError(
-                f'{map_type} is an invalid model_type for a fully supervised model'
-            )
-    else:
-        if map_type == 'regression':
-            from lightning_pose.models import SemiSupervisedRegressionTracker as ModelClass
-        elif map_type == 'heatmap':
-            from lightning_pose.models import SemiSupervisedHeatmapTracker as ModelClass
-        elif map_type == 'heatmap_mhcrnn':
-            from lightning_pose.models import SemiSupervisedHeatmapTrackerMHCRNN as ModelClass
-        elif map_type == 'heatmap_multiview_transformer':
-            from lightning_pose.models import (
-                SemiSupervisedHeatmapTrackerMultiviewTransformer as ModelClass,
-            )
-        else:
-            raise NotImplementedError(
-                f'{map_type} is an invalid model_type for a semi-supervised model'
-            )
-    return ModelClass
 
 
 def load_model_from_checkpoint(
@@ -136,7 +90,7 @@ def load_model_from_checkpoint(
 
     semi_supervised = check_if_semi_supervised(cfg.model.losses_to_use)
     ModelClass = get_model_class(
-        map_type=cfg.model.model_type,
+        model_type=cfg.model.model_type,
         semi_supervised=semi_supervised,
     )
 

--- a/lightning_pose/api/model_config.py
+++ b/lightning_pose/api/model_config.py
@@ -8,14 +8,15 @@ from typing import get_args
 
 from omegaconf import DictConfig, ListConfig, OmegaConf, open_dict
 
-__all__ = ["ModelConfig"]
-
 from lightning_pose.models import ALLOWED_MODEL_TYPES
 from lightning_pose.utils.io import (
     check_video_paths,
     find_video_files_for_views,
     return_absolute_path,
 )
+
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class ModelConfig:

--- a/lightning_pose/data/__init__.py
+++ b/lightning_pose/data/__init__.py
@@ -1,4 +1,45 @@
-"""Data loading, preprocessing, and augmentation for pose estimation."""
+"""Data loading, preprocessing, and augmentation for pose estimation.
+
+**Three-stage factory pipeline** (the main entry points for all callers):
+
+1. :func:`get_imgaug_transform` — build an ``imgaug`` augmentation pipeline from config.
+2. :func:`get_dataset` — build a labeled dataset that pairs images with CSV keypoints.
+3. :func:`get_data_module` — build a Lightning ``DataModule`` (labeled dataset +
+   optional unlabeled video loader for semi-supervised training).
+
+All three dispatch on ``cfg.model.model_type`` to select the right class.
+
+**Module layout**:
+
+*Pipeline stages* — what most callers interact with:
+
+- ``factory.py`` — the three factory functions above.
+- ``datasets.py`` — :class:`~lightning_pose.data.datasets.BaseTrackingDataset`,
+  :class:`~lightning_pose.data.datasets.HeatmapDataset`,
+  :class:`~lightning_pose.data.datasets.MultiviewHeatmapDataset`.
+- ``datamodules.py`` — :class:`~lightning_pose.data.datamodules.BaseDataModule`,
+  :class:`~lightning_pose.data.datamodules.UnlabeledDataModule`.
+- ``augmentations.py`` — imgaug transform construction helpers.
+- ``datatypes.py`` — TypedDict batch-dict types used throughout the package
+  (e.g. ``HeatmapLabeledBatchDict``, ``MultiviewUnlabeledBatchDict``).
+
+*Coordinate and label utilities* — used inside datasets and model forward passes:
+
+- ``bboxes.py`` — coordinate transforms between frame, normalised-bbox, and model
+  pixel spaces; see that module's docstring for the three-space mental model.
+- ``heatmaps.py`` — :func:`~lightning_pose.data.heatmaps.generate_heatmaps` and
+  :func:`~lightning_pose.data.heatmaps.evaluate_heatmaps_at_location`.
+- ``cameras.py`` — camera-parameter utilities for multiview calibration.
+- ``utils.py`` — dataset-level utilities: train/val/test splits, frame counting,
+  affine-transform undo.
+
+*Video infrastructure* — used only for semi-supervised training:
+
+- ``dali.py`` — GPU-accelerated video loading via NVIDIA DALI
+  (:class:`~lightning_pose.data.dali.PrepareDALI`,
+  :class:`~lightning_pose.data.dali.LitDaliWrapper`).
+- ``extractor.py`` — frame extraction utilities.
+"""
 
 # statistics of imagenet dataset on which the resnet was trained
 # see https://pytorch.org/vision/stable/models.html

--- a/lightning_pose/data/__init__.py
+++ b/lightning_pose/data/__init__.py
@@ -51,3 +51,9 @@ from lightning_pose.data.factory import (  # noqa: E402
     get_dataset,
     get_imgaug_transform,
 )
+
+__all__ = [
+    'get_data_module',
+    'get_dataset',
+    'get_imgaug_transform',
+]

--- a/lightning_pose/data/augmentations.py
+++ b/lightning_pose/data/augmentations.py
@@ -5,10 +5,8 @@ from typing import Any
 import imgaug.augmenters as iaa
 from omegaconf import DictConfig, ListConfig
 
-# to ignore imports for sphix-autoapidoc
-__all__ = [
-    "imgaug_transform",
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def imgaug_transform(params_dict: dict | DictConfig) -> iaa.Sequential:

--- a/lightning_pose/data/bboxes.py
+++ b/lightning_pose/data/bboxes.py
@@ -36,16 +36,8 @@ from lightning_pose.data.datatypes import (
     UnlabeledBatchDict,
 )
 
-__all__ = [
-    'frame_to_norm',
-    'norm_to_frame',
-    'model_to_norm',
-    'norm_to_model',
-    'frame_to_model',
-    'model_to_frame',
-    'frame_to_model_batch',
-    'model_to_frame_batch',
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def frame_to_norm(

--- a/lightning_pose/data/cameras.py
+++ b/lightning_pose/data/cameras.py
@@ -15,12 +15,8 @@ from kornia.geometry.calibration import distort_points, undistort_points
 from kornia.geometry.camera import PinholeCamera
 from kornia.geometry.epipolar import triangulate_points
 
-# to ignore imports for sphix-autoapidoc
-__all__ = [
-    "project_camera_pairs_to_3d",
-    "project_3d_to_2d",
-    "CameraGroup",
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def project_camera_pairs_to_3d(

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -44,12 +44,8 @@ from lightning_pose.data.datatypes import (
 )
 from lightning_pose.data.utils import count_frames
 
-# to ignore imports for sphix-autoapidoc
-__all__ = [
-    "video_pipe",
-    "LitDaliWrapper",
-    "PrepareDALI",
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 # cannot typecheck due to way pipeline_def decorator consumes additional args

--- a/lightning_pose/data/datamodules.py
+++ b/lightning_pose/data/datamodules.py
@@ -31,11 +31,8 @@ from lightning_pose.utils.io import check_video_paths
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = [
-    "BaseDataModule",
-    "UnlabeledDataModule",
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class BaseDataModule(pl.LightningDataModule):

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -29,12 +29,8 @@ from lightning_pose.utils import io as io_utils
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = [
-    "BaseTrackingDataset",
-    "HeatmapDataset",
-    "MultiviewHeatmapDataset",
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def _patched_prevent(axis_size: int, crop_start: int, crop_end: int) -> tuple[int, ...]:

--- a/lightning_pose/data/extractor.py
+++ b/lightning_pose/data/extractor.py
@@ -14,8 +14,8 @@ from lightning_pose.data.datasets import (
     MultiviewHeatmapDataset,
 )
 
-# to ignore imports for sphix-autoapidoc
-__all__ = ["DataExtractor"]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class DataExtractor:

--- a/lightning_pose/data/factory.py
+++ b/lightning_pose/data/factory.py
@@ -10,6 +10,16 @@ Three public functions, typically called in order:
    splitting; selects :class:`~lightning_pose.data.datamodules.UnlabeledDataModule` for
    semi-supervised training (adds DALI video loader) or
    :class:`~lightning_pose.data.datamodules.BaseDataModule` for supervised-only training.
+
+**Adding a new model type** (data-side changes only — see ``models/factory.py`` for the
+model-side steps):
+
+1. If the new type can reuse an existing dataset class (e.g. it is a heatmap variant),
+   extend the appropriate ``elif`` branch in :func:`get_dataset` to match the new
+   ``cfg.model.model_type`` string.  If it needs a new dataset class, define that class
+   in ``datasets.py``, import it here, and add a new ``elif`` branch.
+2. If the new type needs a different :class:`~lightning_pose.data.datamodules.BaseDataModule`
+   subclass, add a branch in :func:`get_data_module`; otherwise no change is needed there.
 """
 
 import warnings

--- a/lightning_pose/data/factory.py
+++ b/lightning_pose/data/factory.py
@@ -240,7 +240,7 @@ def get_data_module(
     )
     val_batch_size = int(np.ceil(cfg.training.val_batch_size / cfg.training.num_gpus))
 
-    from lightning_pose.models.base import check_if_semi_supervised
+    from lightning_pose.models import check_if_semi_supervised
     semi_supervised = check_if_semi_supervised(cfg.model.losses_to_use)
     if not semi_supervised:
         data_module = BaseDataModule(

--- a/lightning_pose/data/factory.py
+++ b/lightning_pose/data/factory.py
@@ -41,11 +41,7 @@ from lightning_pose.data.datasets import (
 )
 
 # to ignore imports for sphinx-autoapidoc
-__all__ = [
-    'get_imgaug_transform',
-    'get_dataset',
-    'get_data_module',
-]
+__all__: list[str] = []
 
 
 def get_imgaug_transform(cfg: DictConfig | ListConfig) -> iaa.Sequential:

--- a/lightning_pose/data/heatmaps.py
+++ b/lightning_pose/data/heatmaps.py
@@ -4,10 +4,8 @@ import numpy as np
 import torch
 from jaxtyping import Float, Int
 
-__all__ = [
-    'generate_heatmaps',
-    'evaluate_heatmaps_at_location',
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def generate_heatmaps(

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -10,15 +10,8 @@ from jaxtyping import Float
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = [
-    'split_sizes_from_probabilities',
-    'clean_any_nans',
-    'count_frames',
-    'compute_num_train_frames',
-    'undo_affine_transform',
-    'undo_affine_transform_batch',
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def split_sizes_from_probabilities(

--- a/lightning_pose/losses/__init__.py
+++ b/lightning_pose/losses/__init__.py
@@ -35,3 +35,9 @@ by :func:`get_loss_classes`; the names below are the strings used in config file
 """
 
 from lightning_pose.losses.factory import get_loss_classes, get_loss_factories
+
+# to ignore imports for sphinx-autoapidoc
+__all__ = [
+    "get_loss_classes",
+    "get_loss_factories",
+]

--- a/lightning_pose/losses/__init__.py
+++ b/lightning_pose/losses/__init__.py
@@ -1,3 +1,37 @@
-"""Supervised and semi-supervised loss functions for pose estimation."""
+"""Supervised and semi-supervised loss functions for pose estimation.
+
+Loss names follow a ``{domain}_{variant}`` convention.  The full registry is returned
+by :func:`get_loss_classes`; the names below are the strings used in config files under
+``cfg.model.losses_to_use`` and ``cfg.model.heatmap_loss_type``.
+
+*Supervised losses* (always active; selected automatically by model type):
+
+- ``heatmap_mse``, ``heatmap_kl``, ``heatmap_js`` — pixel-wise heatmap losses
+  (:class:`~lightning_pose.losses.losses.HeatmapMSELoss`,
+  :class:`~lightning_pose.losses.losses.HeatmapKLLoss`,
+  :class:`~lightning_pose.losses.losses.HeatmapJSLoss`).
+- ``regression`` — MSE on (x, y) coordinates
+  (:class:`~lightning_pose.losses.losses.RegressionMSELoss`).
+- ``rmse`` — RMSE on (x, y) coordinates
+  (:class:`~lightning_pose.losses.losses.RegressionRMSELoss`).
+
+*Supervised losses* (active when log_weight is not null; needs updating to mirror semi-supervised)
+- ``supervised_pairwise_projections`` — multiview epipolar consistency
+  (:class:`~lightning_pose.losses.losses.PairwiseProjectionsLoss`).
+- ``supervised_reprojection_heatmap_mse`` — multiview reprojection heatmap loss
+  (:class:`~lightning_pose.losses.losses.ReprojectionHeatmapLoss`).
+
+*Semi-supervised losses* (opt-in via ``cfg.model.losses_to_use``):
+
+- ``pca_multiview``, ``pca_singleview`` — both served by
+  :class:`~lightning_pose.losses.losses.PCALoss`; enforce pose-space structure via PCA.
+- ``temporal`` — penalises abrupt frame-to-frame keypoint movement
+  (:class:`~lightning_pose.losses.losses.TemporalLoss`).
+- ``temporal_heatmap_mse``, ``temporal_heatmap_kl`` — both served by
+  :class:`~lightning_pose.losses.losses.TemporalHeatmapLoss`; heatmap-level temporal
+  smoothness.
+- ``unimodal_mse``, ``unimodal_kl``, ``unimodal_js`` — all served by
+  :class:`~lightning_pose.losses.losses.UnimodalLoss`; encourage single-peaked heatmaps.
+"""
 
 from lightning_pose.losses.factory import get_loss_classes, get_loss_factories

--- a/lightning_pose/losses/factory.py
+++ b/lightning_pose/losses/factory.py
@@ -8,6 +8,18 @@ Three components work together:
   'unsupervised': LossFactory}`` dict ready to be passed to a model constructor.
 - :class:`LossFactory` — a ``LightningModule`` that holds instantiated loss objects and
   computes the total weighted loss in its ``__call__`` method.
+
+**Adding a new loss**:
+
+1. Define the class in ``losses/losses.py``, inheriting from
+   :class:`~lightning_pose.losses.losses.Loss`.  Set a ``loss_name: str`` class attribute
+   (single name) or multiple ``LOSS_NAME_*: str`` class attributes when one class serves
+   several config strings (e.g. :class:`~lightning_pose.losses.losses.PCALoss`).
+2. Import the class at the top of this file and add one entry per name to the dict returned
+   by :func:`get_loss_classes`.
+3. If the loss requires parameters from ``cfg.losses`` (weight, epsilon, etc.), add a
+   corresponding block in :func:`get_loss_factories` that reads those values and adds them
+   to the ``params`` dict for that loss name.
 """
 
 import logging

--- a/lightning_pose/losses/factory.py
+++ b/lightning_pose/losses/factory.py
@@ -49,11 +49,7 @@ from lightning_pose.losses.losses import (
 logger = logging.getLogger(__name__)
 
 # to ignore imports for sphix-autoapidoc
-__all__ = [
-    'LossFactory',
-    'get_loss_classes',
-    'get_loss_factories',
-]
+__all__: list[str] = []
 
 
 def get_loss_classes() -> dict[str, type[Loss]]:

--- a/lightning_pose/models/__init__.py
+++ b/lightning_pose/models/__init__.py
@@ -57,16 +57,6 @@ from lightning_pose.models.regression_tracker import (
     SemiSupervisedRegressionTracker,
 )
 
-# reassign module to make classes appear to belong here
-HeatmapTracker.__module__ = 'lightning_pose.models'
-SemiSupervisedHeatmapTracker.__module__ = 'lightning_pose.models'
-HeatmapTrackerMHCRNN.__module__ = 'lightning_pose.models'
-SemiSupervisedHeatmapTrackerMHCRNN.__module__ = 'lightning_pose.models'
-HeatmapTrackerMultiviewTransformer.__module__ = 'lightning_pose.models'
-SemiSupervisedHeatmapTrackerMultiviewTransformer.__module__ = 'lightning_pose.models'
-RegressionTracker.__module__ = 'lightning_pose.models'
-SemiSupervisedRegressionTracker.__module__ = 'lightning_pose.models'
-
 ALLOWED_MODELS = (
     HeatmapTracker
     | SemiSupervisedHeatmapTracker
@@ -78,9 +68,8 @@ ALLOWED_MODELS = (
     | SemiSupervisedRegressionTracker
 )
 
-# to ignore imports for sphix-autoapidoc
+# to ignore imports for sphinx-autoapidoc
 __all__ = [
-    'ALLOWED_MODEL_TYPES',
     'check_if_semi_supervised',
     'get_model',
     'get_model_class',

--- a/lightning_pose/models/__init__.py
+++ b/lightning_pose/models/__init__.py
@@ -1,9 +1,7 @@
 """Pose estimation model classes, re-exported at the package level."""
 
-from typing import Literal
-
 from lightning_pose.models.base import check_if_semi_supervised
-from lightning_pose.models.factory import get_model
+from lightning_pose.models.factory import ALLOWED_MODEL_TYPES, get_model, get_model_class
 from lightning_pose.models.heatmap_tracker import (
     HeatmapTracker,
     SemiSupervisedHeatmapTracker,
@@ -31,13 +29,6 @@ SemiSupervisedHeatmapTrackerMultiviewTransformer.__module__ = 'lightning_pose.mo
 RegressionTracker.__module__ = 'lightning_pose.models'
 SemiSupervisedRegressionTracker.__module__ = 'lightning_pose.models'
 
-ALLOWED_MODEL_TYPES = Literal[
-    'regression',
-    'heatmap',
-    'heatmap_mhcrnn',
-    'heatmap_multiview_transformer',
-]
-
 ALLOWED_MODELS = (
     HeatmapTracker
     | SemiSupervisedHeatmapTracker
@@ -51,8 +42,10 @@ ALLOWED_MODELS = (
 
 # to ignore imports for sphix-autoapidoc
 __all__ = [
+    'ALLOWED_MODEL_TYPES',
     'check_if_semi_supervised',
     'get_model',
+    'get_model_class',
     'HeatmapTracker',
     'SemiSupervisedHeatmapTracker',
     'HeatmapTrackerMHCRNN',

--- a/lightning_pose/models/__init__.py
+++ b/lightning_pose/models/__init__.py
@@ -1,4 +1,42 @@
-"""Pose estimation model classes, re-exported at the package level."""
+"""Pose estimation model classes, re-exported at the package level.
+
+**Four model types**, each available in a supervised and a semi-supervised variant
+(8 concrete classes total):
+
+- ``regression`` — direct (x, y) coordinate regression.
+  ``RegressionTracker`` / ``SemiSupervisedRegressionTracker`` → ``regression_tracker.py``
+- ``heatmap`` — per-keypoint 2-D Gaussian heatmaps.
+  ``HeatmapTracker`` / ``SemiSupervisedHeatmapTracker`` → ``heatmap_tracker.py``
+- ``heatmap_mhcrnn`` — heatmaps with temporal context via a recurrent head (MHCRNN).
+  ``HeatmapTrackerMHCRNN`` / ``SemiSupervisedHeatmapTrackerMHCRNN``
+  → ``heatmap_tracker_mhcrnn.py``
+- ``heatmap_multiview_transformer`` — multi-camera heatmaps with cross-view attention.
+  ``HeatmapTrackerMultiviewTransformer`` /
+  ``SemiSupervisedHeatmapTrackerMultiviewTransformer``
+  → ``heatmap_tracker_multiview.py``
+
+**Supervised / semi-supervised split**: every supervised class has a semi-supervised
+counterpart produced by mixing in
+:class:`~lightning_pose.models.base.SemiSupervisedTrackerMixin`.  The mixin adds a
+second ``loss_factory_unsupervised`` argument and extends ``training_step`` to compute
+unsupervised losses on unlabeled video frames.
+
+**Other files in this package**:
+
+- ``base.py`` — abstract bases and shared logic:
+  :class:`~lightning_pose.models.base.BaseFeatureExtractor`,
+  :class:`~lightning_pose.models.base.BaseSupervisedTracker`,
+  :class:`~lightning_pose.models.base.SemiSupervisedTrackerMixin`.
+- ``factory.py`` — :func:`get_model` (full construction from config) and
+  :func:`get_model_class` (pure ``(model_type, semi_supervised) → class`` dispatch);
+  :data:`ALLOWED_MODEL_TYPES` Literal defined here.
+- ``backbones/`` — backbone wrappers and :func:`~lightning_pose.models.backbones.build_backbone`;
+  see ``backbones/__init__.py`` for the type hierarchy and how to add a new backbone.
+- ``heads/`` — output head classes
+  (:class:`~lightning_pose.models.heads.HeatmapHead`,
+  :class:`~lightning_pose.models.heads.HeatmapMHCRNNHead`,
+  :class:`~lightning_pose.models.heads.LinearRegressionHead`).
+"""
 
 from lightning_pose.models.base import check_if_semi_supervised
 from lightning_pose.models.factory import ALLOWED_MODEL_TYPES, get_model, get_model_class

--- a/lightning_pose/models/backbones/__init__.py
+++ b/lightning_pose/models/backbones/__init__.py
@@ -1,12 +1,8 @@
-"""Public façade for the backbones package.
+"""Re-export façade for the backbones package.
 
-All backbone type constants and the ``build_backbone`` factory live in
-``factory.py``; this module re-exports them so callers can write::
-
-    from lightning_pose.models.backbones import build_backbone, ALLOWED_BACKBONES
-
-Nothing should be defined here — add new symbols to ``factory.py`` and extend
-the import list below.
+All backbone type constants and the ``build_backbone`` factory are defined in
+``factory.py``; this module re-exports them. Nothing should be defined here —
+add new symbols to ``factory.py`` and extend the import list below.
 """
 
 from lightning_pose.models.backbones.factory import (
@@ -18,11 +14,5 @@ from lightning_pose.models.backbones.factory import (
     build_backbone,
 )
 
-__all__ = [
-    'ALLOWED_BACKBONES',
-    'ALLOWED_CONVNET_BACKBONES',
-    'ALLOWED_TRANSFORMER_BACKBONES',
-    'ALLOWED_TRANSFORMER_BACKBONES_MULTIVIEW',
-    'BACKBONE_STRIDES',
-    'build_backbone',
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []

--- a/lightning_pose/models/backbones/factory.py
+++ b/lightning_pose/models/backbones/factory.py
@@ -20,6 +20,19 @@ prefix — ViT variants go to ``_build_transformer_backbone``, convnets to
 functions rather than at module level. This module is loaded during
 ``lightning_pose.models.backbones.__init__`` initialisation, so a top-level import
 from anywhere else in ``lightning_pose`` would create a circular import.
+
+**Adding a new backbone**:
+
+1. Add its identifier string to the appropriate ``ALLOWED_*`` Literal(s) in this file.
+   ViT variants belong in :data:`ALLOWED_TRANSFORMER_BACKBONES`; convnets in
+   :data:`ALLOWED_CONVNET_BACKBONES`. Add to :data:`ALLOWED_TRANSFORMER_BACKBONES_MULTIVIEW`
+   only if the backbone is compatible with the multiview cross-attention block (requires
+   a standard ``embeddings`` module and NCHW tensor layout).
+2. Add an ``elif`` branch inside :func:`_build_transformer_backbone` or
+   :func:`_build_convnet_backbone` that imports and instantiates the wrapper class.
+   Use a lazy import (inside the ``elif`` body) to avoid circular imports.
+3. If the backbone needs a new wrapper class, create ``vit_<name>.py`` in this package and
+   import it lazily inside the branch.  Add stride info to :data:`BACKBONE_STRIDES` if needed.
 """
 
 import logging

--- a/lightning_pose/models/backbones/factory.py
+++ b/lightning_pose/models/backbones/factory.py
@@ -46,7 +46,7 @@ import torchvision.models as tvmodels
 logger = logging.getLogger(__name__)
 
 # to ignore imports for sphix-autoapidoc
-__all__ = []
+__all__: list[str] = []
 
 ALLOWED_CONVNET_BACKBONES = Literal[
     'resnet18',

--- a/lightning_pose/models/backbones/vit.py
+++ b/lightning_pose/models/backbones/vit.py
@@ -9,8 +9,8 @@ import torch.nn as nn
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class VisionEncoder(nn.Module):

--- a/lightning_pose/models/backbones/vit_dino.py
+++ b/lightning_pose/models/backbones/vit_dino.py
@@ -7,8 +7,8 @@ import torch.nn as nn
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 _DINOV3_ACCESS_HELP = """
 ================================================================================

--- a/lightning_pose/models/backbones/vit_sam.py
+++ b/lightning_pose/models/backbones/vit_sam.py
@@ -9,8 +9,8 @@ from transformers import SamModel
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class VisionEncoderSam(nn.Module):

--- a/lightning_pose/models/backbones/vit_sam2.py
+++ b/lightning_pose/models/backbones/vit_sam2.py
@@ -7,8 +7,8 @@ import torch.nn as nn
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class VisionEncoderSam2(nn.Module):

--- a/lightning_pose/models/base.py
+++ b/lightning_pose/models/base.py
@@ -31,14 +31,8 @@ from lightning_pose.models.backbones import ALLOWED_BACKBONES, build_backbone
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = [
-    'check_if_semi_supervised',
-    'get_context_from_sequence',
-    'BaseFeatureExtractor',
-    'BaseSupervisedTracker',
-    'SemiSupervisedTrackerMixin',
-]
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def check_if_semi_supervised(losses_to_use: ListConfig | list | None = None) -> bool:

--- a/lightning_pose/models/factory.py
+++ b/lightning_pose/models/factory.py
@@ -1,17 +1,24 @@
-"""Factory function for building pose estimation models from a Hydra config.
+"""Factory functions for building pose estimation models from a Hydra config.
 
-The single public entry point is :func:`get_model`, which:
+Public entry points:
 
-1. Resolves optimizer / lr-scheduler defaults.
-2. Dispatches on ``cfg.model.model_type`` × ``semi_supervised`` to instantiate one of eight
-   model classes (four types × supervised/semi-supervised).
-3. Optionally loads weights from ``cfg.model.checkpoint`` after construction.
+- :func:`get_model_class` — pure dispatch: returns the model *class* for a given
+  ``(model_type, semi_supervised)`` pair without instantiating anything.
+- :func:`get_model` — full construction: resolves optimizer/scheduler defaults,
+  instantiates the appropriate model class, and optionally loads weights from a
+  checkpoint.
 
-All model class imports are deferred inside the function body to avoid circular imports
-(this module is loaded early in the call stack, before the model classes are fully defined).
+All model class imports are deferred inside the function bodies to avoid circular
+imports (this module is loaded early in the call stack, before the model classes are
+fully defined).
 
 **Supported model types**: ``regression``, ``heatmap``, ``heatmap_mhcrnn``,
 ``heatmap_multiview_transformer``.
+
+**Adding a new model type**: add its string to :data:`ALLOWED_MODEL_TYPES`, add a
+branch in :func:`get_model_class` (two lines, one per supervision mode), add an
+``elif`` block in :func:`get_model` for its constructor kwargs, and create the model
+file(s) under ``lightning_pose/models/``.
 """
 
 from __future__ import annotations
@@ -20,7 +27,7 @@ import glob
 import logging
 import os
 from collections import OrderedDict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import torch
 from omegaconf import DictConfig, ListConfig
@@ -38,7 +45,63 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ['get_model']
+ALLOWED_MODEL_TYPES = Literal[
+    'regression',
+    'heatmap',
+    'heatmap_mhcrnn',
+    'heatmap_multiview_transformer',
+]
+
+__all__ = ['ALLOWED_MODEL_TYPES', 'get_model', 'get_model_class']
+
+
+def get_model_class(
+    model_type: ALLOWED_MODEL_TYPES,
+    semi_supervised: bool,
+) -> type[ALLOWED_MODELS]:
+    """Return the model class for the given model type and supervision mode.
+
+    Args:
+        model_type: one of ``'regression'``, ``'heatmap'``, ``'heatmap_mhcrnn'``,
+            ``'heatmap_multiview_transformer'``.
+        semi_supervised: True to return the semi-supervised variant.
+
+    Returns:
+        model class (not an instance).
+
+    Raises:
+        NotImplementedError: if ``model_type`` is not recognised.
+
+    """
+    if not semi_supervised:
+        if model_type == 'regression':
+            from lightning_pose.models import RegressionTracker as ModelClass
+        elif model_type == 'heatmap':
+            from lightning_pose.models import HeatmapTracker as ModelClass
+        elif model_type == 'heatmap_mhcrnn':
+            from lightning_pose.models import HeatmapTrackerMHCRNN as ModelClass
+        elif model_type == 'heatmap_multiview_transformer':
+            from lightning_pose.models import HeatmapTrackerMultiviewTransformer as ModelClass
+        else:
+            raise NotImplementedError(
+                f'{model_type} is an invalid model_type for a fully supervised model'
+            )
+    else:
+        if model_type == 'regression':
+            from lightning_pose.models import SemiSupervisedRegressionTracker as ModelClass
+        elif model_type == 'heatmap':
+            from lightning_pose.models import SemiSupervisedHeatmapTracker as ModelClass
+        elif model_type == 'heatmap_mhcrnn':
+            from lightning_pose.models import SemiSupervisedHeatmapTrackerMHCRNN as ModelClass
+        elif model_type == 'heatmap_multiview_transformer':
+            from lightning_pose.models import (
+                SemiSupervisedHeatmapTrackerMultiviewTransformer as ModelClass,
+            )
+        else:
+            raise NotImplementedError(
+                f'{model_type} is an invalid model_type for a semi-supervised model'
+            )
+    return ModelClass
 
 
 def get_model(
@@ -76,7 +139,6 @@ def get_model(
         RuntimeError: if a ViT backbone is selected with non-square image dimensions.
         NotImplementedError: if ``cfg.model.model_type`` is not a recognised value.
     """
-
     optimizer = cfg.training.get('optimizer', 'Adam')
     optimizer_params = _apply_defaults_for_optimizer_params(
         optimizer,
@@ -97,152 +159,54 @@ def get_model(
             raise RuntimeError('ViT model requires resized height and width to be equal')
 
     backbone_pretrained = cfg.model.get('backbone_pretrained', True)
-    if not semi_supervised:
-        if cfg.model.model_type == 'regression':
-            from lightning_pose.models import RegressionTracker
-            model = RegressionTracker(
-                num_keypoints=cfg.data.num_keypoints,
-                loss_factory=loss_factories['supervised'],
-                backbone=cfg.model.backbone,
-                pretrained=backbone_pretrained,
-                torch_seed=cfg.training.rng_seed_model_pt,
-                optimizer=optimizer,
-                optimizer_params=optimizer_params,
-                lr_scheduler=lr_scheduler,
-                lr_scheduler_params=lr_scheduler_params,
-                image_size=image_h,
-            )
-        elif cfg.model.model_type == 'heatmap':
-            num_targets = data_module.dataset.num_targets if data_module else None
-            from lightning_pose.models import HeatmapTracker
-            model = HeatmapTracker(
-                num_keypoints=cfg.data.num_keypoints,
-                num_targets=num_targets,
-                loss_factory=loss_factories['supervised'],
-                backbone=cfg.model.backbone,
-                pretrained=backbone_pretrained,
-                downsample_factor=cfg.data.get('downsample_factor', 2),
-                torch_seed=cfg.training.rng_seed_model_pt,
-                optimizer=optimizer,
-                optimizer_params=optimizer_params,
-                lr_scheduler=lr_scheduler,
-                lr_scheduler_params=lr_scheduler_params,
-                image_size=image_h,
-                backbone_checkpoint=cfg.model.get('backbone_checkpoint'),
-            )
-        elif cfg.model.model_type == 'heatmap_mhcrnn':
-            from lightning_pose.models import HeatmapTrackerMHCRNN
-            model = HeatmapTrackerMHCRNN(
-                num_keypoints=cfg.data.num_keypoints,
-                loss_factory=loss_factories['supervised'],
-                backbone=cfg.model.backbone,
-                pretrained=backbone_pretrained,
-                downsample_factor=cfg.data.get('downsample_factor', 2),
-                torch_seed=cfg.training.rng_seed_model_pt,
-                optimizer=optimizer,
-                optimizer_params=optimizer_params,
-                lr_scheduler=lr_scheduler,
-                lr_scheduler_params=lr_scheduler_params,
-                image_size=image_h,
-                backbone_checkpoint=cfg.model.get('backbone_checkpoint'),
-            )
-        elif cfg.model.model_type == 'heatmap_multiview_transformer':
-            from lightning_pose.models import HeatmapTrackerMultiviewTransformer
-            model = HeatmapTrackerMultiviewTransformer(
-                num_keypoints=cfg.data.num_keypoints,
-                num_views=len(cfg.data.view_names),
-                loss_factory=loss_factories['supervised'],
-                backbone=cfg.model.backbone,
-                pretrained=backbone_pretrained,
-                head=cfg.model.get('head', 'heatmap_cnn'),
-                downsample_factor=cfg.data.get('downsample_factor', 2),
-                torch_seed=cfg.training.rng_seed_model_pt,
-                optimizer=optimizer,
-                optimizer_params=optimizer_params,
-                lr_scheduler=lr_scheduler,
-                lr_scheduler_params=lr_scheduler_params,
-                image_size=image_h,
-                backbone_checkpoint=cfg.model.get('backbone_checkpoint'),
-            )
-        else:
-            raise NotImplementedError(
-                f'{cfg.model.model_type} is an invalid cfg.model.model_type for a fully '
-                f'supervised model'
-            )
+    ModelClass = get_model_class(cfg.model.model_type, semi_supervised)
 
+    # args shared by every model type
+    common = dict(
+        num_keypoints=cfg.data.num_keypoints,
+        loss_factory=loss_factories['supervised'],
+        backbone=cfg.model.backbone,
+        pretrained=backbone_pretrained,
+        torch_seed=cfg.training.rng_seed_model_pt,
+        optimizer=optimizer,
+        optimizer_params=optimizer_params,
+        lr_scheduler=lr_scheduler,
+        lr_scheduler_params=lr_scheduler_params,
+        image_size=image_h,
+    )
+    if semi_supervised:
+        common['loss_factory_unsupervised'] = loss_factories['unsupervised']
+
+    # model-type-specific constructor args
+    if cfg.model.model_type == 'regression':
+        extra: dict = {}
+    elif cfg.model.model_type == 'heatmap':
+        num_targets = data_module.dataset.num_targets if data_module else None
+        extra = dict(
+            num_targets=num_targets,
+            downsample_factor=cfg.data.get('downsample_factor', 2),
+            backbone_checkpoint=cfg.model.get('backbone_checkpoint'),
+        )
+    elif cfg.model.model_type == 'heatmap_mhcrnn':
+        extra = dict(
+            downsample_factor=cfg.data.get('downsample_factor', 2),
+            backbone_checkpoint=cfg.model.get('backbone_checkpoint'),
+        )
+    elif cfg.model.model_type == 'heatmap_multiview_transformer':
+        extra = dict(
+            num_views=len(cfg.data.view_names),
+            head=cfg.model.get('head', 'heatmap_cnn'),
+            downsample_factor=cfg.data.get('downsample_factor', 2),
+            backbone_checkpoint=cfg.model.get('backbone_checkpoint'),
+        )
+        if semi_supervised:
+            extra['patch_mask_config'] = cfg.training.get('patch_mask', {})
     else:
-        if cfg.model.model_type == 'regression':
-            from lightning_pose.models import SemiSupervisedRegressionTracker
-            model = SemiSupervisedRegressionTracker(
-                num_keypoints=cfg.data.num_keypoints,
-                loss_factory=loss_factories['supervised'],
-                loss_factory_unsupervised=loss_factories['unsupervised'],
-                backbone=cfg.model.backbone,
-                pretrained=backbone_pretrained,
-                torch_seed=cfg.training.rng_seed_model_pt,
-                optimizer=optimizer,
-                optimizer_params=optimizer_params,
-                lr_scheduler=lr_scheduler,
-                lr_scheduler_params=lr_scheduler_params,
-                image_size=image_h,
-            )
-        elif cfg.model.model_type == 'heatmap':
-            from lightning_pose.models import SemiSupervisedHeatmapTracker
-            model = SemiSupervisedHeatmapTracker(
-                num_keypoints=cfg.data.num_keypoints,
-                loss_factory=loss_factories['supervised'],
-                loss_factory_unsupervised=loss_factories['unsupervised'],
-                backbone=cfg.model.backbone,
-                pretrained=backbone_pretrained,
-                downsample_factor=cfg.data.get('downsample_factor', 2),
-                torch_seed=cfg.training.rng_seed_model_pt,
-                optimizer=optimizer,
-                optimizer_params=optimizer_params,
-                lr_scheduler=lr_scheduler,
-                lr_scheduler_params=lr_scheduler_params,
-                image_size=image_h,
-                backbone_checkpoint=cfg.model.get('backbone_checkpoint'),
-            )
-        elif cfg.model.model_type == 'heatmap_mhcrnn':
-            from lightning_pose.models import SemiSupervisedHeatmapTrackerMHCRNN
-            model = SemiSupervisedHeatmapTrackerMHCRNN(
-                num_keypoints=cfg.data.num_keypoints,
-                loss_factory=loss_factories['supervised'],
-                loss_factory_unsupervised=loss_factories['unsupervised'],
-                backbone=cfg.model.backbone,
-                pretrained=backbone_pretrained,
-                downsample_factor=cfg.data.get('downsample_factor', 2),
-                torch_seed=cfg.training.rng_seed_model_pt,
-                optimizer=optimizer,
-                optimizer_params=optimizer_params,
-                lr_scheduler=lr_scheduler,
-                lr_scheduler_params=lr_scheduler_params,
-                image_size=image_h,
-                backbone_checkpoint=cfg.model.get('backbone_checkpoint'),
-            )
-        elif cfg.model.model_type == 'heatmap_multiview_transformer':
-            from lightning_pose.models import SemiSupervisedHeatmapTrackerMultiviewTransformer
-            model = SemiSupervisedHeatmapTrackerMultiviewTransformer(
-                num_keypoints=cfg.data.num_keypoints,
-                num_views=len(cfg.data.view_names),
-                loss_factory=loss_factories['supervised'],
-                loss_factory_unsupervised=loss_factories['unsupervised'],
-                backbone=cfg.model.backbone,
-                pretrained=backbone_pretrained,
-                head=cfg.model.get('head', 'heatmap_cnn'),
-                downsample_factor=cfg.data.get('downsample_factor', 2),
-                torch_seed=cfg.training.rng_seed_model_pt,
-                optimizer=optimizer,
-                optimizer_params=optimizer_params,
-                lr_scheduler=lr_scheduler,
-                lr_scheduler_params=lr_scheduler_params,
-                image_size=image_h,
-                patch_mask_config=cfg.training.get('patch_mask', {}),
-            )
-        else:
-            raise NotImplementedError(
-                f'{cfg.model.model_type} invalid cfg.model.model_type for a semi-supervised model'
-            )
+        raise NotImplementedError(
+            f'{cfg.model.model_type} is an invalid cfg.model.model_type'
+        )
+
+    model = ModelClass(**common, **extra)
 
     if cfg.model.get('checkpoint', None):
         ckpt = cfg.model.checkpoint

--- a/lightning_pose/models/factory.py
+++ b/lightning_pose/models/factory.py
@@ -52,7 +52,7 @@ ALLOWED_MODEL_TYPES = Literal[
     'heatmap_multiview_transformer',
 ]
 
-__all__ = ['ALLOWED_MODEL_TYPES', 'get_model', 'get_model_class']
+__all__: list[str] = []
 
 
 def get_model_class(

--- a/lightning_pose/models/heads/__init__.py
+++ b/lightning_pose/models/heads/__init__.py
@@ -4,14 +4,4 @@ from lightning_pose.models.heads.heatmap import HeatmapHead
 from lightning_pose.models.heads.heatmap_mhcrnn import HeatmapMHCRNNHead
 from lightning_pose.models.heads.regression import LinearRegressionHead
 
-# reassign module to make classes appear to belong here
-HeatmapHead.__module__ = "lightning_pose.models.heads"
-HeatmapMHCRNNHead.__module__ = "lightning_pose.models.heads"
-LinearRegressionHead.__module__ = "lightning_pose.models.heads"
-
-# to ignore imports for sphix-autoapidoc
-__all__ = [
-    "HeatmapHead",
-    "HeatmapMHCRNNHead",
-    "LinearRegressionHead",
-]
+__all__: list[str] = []

--- a/lightning_pose/models/heads/heatmap.py
+++ b/lightning_pose/models/heads/heatmap.py
@@ -13,8 +13,8 @@ from torch import nn
 from lightning_pose.data.heatmaps import evaluate_heatmaps_at_location
 from lightning_pose.models.backbones import BACKBONE_STRIDES
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 def make_upsampling_layers(

--- a/lightning_pose/models/heads/heatmap_mhcrnn.py
+++ b/lightning_pose/models/heads/heatmap_mhcrnn.py
@@ -11,8 +11,8 @@ from torch import nn
 from lightning_pose.models.heads import HeatmapHead
 from lightning_pose.models.heads.heatmap import run_subpixelmaxima
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class HeatmapMHCRNNHead(nn.Module):

--- a/lightning_pose/models/heads/regression.py
+++ b/lightning_pose/models/heads/regression.py
@@ -4,8 +4,8 @@ import torch
 from jaxtyping import Float
 from torch import nn
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class LinearRegressionHead(nn.Module):

--- a/lightning_pose/models/heatmap_tracker.py
+++ b/lightning_pose/models/heatmap_tracker.py
@@ -23,8 +23,8 @@ from lightning_pose.models.base import (
 )
 from lightning_pose.models.heads import HeatmapHead
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class HeatmapTracker(BaseSupervisedTracker):

--- a/lightning_pose/models/heatmap_tracker_mhcrnn.py
+++ b/lightning_pose/models/heatmap_tracker_mhcrnn.py
@@ -23,8 +23,8 @@ from lightning_pose.models.base import (
 )
 from lightning_pose.models.heads import HeatmapMHCRNNHead
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class HeatmapTrackerMHCRNN(BaseSupervisedTracker):

--- a/lightning_pose/models/heatmap_tracker_multiview.py
+++ b/lightning_pose/models/heatmap_tracker_multiview.py
@@ -25,8 +25,8 @@ from lightning_pose.models.heads import HeatmapHead
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class HeatmapTrackerMultiviewTransformer(BaseSupervisedTracker):

--- a/lightning_pose/models/regression_tracker.py
+++ b/lightning_pose/models/regression_tracker.py
@@ -14,8 +14,8 @@ from lightning_pose.models.backbones import ALLOWED_BACKBONES
 from lightning_pose.models.base import BaseSupervisedTracker, SemiSupervisedTrackerMixin
 from lightning_pose.models.heads import LinearRegressionHead
 
-# to ignore imports for sphix-autoapidoc
-__all__ = []
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
 
 
 class RegressionTracker(BaseSupervisedTracker):

--- a/lightning_pose/utils/__init__.py
+++ b/lightning_pose/utils/__init__.py
@@ -1,4 +1,15 @@
-"""Utility functions for configuration display."""
+"""Utility helpers used across training, inference, and evaluation.
+
+**Submodules**:
+
+- ``utils.io`` — path handling and file I/O utilities.
+- ``utils.predictions`` — inference on labeled datasets and unlabeled videos; video annotation.
+- ``utils.pca`` — :class:`~lightning_pose.utils.pca.KeypointPCA` for PCA-based
+  unsupervised losses.
+- ``utils.cropzoom`` — crop/zoom pipeline: labeled-frame and video cropping to bounding-box ROIs.
+
+This module itself exports :func:`pretty_print_str` and :func:`pretty_print_cfg`.
+"""
 
 import logging
 

--- a/lightning_pose/utils/cropzoom.py
+++ b/lightning_pose/utils/cropzoom.py
@@ -18,6 +18,7 @@ from lightning_pose.utils import io
 
 logger = logging.getLogger(__name__)
 
+# to ignore imports for sphix-autoapidoc
 __all__ = [
     "generate_bbox",
     "smooth_bbox",

--- a/lightning_pose/utils/io.py
+++ b/lightning_pose/utils/io.py
@@ -18,7 +18,7 @@ from omegaconf import DictConfig, ListConfig
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
+# to ignore imports for sphinx-autoapidoc
 __all__ = [
     "ckpt_path_from_base_path",
     "get_keypoint_names",

--- a/lightning_pose/utils/pca.py
+++ b/lightning_pose/utils/pca.py
@@ -19,13 +19,11 @@ from lightning_pose.data.extractor import DataExtractor
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
+# to ignore imports for sphinx-autoapidoc
 __all__ = [
     "ComponentChooser",
     "EmpiricalEpsilon",
     "KeypointPCA",
-    "convert_dict_values_to_tensors",
-    "format_multiview_data_for_pca",
 ]
 
 

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -29,12 +29,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# to ignore imports for sphix-autoapidoc
+# to ignore imports for sphinx-autoapidoc
 __all__ = [
-    "PredictionHandler",
     "predict_dataset",
     "predict_video",
-    "make_dlc_pandas_index",
     "generate_labeled_video",
 ]
 

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pytest
 
 from lightning_pose.api import Model
-from lightning_pose.api.model import get_model_class
 from tests.fetch_test_data import fetch_test_data_if_needed
 
 
@@ -305,70 +304,3 @@ class TestModelErrors:
         with patch.object(multiview_model, '_load'):
             with pytest.raises(ValueError, match='expected.*video files'):
                 multiview_model.predict_on_video_file_multiview(['only_one.mp4'])
-
-
-class TestGetModelClass:
-    """Test the get_model_class function."""
-
-    def test_get_model_class_supervised_regression(self):
-        """Returns RegressionTracker for supervised regression."""
-        from lightning_pose.models import RegressionTracker
-        assert get_model_class('regression', semi_supervised=False) is RegressionTracker
-
-    def test_get_model_class_supervised_heatmap(self):
-        """Returns HeatmapTracker for supervised heatmap."""
-        from lightning_pose.models import HeatmapTracker
-        assert get_model_class('heatmap', semi_supervised=False) is HeatmapTracker
-
-    def test_get_model_class_supervised_heatmap_mhcrnn(self):
-        """Returns HeatmapTrackerMHCRNN for supervised heatmap_mhcrnn."""
-        from lightning_pose.models import HeatmapTrackerMHCRNN
-        assert get_model_class('heatmap_mhcrnn', semi_supervised=False) is HeatmapTrackerMHCRNN
-
-    def test_get_model_class_supervised_heatmap_multiview_transformer(self):
-        """Returns HeatmapTrackerMultiviewTransformer for supervised multiview transformer."""
-        from lightning_pose.models import HeatmapTrackerMultiviewTransformer
-        assert (
-            get_model_class('heatmap_multiview_transformer', semi_supervised=False)
-            is HeatmapTrackerMultiviewTransformer
-        )
-
-    def test_get_model_class_supervised_raises_for_unknown(self):
-        """Raises NotImplementedError for an unrecognised supervised model_type."""
-        with pytest.raises(NotImplementedError, match='invalid model_type for a fully supervised'):
-            get_model_class('unknown_type', semi_supervised=False)  # type: ignore[arg-type]
-
-    def test_get_model_class_semi_supervised_regression(self):
-        """Returns SemiSupervisedRegressionTracker for semi-supervised regression."""
-        from lightning_pose.models import SemiSupervisedRegressionTracker
-        assert (
-            get_model_class('regression', semi_supervised=True) is SemiSupervisedRegressionTracker
-        )
-
-    def test_get_model_class_semi_supervised_heatmap(self):
-        """Returns SemiSupervisedHeatmapTracker for semi-supervised heatmap."""
-        from lightning_pose.models import SemiSupervisedHeatmapTracker
-        assert get_model_class('heatmap', semi_supervised=True) is SemiSupervisedHeatmapTracker
-
-    def test_get_model_class_semi_supervised_heatmap_mhcrnn(self):
-        """Returns SemiSupervisedHeatmapTrackerMHCRNN for semi-supervised heatmap_mhcrnn."""
-        from lightning_pose.models import SemiSupervisedHeatmapTrackerMHCRNN
-        assert (
-            get_model_class('heatmap_mhcrnn', semi_supervised=True)
-            is SemiSupervisedHeatmapTrackerMHCRNN
-        )
-
-    def test_get_model_class_semi_supervised_heatmap_multiview_transformer(self):
-        """Returns SemiSupervisedHeatmapTrackerMultiviewTransformer for semi-supervised variant."""
-        from lightning_pose.models import SemiSupervisedHeatmapTrackerMultiviewTransformer
-        assert (
-            get_model_class('heatmap_multiview_transformer', semi_supervised=True)
-            is SemiSupervisedHeatmapTrackerMultiviewTransformer
-        )
-
-    def test_get_model_class_semi_supervised_raises_for_unknown(self):
-        """Raises NotImplementedError for an unrecognised semi-supervised model_type."""
-        with pytest.raises(
-            NotImplementedError, match='invalid model_type for a semi-supervised',
-        ):
-            get_model_class('unknown_type', semi_supervised=True)  # type: ignore[arg-type]

--- a/tests/models/test_factory.py
+++ b/tests/models/test_factory.py
@@ -1,12 +1,14 @@
-"""Tests for models/factory.py — get_model."""
+"""Tests for models/factory.py — get_model and get_model_class."""
 
 import copy
 
+import pytest
 import torch
 
 from lightning_pose.data import get_data_module
 from lightning_pose.losses import get_loss_factories
 from lightning_pose.models import get_model
+from lightning_pose.models.factory import get_model_class
 
 
 class TestGetModel:
@@ -109,3 +111,70 @@ class TestGetModel:
         for k, v in model.state_dict().items():
             if 'backbone' in k:
                 assert torch.allclose(loaded.state_dict()[k], v), f'backbone mismatch at {k}'
+
+
+class TestGetModelClass:
+    """Test the get_model_class function."""
+
+    def test_get_model_class_supervised_regression(self):
+        """Returns RegressionTracker for supervised regression."""
+        from lightning_pose.models import RegressionTracker
+        assert get_model_class('regression', semi_supervised=False) is RegressionTracker
+
+    def test_get_model_class_supervised_heatmap(self):
+        """Returns HeatmapTracker for supervised heatmap."""
+        from lightning_pose.models import HeatmapTracker
+        assert get_model_class('heatmap', semi_supervised=False) is HeatmapTracker
+
+    def test_get_model_class_supervised_heatmap_mhcrnn(self):
+        """Returns HeatmapTrackerMHCRNN for supervised heatmap_mhcrnn."""
+        from lightning_pose.models import HeatmapTrackerMHCRNN
+        assert get_model_class('heatmap_mhcrnn', semi_supervised=False) is HeatmapTrackerMHCRNN
+
+    def test_get_model_class_supervised_heatmap_multiview_transformer(self):
+        """Returns HeatmapTrackerMultiviewTransformer for supervised multiview transformer."""
+        from lightning_pose.models import HeatmapTrackerMultiviewTransformer
+        assert (
+            get_model_class('heatmap_multiview_transformer', semi_supervised=False)
+            is HeatmapTrackerMultiviewTransformer
+        )
+
+    def test_get_model_class_supervised_raises_for_unknown(self):
+        """Raises NotImplementedError for an unrecognised supervised model_type."""
+        with pytest.raises(NotImplementedError, match='invalid model_type for a fully supervised'):
+            get_model_class('unknown_type', semi_supervised=False)  # type: ignore[arg-type]
+
+    def test_get_model_class_semi_supervised_regression(self):
+        """Returns SemiSupervisedRegressionTracker for semi-supervised regression."""
+        from lightning_pose.models import SemiSupervisedRegressionTracker
+        assert (
+            get_model_class('regression', semi_supervised=True) is SemiSupervisedRegressionTracker
+        )
+
+    def test_get_model_class_semi_supervised_heatmap(self):
+        """Returns SemiSupervisedHeatmapTracker for semi-supervised heatmap."""
+        from lightning_pose.models import SemiSupervisedHeatmapTracker
+        assert get_model_class('heatmap', semi_supervised=True) is SemiSupervisedHeatmapTracker
+
+    def test_get_model_class_semi_supervised_heatmap_mhcrnn(self):
+        """Returns SemiSupervisedHeatmapTrackerMHCRNN for semi-supervised heatmap_mhcrnn."""
+        from lightning_pose.models import SemiSupervisedHeatmapTrackerMHCRNN
+        assert (
+            get_model_class('heatmap_mhcrnn', semi_supervised=True)
+            is SemiSupervisedHeatmapTrackerMHCRNN
+        )
+
+    def test_get_model_class_semi_supervised_heatmap_multiview_transformer(self):
+        """Returns SemiSupervisedHeatmapTrackerMultiviewTransformer for semi-supervised variant."""
+        from lightning_pose.models import SemiSupervisedHeatmapTrackerMultiviewTransformer
+        assert (
+            get_model_class('heatmap_multiview_transformer', semi_supervised=True)
+            is SemiSupervisedHeatmapTrackerMultiviewTransformer
+        )
+
+    def test_get_model_class_semi_supervised_raises_for_unknown(self):
+        """Raises NotImplementedError for an unrecognised semi-supervised model_type."""
+        with pytest.raises(
+            NotImplementedError, match='invalid model_type for a semi-supervised',
+        ):
+            get_model_class('unknown_type', semi_supervised=True)  # type: ignore[arg-type]


### PR DESCRIPTION
# Consolidate model dispatch and standardise package public API

##  Motivation

Two problems motivated this PR:

1. get_model_class existed in both api/model.py and (implicitly) models/factory.py::get_model, duplicating
  the same 2×4 (supervision × model_type) branching logic in two places. Adding a new model type required
  updating both.
2. The package __init__.py files, __all__ declarations, and module docstrings were inconsistent — some
  modules had contributor recipes mixed into user-facing docstrings, some factory modules had no recipe at all,
  __all__ was partially populated in implementation modules that shouldn't be advertising a public API, and
  imports used deep submodule paths even when higher-level re-exports existed.

## Changes

Eliminate duplicate model dispatch

  - Moved get_model_class from api/model.py into models/factory.py as the single source of truth for
  (model_type, semi_supervised) → class dispatch.
  - Refactored get_model to call get_model_class and use a shared common kwargs dict plus per-type extra dict,
  replacing 8 near-identical branches.
  - api/model.py now imports get_model_class from models/factory.py; ALLOWED_MODEL_TYPES Literal is also
  defined in models/factory.py and re-exported from models/__init__.py.
  - Moved TestGetModelClass from tests/api/test_model.py to tests/models/test_factory.py.

Module docstring conventions (documented in CLAUDE.md)

  Each subpackage with both an __init__.py and a factory.py now observes a strict separation:
  - __init__.py — user-facing package map: what's exported and where to find it. No contributor recipes.
  - factory.py — contributor guide: dispatch logic and an explicit "Adding a new X" step-by-step recipe.

  Applied to data/, losses/, models/, and models/backbones/.

Roadmap docstrings

  Added comprehensive module-level docstrings to:
  - data/__init__.py — three-stage factory pipeline; all 11 modules grouped by role.
  - models/__init__.py — all 4 model types × 2 supervision variants; mixin pattern; how the package is laid
  out.
  - losses/__init__.py — all 14 loss names grouped supervised/semi-supervised; multi-name classes called out.
  - utils/__init__.py — maps all 4 submodules (io, predictions, pca, cropzoom).

__all__ cleanup

  - All factory modules (data/factory.py, losses/factory.py, models/factory.py, models/backbones/factory.py):
  __all__: list[str] = [] — Sphinx surfaces these only via their parent __init__.py.
  - models/__init__.py: removed ALLOWED_MODEL_TYPES (internal type constant) and __module__ reassignments
  (cosmetic, inconsistent with rest of codebase).
  - models/heads/__init__.py, models/backbones/__init__.py: __all__: list[str] = [] — head and backbone classes
  are internal; not promoted to models/__init__.py.
