### PR TITLE
horizontal flip augmentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,57 @@ inside the helper functions, not at module level. `factory.py` is loaded during
 `backbones/__init__.py` initialisation, so a top-level `lightning_pose` import there would
 create a circular import.
 
+### Dataset class hierarchy (`lightning_pose/data/datasets.py`)
+
+Three dataset classes, with a clear inheritance structure:
+
+- **`BaseTrackingDataset`** — base class. Loads images and (x, y) keypoints, applies the imgaug
+  pipeline, and handles `imgaug_hflip`. Returns a `BaseLabeledExampleDict`.
+- **`HeatmapDataset(BaseTrackingDataset)`** — adds `compute_heatmap` to convert keypoints to
+  `(K, H, W)` Gaussian heatmap targets, and synthesizes `self.visibility` from NaN positions when
+  the CSV has no `visible` column. Returns a `HeatmapLabeledExampleDict`.
+- **`MultiviewHeatmapDataset`** — does **not** inherit from `BaseTrackingDataset`. Holds a
+  `dict[str, HeatmapDataset]` at `self.dataset` (keyed by view name). `__getitem__` delegates to
+  each child and stacks results. Shares `imgaug_transform` and `imgaug_hflip` attributes with
+  child datasets so the data module can update them in one pass.
+
+**`__getitem__` branching**: both `BaseTrackingDataset` and `HeatmapDataset` branch on
+`self.do_context` at the top of `__getitem__`. The non-context branch loads a single PIL image;
+the context branch loads a sequence of frames. All augmentation logic (imgaug pipeline + hflip) is
+duplicated in both branches.
+
+**Adding an augmentation that affects keypoints**:
+
+1. Add any per-sample state (e.g. `do_hflip`) at the top of each branch in `__getitem__`, not
+   outside the branch, since the two paths are structurally independent.
+2. Apply the augmentation *after* the imgaug pipeline so keypoints are already in resized
+   coordinate space.
+3. For context mode, generate any random decision once before the per-frame loop and reuse it for
+   all frames so the same transform is applied consistently across the sequence.
+4. Set `self.imgaug_hflip = False` (or equivalent sentinel) on `MultiviewHeatmapDataset` so the
+   data module can safely reset it without `AttributeError`.
+5. Update the data module's `_setup` condition (see comment there) if the new augmentation must
+   also be disabled for val/test subsets.
+6. **Also set the flag to `False` in `_build_datamodule_pred`** (`lightning_pose/api/model.py`).
+   That function deep-copies the training config and overrides `cfg_pred.training.imgaug =
+   "default"`, but it does **not** automatically clear other training-only flags. Any augmentation
+   flag that is not cleared here will remain active during prediction, causing randomly-augmented
+   inference on labeled frames and silently wrong evaluation metrics. The fix pattern is:
+   ```python
+   cfg_pred.training.imgaug = "default"
+   cfg_pred.training.<your_flag> = False   # ← must be explicit
+   ```
+
+### Data module split logic (`lightning_pose/data/datamodules.py` → `BaseDataModule._setup`)
+
+The imgaug pipeline always contains at least one element: a final resize transform appended by
+`BaseTrackingDataset.__init__`. `len(imgaug_transform) == 1` therefore means "resize only, no
+augmentations." When this is true **and** `imgaug_hflip` is False, all three splits can share the
+same underlying dataset object (cheap path). Otherwise, three deep-copied datasets are created and
+the val/test copies have their pipeline replaced with resize-only and their `imgaug_hflip` reset to
+`False`. Any new augmentation applied outside the pipeline (like `imgaug_hflip`) must be added to
+this condition and explicitly stripped from val/test datasets in the `else` branch.
+
 ### DALI Pipeline (`lightning_pose/data/dali.py`)
 
 **`PrepareDALI`** — two-phase construction:

--- a/docs/source/directory_structure_reference/model_config_file.rst
+++ b/docs/source/directory_structure_reference/model_config_file.rst
@@ -76,8 +76,8 @@ See the :ref:`FAQs <faq_oom>` for more information on memory management.
 
   * default: resizing only
   * dlc: imgaug pipeline implmented in DLC 2.0 package
-  * dlc-lr: dlc augmentations plus horizontal flips
-  * dlc-top-down: dlc augmentations plus additional vertical and horizontal flips
+  * dlc-lr: dlc augmentations plus 180 degree rotations
+  * dlc-top-down: dlc augmentations plus additional 90, 180, and 270 degree rotations
 
   You can also define custom augmentation pipelines following
   :ref:`these instructions <custom_imgaug_pipeline>`.

--- a/docs/source/user_guide_advanced/custom_imgaug_pipeline.rst
+++ b/docs/source/user_guide_advanced/custom_imgaug_pipeline.rst
@@ -111,3 +111,42 @@ The order listed in the config file determines the sequence in which transformat
           kwargs:
             percent: [-0.15, 0.15]
             keep_size: false
+
+Horizontal flip for lateralized keypoints
+==========================================
+
+Many animal pose datasets have **lateralized keypoints** — pairs of landmarks that appear on the
+left and right sides of the body (e.g. ``ear_left`` / ``ear_right``, ``paw_front_left`` /
+``paw_front_right``).
+Randomly flipping images horizontally is a powerful augmentation for these datasets, but a naive
+flip must also **swap the left/right labels**: after a flip the right ear appears on the left side
+of the image and must therefore be relabeled as ``ear_left``.
+
+Enable this with the ``training.imgaug_hflip`` flag:
+
+.. code-block:: yaml
+
+    training:
+      imgaug_hflip: true
+
+With ``imgaug_hflip: true``, each training image is horizontally flipped with probability 0.5.
+All keypoint x-coordinates are mirrored, and any ``_left`` / ``_right`` pair is additionally
+swapped so that label identity is preserved.
+
+Naming convention
+-----------------
+
+Lightning Pose detects lateralized pairs by suffix:
+
+* Keypoints whose names end in ``_left`` are paired with the corresponding ``_right`` keypoint
+  (e.g. ``ear_tip_left`` ↔ ``ear_tip_right``).
+* Keypoints that do **not** end in ``_left`` or ``_right`` (e.g. ``nose_tip``, ``spine_mid``)
+  are treated as midline landmarks: their x-coordinate is mirrored but their label is unchanged.
+
+If any ``_left`` keypoint has no matching ``_right`` partner (or vice versa) an error is raised
+at dataset construction time.
+
+.. note::
+
+    ``imgaug_hflip`` is **not** supported for multiview models and will raise an error if set to
+    ``true`` in a multiview config.

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -891,6 +891,7 @@ def _build_datamodule_pred(cfg: DictConfig | ListConfig) -> BaseDataModule | Unl
     """
     cfg_pred = copy.deepcopy(cfg)
     cfg_pred.training.imgaug = "default"
+    cfg_pred.training.imgaug_hflip = False
     imgaug_transform_pred = get_imgaug_transform(cfg=cfg_pred)
     dataset_pred = get_dataset(
         cfg=cfg_pred,

--- a/lightning_pose/data/datamodules.py
+++ b/lightning_pose/data/datamodules.py
@@ -108,7 +108,8 @@ class BaseDataModule(pl.LightningDataModule):
             test_probability=self.test_probability,
         )
 
-        if len(self.dataset.imgaug_transform) == 1:  # type: ignore[arg-type]
+        imgaug_hflip = getattr(self.dataset, 'imgaug_hflip', False)
+        if len(self.dataset.imgaug_transform) == 1 and not imgaug_hflip:  # type: ignore[arg-type]
             # no augmentations in the pipeline; subsets can share same underlying dataset
             self.train_dataset, self.val_dataset, self.test_dataset = random_split(
                 self.dataset,
@@ -147,18 +148,22 @@ class BaseDataModule(pl.LightningDataModule):
                 final_transform = iaa.Sequential([iaa.Resize({"height": height, "width": width})])
 
             self.val_dataset.dataset.imgaug_transform = final_transform  # type: ignore[union-attr]
+            self.val_dataset.dataset.imgaug_hflip = False  # type: ignore[union-attr]
             if hasattr(self.val_dataset.dataset, "dataset"):
                 # this will get triggered for multiview datasets
                 logger.debug('val: updating children datasets with resize imgaug pipeline')
                 for _view_name, dset in self.val_dataset.dataset.dataset.items():  # type: ignore[union-attr]
                     dset.imgaug_transform = final_transform
+                    dset.imgaug_hflip = False
 
             self.test_dataset.dataset.imgaug_transform = final_transform  # type: ignore[union-attr]
+            self.test_dataset.dataset.imgaug_hflip = False  # type: ignore[union-attr]
             if hasattr(self.test_dataset.dataset, "dataset"):
                 # this will get triggered for multiview datasets
                 logger.debug('test: updating children datasets with resize imgaug pipeline')
                 for _view_name, dset in self.test_dataset.dataset.dataset.items():  # type: ignore[union-attr]
                     dset.imgaug_transform = final_transform
+                    dset.imgaug_hflip = False
 
         # further subsample training data if desired
         if self.train_frames is not None:

--- a/lightning_pose/data/datamodules.py
+++ b/lightning_pose/data/datamodules.py
@@ -109,6 +109,10 @@ class BaseDataModule(pl.LightningDataModule):
         )
 
         imgaug_hflip = getattr(self.dataset, 'imgaug_hflip', False)
+        # the imgaug pipeline always contains at least one element (the final resize transform);
+        # len == 1 therefore means "no augmentations" and subsets can safely share the same
+        # underlying dataset object. imgaug_hflip is checked separately because it is applied
+        # outside the pipeline in __getitem__ and must also be stripped from val/test.
         if len(self.dataset.imgaug_transform) == 1 and not imgaug_hflip:  # type: ignore[arg-type]
             # no augmentations in the pipeline; subsets can share same underlying dataset
             self.train_dataset, self.val_dataset, self.test_dataset = random_split(

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -150,6 +150,7 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
 
         self.imgaug_hflip = imgaug_hflip
         if imgaug_hflip:
+            logger.info("applying horizontal flip")
             self._hflip_swap_indices = self._build_hflip_swap_indices(self.keypoint_names)
         else:
             self._hflip_swap_indices = np.arange(self.num_keypoints, dtype=np.intp)
@@ -349,7 +350,18 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
 
 # the only addition here, should be the heatmap creation method.
 class HeatmapDataset(BaseTrackingDataset):
-    """Heatmap dataset that contains the images and keypoints in 2D arrays."""
+    """Heatmap dataset that extends BaseTrackingDataset with 2D Gaussian heatmap targets.
+
+    Inherits all image loading, keypoint parsing, imgaug pipeline, and hflip logic from
+    :class:`BaseTrackingDataset`. The key addition is :meth:`compute_heatmap`, which converts
+    (x, y) keypoint coordinates into ``(K, H, W)`` heatmap tensors used as supervision targets.
+    Visibility synthesis also happens here: when the CSV lacks a ``visible`` column,
+    ``self.visibility`` is populated from NaN positions using the ``uniform_heatmaps`` flag (see
+    the visibility section of CLAUDE.md for the full mapping).
+
+    ``__getitem__`` calls ``super().__getitem__()`` to obtain the base dict, then appends
+    ``heatmaps`` and ``labeled_heatmaps`` keys before returning.
+    """
 
     def __init__(
         self,
@@ -511,7 +523,22 @@ class HeatmapDataset(BaseTrackingDataset):
 
 
 class MultiviewHeatmapDataset(torch.utils.data.Dataset):
-    """Heatmap dataset that contains the images and keypoints in 2D arrays from all the cameras."""
+    """Heatmap dataset that aggregates one :class:`HeatmapDataset` per camera view.
+
+    Internally stores a ``dict[str, HeatmapDataset]`` at ``self.dataset``, keyed by view name.
+    ``__getitem__`` calls each child dataset and stacks the results into a single
+    :class:`~lightning_pose.data.datatypes.MultiviewHeatmapLabeledExampleDict`.
+
+    The shared ``imgaug_transform`` and ``imgaug_hflip`` attributes on this class are replicated
+    to each child dataset so that the data module can update them in one place. ``imgaug_hflip``
+    is always ``False`` here (multiview hflip is not supported; setting it in the config raises a
+    ``ValueError`` in the factory). The data module checks ``hasattr(dataset, 'dataset')`` to
+    detect the multiview case and iterate over child datasets when stripping val/test
+    augmentations.
+
+    Does **not** inherit from :class:`BaseTrackingDataset`; augmentation routing is delegated
+    entirely to the child :class:`HeatmapDataset` instances.
+    """
 
     def __init__(
         self,

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -61,6 +61,7 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
         do_context: bool = False,
         resize: bool = True,
         bbox_path: str | None = None,
+        imgaug_hflip: bool = False,
     ) -> None:
         """Initialize a dataset for regression (rather than heatmap) models.
 
@@ -90,6 +91,12 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
                 and keypoints before returning a batch of data.
             bbox_path: path to csv file that contains bounding box information; rows must be in
                 same order as csv file
+            imgaug_hflip: if True, apply a random horizontal flip with probability 0.5 after the
+                standard imgaug pipeline. All keypoint x-coordinates are mirrored; keypoints whose
+                names end in ``_left`` or ``_right`` are additionally swapped with their partner so
+                that label identity is preserved. Every ``_left`` keypoint must have a matching
+                ``_right`` keypoint and vice versa, or a ValueError is raised. Disabled
+                automatically for validation and test subsets by the data module.
 
         """
         self.root_directory = Path(root_directory)
@@ -141,6 +148,12 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
         self.num_targets = self.keypoints.shape[1] * 2
         self.num_keypoints = self.keypoints.shape[1]
 
+        self.imgaug_hflip = imgaug_hflip
+        if imgaug_hflip:
+            self._hflip_swap_indices = self._build_hflip_swap_indices(self.keypoint_names)
+        else:
+            self._hflip_swap_indices = np.arange(self.num_keypoints, dtype=np.intp)
+
         self.data_length = len(self.image_names)
 
         # load bounding box data
@@ -157,6 +170,51 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
         else:
             bboxes = [None] * len(self.image_names)
         self.bboxes = bboxes
+
+    @staticmethod
+    def _build_hflip_swap_indices(keypoint_names: list[str]) -> np.ndarray:
+        """Build an index array that swaps lateralized (_left/_right) keypoint pairs.
+
+        Args:
+            keypoint_names: list of keypoint name strings from the label CSV.
+
+        Returns:
+            integer array of shape (num_keypoints,) where entry i gives the source keypoint
+            index that should fill position i after a horizontal flip. Non-lateralized keypoints
+            map to themselves; each _left/_right pair maps to its partner.
+
+        Raises:
+            ValueError: if any keypoint ending in _left has no matching _right partner,
+                or vice versa.
+        """
+        indices = list(range(len(keypoint_names)))
+        left_map = {
+            name[:-5]: i for i, name in enumerate(keypoint_names) if name.endswith('_left')
+        }
+        right_map = {
+            name[:-6]: i for i, name in enumerate(keypoint_names) if name.endswith('_right')
+        }
+
+        unmatched_left = sorted(f'{b}_left' for b in set(left_map) - set(right_map))
+        unmatched_right = sorted(f'{b}_right' for b in set(right_map) - set(left_map))
+        if unmatched_left:
+            raise ValueError(
+                f'imgaug_hflip requires matching _left/_right pairs, '
+                f'but found _left keypoints with no _right partner: {unmatched_left}'
+            )
+        if unmatched_right:
+            raise ValueError(
+                f'imgaug_hflip requires matching _left/_right pairs, '
+                f'but found _right keypoints with no _left partner: {unmatched_right}'
+            )
+
+        for base_name in left_map:
+            idx_left = left_map[base_name]
+            idx_right = right_map[base_name]
+            indices[idx_left] = idx_right
+            indices[idx_right] = idx_left
+
+        return np.array(indices, dtype=np.intp)
 
     @property
     def height(self) -> int:
@@ -185,6 +243,7 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
         keypoints_on_image = self.keypoints[idx]
         img_path = self.root_directory / img_name
         if not self.do_context:
+            do_hflip = self.imgaug_hflip and np.random.random() < 0.5
             # read image from file and apply transformations (if any)
             # if 1 color channel, change to 3.
             image = Image.open(img_path).convert("RGB")
@@ -196,6 +255,13 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
                 # get rid of the batch dim
                 transformed_images = imgs_aug[0]
                 transformed_keypoints = kps_aug[0].reshape(-1)
+
+                if do_hflip:
+                    transformed_images = np.ascontiguousarray(np.fliplr(transformed_images))
+                    kps_2d = transformed_keypoints.reshape(self.num_keypoints, 2).copy()
+                    kps_2d[:, 0] = self.image_resize_width - kps_2d[:, 0]
+                    kps_2d = kps_2d[self._hflip_swap_indices]
+                    transformed_keypoints = kps_2d.reshape(-1)
             else:
                 transformed_images = np.expand_dims(np.array(image), axis=0)
                 transformed_keypoints = np.expand_dims(keypoints_on_image, axis=0)
@@ -216,6 +282,9 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
                 image = Image.open(path).convert("RGB")
                 images.append(np.asarray(image))
 
+            # decide flip once so all context frames get the same transformation
+            do_hflip = self.imgaug_hflip and np.random.random() < 0.5
+
             # apply data aug pipeline
             if self.imgaug_transform is not None:
                 # need to apply the same transform to all context frames
@@ -229,6 +298,13 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
                     transformed_images.append(img_aug[0])
                 transformed_images = np.asarray(transformed_images)
                 transformed_keypoints = kps_aug[0].reshape(-1)
+
+                if do_hflip:
+                    transformed_images = np.stack([np.fliplr(im) for im in transformed_images])
+                    kps_2d = transformed_keypoints.reshape(self.num_keypoints, 2).copy()
+                    kps_2d[:, 0] = self.image_resize_width - kps_2d[:, 0]
+                    kps_2d = kps_2d[self._hflip_swap_indices]
+                    transformed_keypoints = kps_2d.reshape(-1)
             else:
                 transformed_images = np.asarray(images)
                 transformed_keypoints = keypoints_on_image.numpy().reshape(-1)
@@ -255,16 +331,19 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
         else:
             bbox = torch.tensor([0, 0, image.height, image.width])
 
+        if self.visibility is not None:
+            vis = self.visibility[idx]
+            if do_hflip:
+                vis = vis[torch.from_numpy(self._hflip_swap_indices)]
+        else:
+            vis = torch.zeros(0, dtype=torch.long)
+
         return BaseLabeledExampleDict(
             images=transformed_images,  # shape (3, img_height, img_width) or (5, 3, H, W)
             keypoints=torch.from_numpy(transformed_keypoints),  # shape (n_targets,)
             idxs=idx,
             bbox=bbox,
-            visibility=(
-                self.visibility[idx]
-                if self.visibility is not None
-                else torch.zeros(0, dtype=torch.long)
-            ),
+            visibility=vis,
         )
 
 
@@ -285,6 +364,7 @@ class HeatmapDataset(BaseTrackingDataset):
         resize: bool = True,
         uniform_heatmaps: bool = False,
         bbox_path: str | None = None,
+        imgaug_hflip: bool = False,
     ) -> None:
         """Initialize the Heatmap Dataset.
 
@@ -313,6 +393,7 @@ class HeatmapDataset(BaseTrackingDataset):
                 provides explicit visibility flags.
             bbox_path: path to csv file that contains bounding box information; rows must be in
                 same order as csv file
+            imgaug_hflip: see :class:`BaseTrackingDataset` for full documentation.
 
         """
         super().__init__(
@@ -325,6 +406,7 @@ class HeatmapDataset(BaseTrackingDataset):
             do_context=do_context,
             resize=resize,
             bbox_path=bbox_path,
+            imgaug_hflip=imgaug_hflip,
         )
 
         if self.height % 128 != 0 or self.height % 128 != 0:
@@ -482,6 +564,7 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
         if len(view_names) != len(csv_paths):
             raise ValueError("number of names does not match with the number of files!")
         logger.info('using MultiviewHeatmapDataset')
+        self.imgaug_hflip = False  # not supported for multiview; sentinel for data module
         self.root_directory = root_directory
         self.csv_paths = csv_paths
         self.bbox_paths = bbox_paths or [None] * len(view_names)

--- a/lightning_pose/data/factory.py
+++ b/lightning_pose/data/factory.py
@@ -132,6 +132,8 @@ def get_dataset(
             a multi-view regression model is requested.
     """
 
+    imgaug_hflip = bool(cfg.training.get('imgaug_hflip', False))
+
     if cfg.model.model_type == 'regression':
         if cfg.data.get('view_names', None) and len(cfg.data.view_names) > 1:
             raise NotImplementedError('Multi-view support only available for heatmap-based models')
@@ -144,9 +146,14 @@ def get_dataset(
                 imgaug_transform=imgaug_transform,
                 do_context=False,  # no context for regression models
                 bbox_path=cfg.data.get('bbox_file', None),
+                imgaug_hflip=imgaug_hflip,
             )
     elif cfg.model.model_type.find('heatmap') > -1:
         if cfg.data.get('view_names', None) and len(cfg.data.view_names) > 1:
+            if imgaug_hflip:
+                raise ValueError(
+                    'imgaug_hflip is not supported for multiview models'
+                )
             UserWarning(
                 'No precautions regarding the size of the images were considered here, '
                 'images will be resized accordingly to configs!'
@@ -186,6 +193,7 @@ def get_dataset(
                 do_context=cfg.model.model_type == 'heatmap_mhcrnn',  # context only for mhcrnn
                 uniform_heatmaps=cfg.training.get('uniform_heatmaps_for_nan_keypoints', False),
                 bbox_path=cfg.data.get('bbox_file', None),
+                imgaug_hflip=imgaug_hflip,
             )
 
     else:

--- a/scripts/configs/config_default.yaml
+++ b/scripts/configs/config_default.yaml
@@ -31,9 +31,13 @@ training:
   # select from one of several predefined image/video augmentation pipelines
   # default: resizing only
   # dlc: imgaug pipeline implemented in DLC 2.0 package
-  # dlc-lr: dlc augmentation plus horizontal flips
-  # dlc-top-down: dlc augmentations plus vertical and horizontal flips
+  # dlc-lr: dlc augmentation plus 180 degree rotations
+  # dlc-top-down: dlc augmentations plus 90, 180, and 270 degree rotations
   imgaug: dlc
+  # apply a random horizontal flip with probability 0.5 after the standard imgaug pipeline;
+  # keypoints ending in _left/_right are swapped with their partner to preserve label identity;
+  # every _left keypoint must have a matching _right (and vice versa), else an error is raised;
+  imgaug_hflip: false
   # batch size of labeled data during training
   train_batch_size: 16
   # batch size of labeled data during validation

--- a/scripts/configs/config_default_multiview.yaml
+++ b/scripts/configs/config_default_multiview.yaml
@@ -49,6 +49,8 @@ training:
   imgaug: dlc
   # apply 3D augmentations (scale/translate in 3D then reproject); requires camera_params_file
   imgaug_3d: true
+  # imgaug_hflip is not supported for multiview models; setting to true will raise an error
+  imgaug_hflip: false
   # batch size of labeled data during training
   train_batch_size: 16
   # batch size of labeled data during validation

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -1,3 +1,4 @@
+import copy
 import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -7,6 +8,7 @@ import pandas as pd
 import pytest
 
 from lightning_pose.api import Model
+from lightning_pose.api.model import _build_datamodule_pred
 from tests.fetch_test_data import fetch_test_data_if_needed
 
 
@@ -304,3 +306,31 @@ class TestModelErrors:
         with patch.object(multiview_model, '_load'):
             with pytest.raises(ValueError, match='expected.*video files'):
                 multiview_model.predict_on_video_file_multiview(['only_one.mp4'])
+
+
+class TestBuildDatamodulePred:
+    """Test the _build_datamodule_pred helper."""
+
+    def test_build_datamodule_pred_imgaug_reset_to_default(self, cfg):
+        """imgaug pipeline is resize-only regardless of the training config."""
+        cfg_copy = copy.deepcopy(cfg)
+        cfg_copy.training.imgaug = 'dlc'
+        data_module = _build_datamodule_pred(cfg_copy)
+        # pipeline always has exactly one element: the final resize transform
+        assert len(data_module.dataset.imgaug_transform) == 1
+
+    def test_build_datamodule_pred_imgaug_hflip_cleared(self, cfg):
+        """imgaug_hflip is False on the prediction dataset even when True in the config."""
+        cfg_copy = copy.deepcopy(cfg)
+        cfg_copy.training.imgaug_hflip = True
+        data_module = _build_datamodule_pred(cfg_copy)
+        assert data_module.dataset.imgaug_hflip is False
+
+    def test_build_datamodule_pred_does_not_mutate_cfg(self, cfg):
+        """the original config object is not modified."""
+        cfg_copy = copy.deepcopy(cfg)
+        cfg_copy.training.imgaug = 'dlc'
+        cfg_copy.training.imgaug_hflip = True
+        _build_datamodule_pred(cfg_copy)
+        assert cfg_copy.training.imgaug == 'dlc'
+        assert cfg_copy.training.imgaug_hflip is True

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -317,6 +317,7 @@ class TestBuildDatamodulePred:
         cfg_copy.training.imgaug = 'dlc'
         data_module = _build_datamodule_pred(cfg_copy)
         # pipeline always has exactly one element: the final resize transform
+        assert data_module.dataset.imgaug_transform is not None
         assert len(data_module.dataset.imgaug_transform) == 1
 
     def test_build_datamodule_pred_imgaug_hflip_cleared(self, cfg):

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -1,15 +1,27 @@
 """Test basic dataset functionality."""
 
 import copy
+import logging
+import os
 from unittest.mock import patch
 
 import cv2
+import imgaug.augmenters as iaa
 import numpy as np
 import pandas as pd
 import pytest
 import torch
+from aniposelib.cameras import Camera
+from PIL import Image
 
-from lightning_pose.data.datasets import MultiviewHeatmapDataset
+from lightning_pose.data.bboxes import norm_to_frame
+from lightning_pose.data.cameras import CameraGroup
+from lightning_pose.data.datamodules import BaseDataModule
+from lightning_pose.data.datasets import (
+    BaseTrackingDataset,
+    HeatmapDataset,
+    MultiviewHeatmapDataset,
+)
 
 
 def test_base_dataset(cfg, base_dataset):
@@ -466,8 +478,6 @@ class TestMultiviewHeatmapDataset:
 
     def test_get_2d_keypoints_from_example_dict_absolute_coords(self, multiview_heatmap_dataset):
 
-        from lightning_pose.data.bboxes import norm_to_frame
-
         # test data
         data_dict = {
             "view_0": {
@@ -527,10 +537,6 @@ class TestApply3DTransforms:
         # hard-coded values from anipose-fly example
         # (using aniposelib CameraGroup object)
         # ------------------------------------------
-
-        from aniposelib.cameras import Camera
-
-        from lightning_pose.data.cameras import CameraGroup
 
         intrinsics = torch.tensor(
             [[[1.4633e+04, 0.0000e+00, 4.1600e+02],
@@ -1074,8 +1080,6 @@ class TestDiscoverCamParamsFromImagePaths:
 
     def test_discover_mixed_calibration_disables_3d(self, fake_ds, tmp_path, caplog):
         """Returns (None, None) and logs a warning when only some frames have calibration."""
-        import logging
-
         # Arrange: session0 has a toml, session1 does not
         calib_dir = tmp_path / 'calibrations'
         calib_dir.mkdir()
@@ -1190,11 +1194,9 @@ class TestBaseTrackingDatasetVisibility:
 
     @pytest.fixture
     def imgaug(self):
-        import imgaug.augmenters as iaa
         return iaa.Sequential([])
 
     def _make_base_dataset(self, csv_path, tmp_path, imgaug):
-        from lightning_pose.data.datasets import BaseTrackingDataset
         return BaseTrackingDataset(
             root_directory=str(tmp_path),
             csv_path=csv_path,
@@ -1204,7 +1206,6 @@ class TestBaseTrackingDatasetVisibility:
         )
 
     def _make_heatmap_dataset(self, csv_path, tmp_path, imgaug):
-        from lightning_pose.data.datasets import HeatmapDataset
         return HeatmapDataset(
             root_directory=str(tmp_path),
             csv_path=csv_path,
@@ -1243,7 +1244,6 @@ class TestBaseTrackingDatasetVisibility:
         bad_csv = tmp_path / 'bad.csv'
         bad_csv.write_text(content)
         with pytest.raises(ValueError, match='visibility column contains invalid values'):
-            from lightning_pose.data.datasets import BaseTrackingDataset
             BaseTrackingDataset(
                 root_directory=str(tmp_path),
                 csv_path=str(bad_csv),
@@ -1256,7 +1256,6 @@ class TestBaseTrackingDatasetVisibility:
         self, tmp_path, imgaug, caplog,
     ):
         """A warning is logged when vis=1 keypoints have non-NaN x,y coordinates."""
-        import logging
         content = (
             'scorer,scorer,scorer,scorer\n'
             'bodyparts,kp1,kp1,kp1\n'
@@ -1267,7 +1266,6 @@ class TestBaseTrackingDatasetVisibility:
         p = tmp_path / 'occluded_with_coords.csv'
         p.write_text(content)
         with caplog.at_level(logging.WARNING, logger='lightning_pose.data.datasets'):
-            from lightning_pose.data.datasets import BaseTrackingDataset
             BaseTrackingDataset(
                 root_directory=str(tmp_path),
                 csv_path=str(p),
@@ -1279,11 +1277,6 @@ class TestBaseTrackingDatasetVisibility:
 
     def test_heatmap_dataset_getitem_populates_visibility(self, visibility_csv, tmp_path, imgaug):
         """__getitem__ populates the 'visibility' key from self.visibility[idx]."""
-        import os
-
-        from PIL import Image
-
-        from lightning_pose.data.datasets import BaseTrackingDataset
         for name in ('img01.png', 'img02.png'):
             Image.fromarray(
                 (128 * torch.ones(128, 128, 3)).byte().numpy()
@@ -1301,11 +1294,6 @@ class TestBaseTrackingDatasetVisibility:
 
     def test_heatmap_dataset_getitem_no_visibility(self, standard_csv, tmp_path, imgaug):
         """HeatmapDataset synthesizes visibility=2 for all valid keypoints in a standard CSV."""
-        import os
-
-        from PIL import Image
-
-        from lightning_pose.data.datasets import BaseTrackingDataset
         for name in ('img01.png', 'img02.png'):
             Image.fromarray(
                 (128 * torch.ones(128, 128, 3)).byte().numpy()
@@ -1375,3 +1363,249 @@ class TestBaseTrackingDatasetVisibility:
 def test_equal_return_sizes(base_dataset, heatmap_dataset):
     # can only assert the batches are the same if not using imgaug pipeline
     assert base_dataset[0]["images"].shape == heatmap_dataset[0]["images"].shape
+
+
+class TestBuildHflipSwapIndices:
+    """Test BaseTrackingDataset._build_hflip_swap_indices."""
+
+    def test_no_lateralized_keypoints_returns_identity(self):
+        """keypoints with no _left/_right suffix map to themselves."""
+        names = ['nose', 'tail', 'spine']
+        indices = BaseTrackingDataset._build_hflip_swap_indices(names)
+        assert list(indices) == [0, 1, 2]
+
+    def test_single_pair_swaps(self):
+        """a single _left/_right pair is correctly swapped."""
+        names = ['nose', 'ear_left', 'ear_right', 'tail']
+        indices = BaseTrackingDataset._build_hflip_swap_indices(names)
+        # ear_left (idx 1) <-> ear_right (idx 2); nose and tail stay
+        assert list(indices) == [0, 2, 1, 3]
+
+    def test_multiple_pairs_swap(self):
+        """multiple _left/_right pairs are all correctly swapped."""
+        names = ['ear_left', 'paw_left', 'nose', 'paw_right', 'ear_right']
+        indices = BaseTrackingDataset._build_hflip_swap_indices(names)
+        # ear_left(0)<->ear_right(4), paw_left(1)<->paw_right(3), nose(2) stays
+        assert list(indices) == [4, 3, 2, 1, 0]
+
+    def test_unmatched_left_raises(self):
+        """ValueError raised when a _left keypoint has no _right partner."""
+        with pytest.raises(ValueError, match='_left'):
+            BaseTrackingDataset._build_hflip_swap_indices(['ear_left', 'nose'])
+
+    def test_unmatched_right_raises(self):
+        """ValueError raised when a _right keypoint has no _left partner."""
+        with pytest.raises(ValueError, match='_right'):
+            BaseTrackingDataset._build_hflip_swap_indices(['ear_right', 'nose'])
+
+    def test_return_dtype_is_intp(self):
+        """returned array has dtype np.intp for safe indexing."""
+        indices = BaseTrackingDataset._build_hflip_swap_indices(['a_left', 'a_right'])
+        assert indices.dtype == np.intp
+
+
+class TestImgaugHflip:
+    """Test the imgaug_hflip augmentation in BaseTrackingDataset and HeatmapDataset."""
+
+    @pytest.fixture
+    def lateralized_csv(self, tmp_path) -> str:
+        """DLC-format CSV with _left/_right keypoints and one non-lateralized keypoint."""
+        # 5 keypoints: nose, ear_left, ear_right, paw_left, paw_right (x, y each)
+        bp = (
+            'nose,nose,ear_left,ear_left,ear_right,ear_right,'
+            'paw_left,paw_left,paw_right,paw_right'
+        )
+        content = (
+            'scorer,scorer,scorer,scorer,scorer,scorer,scorer,scorer,scorer,scorer,scorer\n'
+            f'bodyparts,{bp}\n'
+            'coords,x,y,x,y,x,y,x,y,x,y\n'
+            'img01.png,64.0,64.0,30.0,40.0,90.0,40.0,20.0,80.0,100.0,80.0\n'
+            'img02.png,64.0,64.0,35.0,45.0,85.0,45.0,25.0,75.0,95.0,75.0\n'
+        )
+        p = tmp_path / 'lateralized.csv'
+        p.write_text(content)
+        return str(p)
+
+    @pytest.fixture
+    def dummy_images(self, tmp_path):
+        """Write two dummy PNG images so __getitem__ can open them."""
+        for name in ('img01.png', 'img02.png'):
+            arr = np.zeros((128, 128, 3), dtype=np.uint8)
+            Image.fromarray(arr).save(tmp_path / name)
+
+    @pytest.fixture
+    def hflip_dataset(self, lateralized_csv, dummy_images, tmp_path):
+        """HeatmapDataset with imgaug_hflip=True."""
+        return HeatmapDataset(
+            root_directory=str(tmp_path),
+            csv_path=lateralized_csv,
+            image_resize_height=128,
+            image_resize_width=128,
+            imgaug_transform=iaa.Sequential([]),
+            imgaug_hflip=True,
+        )
+
+    def test_swap_indices_built_correctly(self, hflip_dataset):
+        """_hflip_swap_indices correctly maps lateralized pairs."""
+        # keypoints: nose(0), ear_left(1), ear_right(2), paw_left(3), paw_right(4)
+        expected = np.array([0, 2, 1, 4, 3], dtype=np.intp)
+        assert np.array_equal(hflip_dataset._hflip_swap_indices, expected)
+
+    def test_unmatched_left_raises_at_init(self, tmp_path):
+        """ValueError raised at dataset init when a _left has no _right partner."""
+        content = (
+            'scorer,scorer,scorer,scorer,scorer\n'
+            'bodyparts,ear_left,ear_left,nose,nose\n'
+            'coords,x,y,x,y\n'
+            'img01.png,30.0,40.0,64.0,64.0\n'
+        )
+        (tmp_path / 'bad.csv').write_text(content)
+        with pytest.raises(ValueError, match='_left'):
+            HeatmapDataset(
+                root_directory=str(tmp_path),
+                csv_path=str(tmp_path / 'bad.csv'),
+                image_resize_height=128,
+                image_resize_width=128,
+                imgaug_transform=iaa.Sequential([]),
+                imgaug_hflip=True,
+            )
+
+    def test_hflip_false_does_not_build_swap_indices(self, tmp_path):
+        """With imgaug_hflip=False, no validation is run and identity indices are stored."""
+        # CSV with unmatched _left — would raise if imgaug_hflip=True, but not with False
+        content = (
+            'scorer,scorer,scorer\n'
+            'bodyparts,ear_left,ear_left\n'
+            'coords,x,y\n'
+            'img01.png,30.0,40.0\n'
+        )
+        (tmp_path / 'unmatched.csv').write_text(content)
+        ds = HeatmapDataset(
+            root_directory=str(tmp_path),
+            csv_path=str(tmp_path / 'unmatched.csv'),
+            image_resize_height=128,
+            image_resize_width=128,
+            imgaug_transform=iaa.Sequential([]),
+            imgaug_hflip=False,
+        )
+        assert not ds.imgaug_hflip
+        assert np.array_equal(ds._hflip_swap_indices, np.arange(1, dtype=np.intp))
+
+    def test_hflip_mirrors_x_coordinates(self, hflip_dataset):
+        """After a forced hflip, all x-coordinates are mirrored and lateralized pairs swapped."""
+        width = hflip_dataset.image_resize_width
+        # original keypoints for frame 0: nose(64,64), ear_left(30,40), ear_right(90,40),
+        # paw_left(20,80), paw_right(100,80)
+        orig_kps = hflip_dataset.keypoints[0].numpy()  # (5, 2)
+
+        with patch('numpy.random.random', return_value=0.0):  # force flip (0.0 < 0.5)
+            batch = hflip_dataset[0]
+
+        kps = batch['keypoints'].numpy().reshape(5, 2)
+
+        # after flip and swap:
+        # position 0 (nose, non-lateral): x = 128 - 64 = 64
+        assert np.isclose(kps[0, 0], width - orig_kps[0, 0])
+        # position 1 gets ear_right's flipped x: 128 - 90 = 38
+        assert np.isclose(kps[1, 0], width - orig_kps[2, 0])
+        # position 2 gets ear_left's flipped x: 128 - 30 = 98
+        assert np.isclose(kps[2, 0], width - orig_kps[1, 0])
+        # y-coordinates are unchanged for both lateralized keypoints
+        assert np.isclose(kps[1, 1], orig_kps[2, 1])
+        assert np.isclose(kps[2, 1], orig_kps[1, 1])
+
+    def test_hflip_no_flip_when_random_above_half(self, hflip_dataset):
+        """When random >= 0.5, no flip is applied and keypoints are unchanged."""
+        orig_kps = hflip_dataset.keypoints[0].numpy()
+
+        with patch('numpy.random.random', return_value=0.9):  # force no flip
+            batch = hflip_dataset[0]
+
+        kps = batch['keypoints'].numpy().reshape(5, 2)
+        # after standard imgaug (empty pipeline + resize to 128x128), coords are unchanged
+        assert np.allclose(kps, orig_kps, equal_nan=True)
+
+    def test_hflip_swaps_visibility(self, tmp_path, dummy_images):
+        """After hflip, visibility values are swapped for lateralized pairs."""
+        content = (
+            'scorer,scorer,scorer,scorer,scorer,scorer,scorer\n'
+            'bodyparts,ear_left,ear_left,ear_left,ear_right,ear_right,ear_right\n'
+            'coords,x,y,visible,x,y,visible\n'
+            'img01.png,30.0,40.0,2,90.0,40.0,1\n'
+            'img02.png,30.0,40.0,1,90.0,40.0,2\n'
+        )
+        (tmp_path / 'vis.csv').write_text(content)
+        ds = HeatmapDataset(
+            root_directory=str(tmp_path),
+            csv_path=str(tmp_path / 'vis.csv'),
+            image_resize_height=128,
+            image_resize_width=128,
+            imgaug_transform=iaa.Sequential([]),
+            imgaug_hflip=True,
+        )
+        # frame 0: ear_left=vis2, ear_right=vis1; after hflip swap → pos0=vis1, pos1=vis2
+        with patch('numpy.random.random', return_value=0.0):
+            batch = ds[0]
+        assert batch['visibility'][0].item() == 1  # was ear_right
+        assert batch['visibility'][1].item() == 2  # was ear_left
+
+    def test_hflip_context_all_frames_flipped(self, lateralized_csv, tmp_path):
+        """In context mode, all frames receive the same horizontal flip."""
+        # create enough context frames: img01.png needs neighbours
+        for i in range(10):
+            arr = np.zeros((128, 128, 3), dtype=np.uint8)
+            arr[:, :64, 0] = 200  # left half red → right half after flip
+            Image.fromarray(arr).save(tmp_path / f'img{i:02d}.png')
+
+        # rewrite csv to use img05.png as center (has neighbours on both sides)
+        bp = (
+            'nose,nose,ear_left,ear_left,ear_right,ear_right,'
+            'paw_left,paw_left,paw_right,paw_right'
+        )
+        content = (
+            'scorer,scorer,scorer,scorer,scorer,scorer,scorer,scorer,scorer,scorer,scorer\n'
+            f'bodyparts,{bp}\n'
+            'coords,x,y,x,y,x,y,x,y,x,y\n'
+            'img05.png,64.0,64.0,30.0,40.0,90.0,40.0,20.0,80.0,100.0,80.0\n'
+        )
+        (tmp_path / 'ctx.csv').write_text(content)
+
+        ds = HeatmapDataset(
+            root_directory=str(tmp_path),
+            csv_path=str(tmp_path / 'ctx.csv'),
+            image_resize_height=128,
+            image_resize_width=128,
+            imgaug_transform=iaa.Sequential([]),
+            imgaug_hflip=True,
+            do_context=True,
+        )
+
+        with patch('numpy.random.random', return_value=0.0):
+            batch = ds[0]
+
+        # images tensor is (5, 3, H, W); after flip the right half should be brighter
+        images = batch['images']  # (5, 3, 128, 128)
+        assert images.shape == (5, 3, 128, 128)
+        for frame_idx in range(5):
+            left_mean = images[frame_idx, 0, :, :64].mean().item()
+            right_mean = images[frame_idx, 0, :, 64:].mean().item()
+            # original left half was red (high), so after flip right half should be higher
+            assert right_mean > left_mean, (
+                f'frame {frame_idx}: expected right > left after hflip'
+            )
+
+    def test_hflip_disabled_for_val_test_in_datamodule(
+        self, cfg, hflip_dataset,
+    ):
+        """datamodule resets imgaug_hflip=False on val and test subsets."""
+        dm = BaseDataModule(
+            dataset=hflip_dataset,
+            train_batch_size=2,
+            val_batch_size=2,
+            test_batch_size=2,
+            train_probability=0.6,
+            val_probability=0.2,
+        )
+        assert dm.train_dataset.dataset.imgaug_hflip is True  # type: ignore[union-attr]
+        assert dm.val_dataset.dataset.imgaug_hflip is False  # type: ignore[union-attr]
+        assert dm.test_dataset.dataset.imgaug_hflip is False  # type: ignore[union-attr]


### PR DESCRIPTION
Many animal pose datasets have **lateralized keypoints** — pairs of landmarks that appear on the
left and right sides of the body (e.g. ``ear_left`` / ``ear_right``, ``paw_front_left`` /
``paw_front_right``).
Randomly flipping images horizontally is a powerful augmentation for these datasets, but a naive
flip must also **swap the left/right labels**: after a flip the right ear appears on the left side
of the image and must therefore be relabeled as ``ear_left``.

Enable this with the ``training.imgaug_hflip`` flag:


    training:
      imgaug_hflip: true

With ``imgaug_hflip: true``, each training image is horizontally flipped with probability 0.5.
All keypoint x-coordinates are mirrored, and any ``_left`` / ``_right`` pair is additionally
swapped so that label identity is preserved.