### PR TITLE
Add ONNX export and runtime support to Model API and predict CLI

### DIFF
--- a/docs/source/directory_structure_reference/model_dir_structure.rst
+++ b/docs/source/directory_structure_reference/model_dir_structure.rst
@@ -13,6 +13,8 @@ Model Directory Structure
    ├── predictions_view1.csv
    |
    ├── tb_logs/ ...
+   ├── exports_onnx/
+   │   └── epoch=214-step=12685-best_fp16.onnx
    ├── video_preds/
    │   ├── session0_view0.mp4/
    │   |   └── predictions.csv
@@ -26,6 +28,7 @@ Detailed descriptions
 -----------------------
 
 * ``tb_logs/``: model weights
+* ``exports_onnx/``: ONNX exports produced by ``litpose export`` or ``Model.export("onnx", ...)``, one file per exported checkpoint and precision, named ``<checkpoint_stem>_<onnx_precision>.onnx``. Read back by ``litpose predict --runtime onnx`` or ``Model.from_dir(..., runtime="onnx")``. See :ref:`Increasing Inference Speed <usage_onnx_runtime>`.
 * ``video_preds/``: predictions and metrics from videos. The config field ``eval.test_videos_directory`` points to a directory of videos; if ``eval.predict_vids_after_training`` is set to ``true``, all videos in the indicated direcotry will be run through the model upon training completion and results stored here.
 * ``video_preds/labeled_videos/``: labeled mp4s. The config field ``eval.test_videos_directory`` points to a directory of videos; if ``eval.save_vids_after_training`` is set to ``true``, all videos in the indicated direcotry will be run through the model upon training completion and results stored here.
 * ``predictions.csv``: predictions on labeled data. The right-most column records the train/val/test split that each example belongs to.

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -203,6 +203,16 @@ you already have -- so check what your PyTorch install is using first:
 Then use that CUDA version to select the proper installation option from ONNX Runtime's
 `installation selector <https://onnxruntime.ai/getting-started>`_.
 
+Exporting additionally requires the ``onnx`` package, which ``onnxruntime-gpu`` does not pull
+in as a dependency:
+
+.. code-block:: console
+
+    pip install onnx
+
+Only ``Model.export()`` needs it. A machine that just runs an already-exported ``.onnx`` file
+needs ``onnxruntime-gpu`` alone.
+
 Usage
 ~~~~~
 

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -187,41 +187,21 @@ a no-op.
 ONNX Runtime
 ------------
 
+.. _onnx_installation:
+
 Installation
 ~~~~~~~~~~~~
 
-ONNX Runtime is an optional dependency:
-
-.. code-block:: console
-
-    pip install onnxruntime-gpu
-
-``onnxruntime-gpu`` wheels are built against a specific CUDA major version at build time --
-currently CUDA 12.x/13.x for the default PyPI package. The wheel does **not** detect or adapt
-to whatever CUDA you already have, so check what your PyTorch install is using and match it:
+ONNX Runtime is an optional dependency. ``onnxruntime-gpu`` wheels are built against a specific
+CUDA major version at build time, and the wheel does **not** detect or adapt to whatever CUDA
+you already have -- so check what your PyTorch install is using first:
 
 .. code-block:: console
 
     python -c "import torch; print(torch.version.cuda)"
 
-If that prints a version outside ``onnxruntime-gpu``'s default -- for example CUDA 11.x, which
-is no longer published to PyPI under the default package name -- use ONNX Runtime's
-`installation selector <https://onnxruntime.ai/getting-started>`_ to get the right command for
-your setup.
-
-You do **not** normally need a separate system CUDA toolkit. ``onnxruntime-gpu`` can reuse the
-CUDA and cuDNN libraries that PyTorch already bundles, provided ``torch`` is imported first --
-which it always is here, since ``lightning_pose.api.Model`` imports ``torch`` at module level.
-On a working PyTorch + CUDA setup, ``pip install onnxruntime-gpu`` is usually all you need.
-
-.. note::
-
-   If the CUDA major versions don't match, ``onnxruntime`` does not raise. It silently drops
-   ``CUDAExecutionProvider`` and runs on CPU instead, which "works" but is drastically slower
-   with no indication why. Lightning Pose checks for this and raises a ``RuntimeError`` when a
-   CUDA device is available but ``CUDAExecutionProvider`` failed to load. If you hit that
-   error, re-check ``torch.version.cuda`` against your installed ``onnxruntime-gpu`` build and
-   reinstall the matching one.
+Then use that CUDA version to select the proper installation option from ONNX Runtime's
+`installation selector <https://onnxruntime.ai/getting-started>`_.
 
 Usage
 ~~~~~

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -187,64 +187,131 @@ a no-op.
 ONNX Runtime
 ------------
 
-Export the model's forward pass to ONNX, then run inference through ``onnxruntime``, plugging
-the ONNX session back in as the model's forward pass the same way as above:
+Installation
+~~~~~~~~~~~~
+
+ONNX Runtime is an optional dependency:
+
+.. code-block:: console
+
+    pip install onnxruntime-gpu
+
+``onnxruntime-gpu`` wheels are built against a specific CUDA major version at build time --
+currently CUDA 12.x/13.x for the default PyPI package. The wheel does **not** detect or adapt
+to whatever CUDA you already have, so check what your PyTorch install is using and match it:
+
+.. code-block:: console
+
+    python -c "import torch; print(torch.version.cuda)"
+
+If that prints a version outside ``onnxruntime-gpu``'s default -- for example CUDA 11.x, which
+is no longer published to PyPI under the default package name -- use ONNX Runtime's
+`installation selector <https://onnxruntime.ai/getting-started>`_ to get the right command for
+your setup.
+
+You do **not** normally need a separate system CUDA toolkit. ``onnxruntime-gpu`` can reuse the
+CUDA and cuDNN libraries that PyTorch already bundles, provided ``torch`` is imported first --
+which it always is here, since ``lightning_pose.api.Model`` imports ``torch`` at module level.
+On a working PyTorch + CUDA setup, ``pip install onnxruntime-gpu`` is usually all you need.
+
+.. note::
+
+   If the CUDA major versions don't match, ``onnxruntime`` does not raise. It silently drops
+   ``CUDAExecutionProvider`` and runs on CPU instead, which "works" but is drastically slower
+   with no indication why. Lightning Pose checks for this and raises a ``RuntimeError`` when a
+   CUDA device is available but ``CUDAExecutionProvider`` failed to load. If you hit that
+   error, re-check ``torch.version.cuda`` against your installed ``onnxruntime-gpu`` build and
+   reinstall the matching one.
+
+Usage
+~~~~~
+
+Exporting and loading are separate steps. Export once, then load with ``runtime="onnx"`` for
+every subsequent prediction run:
 
 .. code-block:: python
 
-    import numpy as np
-    import onnxruntime as ort
-    import torch
     from lightning_pose.api import Model
 
+    # export once
     model = Model.from_dir("path/to/model_dir")
-    real_module = model.model
+    model.export("onnx", onnx_precision="fp16")
 
-    resize_h = model.cfg.data.image_resize_dims.height
-    resize_w = model.cfg.data.image_resize_dims.width
-    # shape is (1, num_views, 3, H, W) instead for a multi-view model
-    dummy = torch.randn(1, 3, resize_h, resize_w, device="cuda")
-
-    torch.onnx.export(
-        real_module, dummy, "/path/to/model.onnx",
-        input_names=["images"], output_names=["heatmaps"],
-        dynamic_axes={"images": {0: "batch"}, "heatmaps": {0: "batch"}},
-        opset_version=17, do_constant_folding=True,
+    # load through ONNX Runtime and predict as normal
+    onnx_model = Model.from_dir(
+        "path/to/model_dir", runtime="onnx", onnx_precision="fp16"
     )
+    result = onnx_model.predict_on_video_file("path/to/video.mp4")
 
-    session = ort.InferenceSession(
-        "/path/to/model.onnx", providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
-    )
+The same two steps from the CLI:
 
-    def onnx_forward(images):
-        io_binding = session.io_binding()
-        io_binding.bind_input(
-            name="images", device_type="cuda", device_id=0,
-            element_type=np.float32, shape=tuple(images.shape),
-            buffer_ptr=images.contiguous().data_ptr(),
-        )
-        io_binding.bind_output(name="heatmaps", device_type="cuda", device_id=0)
-        session.run_with_iobinding(io_binding)
-        return torch.from_numpy(io_binding.copy_outputs_to_cpu()[0]).to(images.device)
+.. code-block:: console
 
-    real_module.forward = onnx_forward
-    result = model.predict_on_video_file("path/to/video.mp4")
+    litpose export /path/to/model_dir --runtime onnx --onnx-precision fp16
+    litpose predict /path/to/model_dir /path/to/video.mp4 --runtime onnx --onnx-precision fp16
 
-Requires ``pip install onnxruntime-gpu`` -- make sure the CUDA version matches your PyTorch
-install. Pip's default ``onnxruntime-gpu`` build may target a newer CUDA major version than
-your PyTorch install uses; check Microsoft's ``onnxruntime-cuda-12`` package index if you're on
-CUDA 12.
+Exports are written to a fixed location inside the model directory:
+
+.. code-block:: text
+
+    model_dir/
+    ├── config.yaml
+    ├── tb_logs/.../checkpoints/epoch=214-step=12685-best.ckpt
+    └── exports_onnx/
+        ├── epoch=214-step=12685-best_fp16.onnx
+        └── epoch=214-step=12685-best_fp32.onnx   # only if exported
+
+You never pass export paths yourself -- ``export()`` always writes here and
+``from_dir(runtime="onnx")`` always reads from here. The filename is the checkpoint's own stem
+plus the export precision, so it stays unambiguous which checkpoint an export came from if a
+model directory ever holds exports alongside an updated checkpoint. ``onnx_precision`` may be
+omitted when exactly one export exists for the checkpoint, and is required to disambiguate when
+several do.
+
+.. note::
+
+   ``precision`` and ``onnx_precision`` are different settings.
+
+   * ``precision`` (``"fp32"``/``"fp16"``/``"bf16"``, also ``litpose predict --precision``)
+     controls the autocast precision of an **eager** forward pass. It leaves the weights on
+     disk untouched.
+   * ``onnx_precision`` (``"fp32"``/``"fp16"``, also ``--onnx-precision``) is the weight
+     precision **baked into the exported** ``.onnx`` **file itself**.
+
+   With ``runtime="onnx"``, ``precision`` is ignored -- the exported file's own precision is
+   what runs.
+
+.. note::
+
+   ``runtime="onnx"`` rebinds the model's ``forward`` method to the ONNX session rather than
+   wrapping the module, for the same reason described in the ``torch.compile()`` note above.
+
+.. note::
+
+   ``torch.compile()`` has no effect on an ONNX Runtime session. Combining ``--compile`` with
+   ``--runtime onnx``, or calling ``compile()`` on a model loaded with ``runtime="onnx"``,
+   raises rather than silently doing nothing.
 
 .. _usage_tensorrt:
 
 TensorRT
 --------
 
-TensorRT engines are built through the same ONNX file, using onnxruntime's
-``TensorrtExecutionProvider`` instead of ``CUDAExecutionProvider`` (continuing the snippet
-above):
+TensorRT engines are built from the same ``.onnx`` file that ``model.export("onnx")``
+produces, using onnxruntime's ``TensorrtExecutionProvider`` instead of
+``CUDAExecutionProvider``. There is no ``runtime="tensorrt"`` yet, so the session is built
+by hand:
 
 .. code-block:: python
+
+    import onnxruntime as ort
+
+    from lightning_pose.api import Model
+
+    model = Model.from_dir("path/to/model_dir")
+    onnx_path = model.export("onnx", onnx_precision="fp32")
+    resize_h = model.cfg.data.image_resize_dims.height
+    resize_w = model.cfg.data.image_resize_dims.width
 
     trt_options = {
         "trt_engine_cache_enable": True,
@@ -255,7 +322,7 @@ above):
         "trt_profile_max_shapes": f"images:1x3x{resize_h}x{resize_w}",
     }
     session = ort.InferenceSession(
-        "/path/to/model.onnx",
+        str(onnx_path),
         providers=[
             ("TensorrtExecutionProvider", trt_options),
             "CUDAExecutionProvider",

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -511,7 +511,7 @@ class Model:
         # Imported lazily: onnxruntime is an optional dependency, and a
         # module-level import would make it mandatory for every eager user.
         try:
-            import onnxruntime as ort
+            import onnxruntime as ort  # type: ignore[import-not-found]
         except ImportError as e:
             raise ImportError(
                 "onnxruntime is required for runtime='onnx' but is not installed. "
@@ -673,7 +673,7 @@ class Model:
         module_to_export.eval()
         torch.onnx.export(
             module_to_export,
-            dummy,
+            (dummy,),
             str(onnx_path),
             input_names=["images"],
             output_names=["heatmaps"],

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -480,14 +480,10 @@ class Model:
             RuntimeError: if the model fails to load, or if ONNX Runtime silently
                 fell back to CPU on a CUDA machine.
         """
-        # Imported lazily: onnxruntime is an optional dependency, and a
-        # module-level import would make it mandatory for every eager user.
-        import onnxruntime as ort
-
-        self._load()
-        if self.model is None:
-            raise RuntimeError('model failed to load; self.model is None after _load()')
-
+        # Export discovery happens before importing onnxruntime or loading
+        # weights: a user who forgot to run export() should get that message
+        # regardless of whether the optional dependency is installed, and
+        # there's no reason to pay for _load() on a path that can't succeed.
         stem = self._ckpt_stem()
         export_dir = self.exports_onnx_dir()
         pattern = (
@@ -511,6 +507,23 @@ class Model:
             )
 
         onnx_path = candidates[0]
+
+        # Imported lazily: onnxruntime is an optional dependency, and a
+        # module-level import would make it mandatory for every eager user.
+        try:
+            import onnxruntime as ort
+        except ImportError as e:
+            raise ImportError(
+                "onnxruntime is required for runtime='onnx' but is not installed. "
+                "Install it with `pip install onnxruntime-gpu`, matching the CUDA "
+                "version your PyTorch build uses -- see the installation section of "
+                "docs/source/user_guide_advanced/increasing_inference_speed.rst."
+            ) from e
+
+        self._load()
+        if self.model is None:
+            raise RuntimeError('model failed to load; self.model is None after _load()')
+
         session = ort.InferenceSession(
             str(onnx_path), providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
         )

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -653,6 +653,10 @@ class Model:
         # Dummy input shape depends on model type. Context models take a temporal
         # stack and multiview models take a per-view stack; see predict_frame and
         # predict_on_video_file_multiview for the corresponding runtime shapes.
+        # The two cases are mutually exclusive rather than composable:
+        # HeatmapTrackerMultiviewTransformer raises on a do_context kwarg and
+        # hardcodes do_context=False, so a true-multiview model never reports
+        # do_context=True.
         if self.config.is_multi_view():
             num_views = len(self.cfg.data.view_names)
             shape = (1, num_views, 3, resize_h, resize_w)

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import logging
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, get_args
 
 import cv2
 import numpy as np
@@ -72,6 +72,11 @@ _CONTEXT_SEQUENCE_LENGTH = 5
 # _Precision -- this is the precision baked into the .onnx file itself, not the
 # autocast precision used for eager inference.
 _OnnxPrecision = Literal["fp32", "fp16"]
+
+# Inference runtimes accepted by Model.from_dir(runtime=...). "tensorrt" is a
+# planned addition that will consume the same exported .onnx file through a
+# different execution provider.
+_Runtime = Literal["eager", "onnx"]
 
 # Maps onnxruntime's tensor type strings to numpy dtypes. Used to bind input
 # buffers at whatever precision the exported file actually expects, rather than
@@ -274,7 +279,7 @@ class Model:
     """Whether ``compile()`` has been called. Guards against double-wrapping
     ``forward`` on repeat calls."""
 
-    _runtime: str = "eager"
+    _runtime: _Runtime = "eager"
     """Which inference runtime backs ``forward``: ``"eager"`` (the loaded
     PyTorch checkpoint) or ``"onnx"`` (an ONNX Runtime session). Set by
     ``from_dir(runtime=...)``; not user-assignable after construction."""
@@ -287,7 +292,7 @@ class Model:
     def from_dir(
         model_dir: str | Path,
         precision: _Precision = "fp32",
-        runtime: str = "eager",
+        runtime: _Runtime = "eager",
         onnx_precision: _OnnxPrecision | None = None,
     ) -> Model:
         """Create a `Model` instance for a model stored at `model_dir`.
@@ -336,7 +341,7 @@ class Model:
         model_dir: str | Path,
         hydra_overrides: list[str] | None = None,
         precision: _Precision = "fp32",
-        runtime: str = "eager",
+        runtime: _Runtime = "eager",
         onnx_precision: _OnnxPrecision | None = None,
     ) -> Model:
         """Internal version of from_dir that supports hydra_overrides. Not sure whether to
@@ -363,8 +368,9 @@ class Model:
             model._attach_onnx_runtime(onnx_precision)
             return model
         else:
+            supported = ", ".join(repr(r) for r in get_args(_Runtime))
             raise ValueError(
-                f"Unsupported runtime: '{runtime}'. Use 'eager' or 'onnx'."
+                f"Unsupported runtime: '{runtime}'. Use one of {supported}."
             )
 
     def __init__(
@@ -515,9 +521,9 @@ class Model:
         except ImportError as e:
             raise ImportError(
                 "onnxruntime is required for runtime='onnx' but is not installed. "
-                "Install it with `pip install onnxruntime-gpu`, matching the CUDA "
-                "version your PyTorch build uses -- see the installation section of "
-                "docs/source/user_guide_advanced/increasing_inference_speed.rst."
+                "See https://lightning-pose.readthedocs.io/en/latest/source/"
+                "user_guide_advanced/increasing_inference_speed.html#onnx-installation "
+                "for installation instructions."
             ) from e
 
         self._load()
@@ -537,11 +543,15 @@ class Model:
         if torch.cuda.is_available() and "CUDAExecutionProvider" not in providers:
             raise RuntimeError(
                 "ONNX Runtime failed to load CUDAExecutionProvider even though a CUDA "
-                "device is available -- inference would silently run on CPU instead. "
-                "This is usually a CUDA/cuDNN major version mismatch between "
-                "onnxruntime-gpu and your installed PyTorch. See the installation "
-                "section of docs/source/user_guide_advanced/increasing_inference_speed.rst "
-                "for how to check and fix this."
+                "device is available -- inference would silently run on CPU instead, "
+                "which works but is drastically slower with no indication why. This is "
+                "usually a CUDA major version mismatch between onnxruntime-gpu and your "
+                "installed PyTorch: onnxruntime-gpu wheels are built against a specific "
+                "CUDA version and do not adapt to the one you have. Check yours with "
+                "`python -c \"import torch; print(torch.version.cuda)\"` and reinstall "
+                "the matching build -- see "
+                "https://lightning-pose.readthedocs.io/en/latest/source/"
+                "user_guide_advanced/increasing_inference_speed.html#onnx-installation"
             )
 
         # Bind at the precision the exported graph declares, not a hardcoded

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -64,6 +64,23 @@ _PRECISION_TO_AUTOCAST_DTYPE: dict[_Precision, torch.dtype] = {
     "bf16": torch.bfloat16,
 }
 
+# Temporal context length used when tracing a context (MHCRNN) model for export.
+# Matches the (T, H, W, 3) convention documented in Model.predict_frame.
+_CONTEXT_SEQUENCE_LENGTH = 5
+
+# Weight precisions supported for ONNX export. Deliberately narrower than
+# _Precision -- this is the precision baked into the .onnx file itself, not the
+# autocast precision used for eager inference.
+_OnnxPrecision = Literal["fp32", "fp16"]
+
+# Maps onnxruntime's tensor type strings to numpy dtypes. Used to bind input
+# buffers at whatever precision the exported file actually expects, rather than
+# assuming fp32 -- an fp16 export takes fp16 input.
+_ORT_TYPE_TO_NUMPY: dict[str, Any] = {
+    "tensor(float)": np.float32,
+    "tensor(float16)": np.float16,
+}
+
 
 # torch.compile's inductor backend emits Triton kernels, which need Volta or newer.
 _TORCH_COMPILE_MIN_CUDA_CAPABILITY = (7, 0)
@@ -257,12 +274,22 @@ class Model:
     """Whether ``compile()`` has been called. Guards against double-wrapping
     ``forward`` on repeat calls."""
 
+    _runtime: str = "eager"
+    """Which inference runtime backs ``forward``: ``"eager"`` (the loaded
+    PyTorch checkpoint) or ``"onnx"`` (an ONNX Runtime session). Set by
+    ``from_dir(runtime=...)``; not user-assignable after construction."""
+
     # Just a constant we can use as a default value for kwargs,
     # to differentiate between user omitting a kwarg, vs explicitly passing None.
     UNSPECIFIED = "unspecified"
 
     @staticmethod
-    def from_dir(model_dir: str | Path, precision: _Precision = "fp32") -> Model:
+    def from_dir(
+        model_dir: str | Path,
+        precision: _Precision = "fp32",
+        runtime: str = "eager",
+        onnx_precision: _OnnxPrecision | None = None,
+    ) -> Model:
         """Create a `Model` instance for a model stored at `model_dir`.
 
         Args:
@@ -273,6 +300,16 @@ class Model:
                 ``litpose predict --precision`` CLI flag. Does not affect
                 the checkpoint itself -- weights stay fp32 on disk; this only
                 controls the precision used during the forward pass.
+            runtime: inference backend. ``"eager"`` (default) loads the trained
+                checkpoint as usual. ``"onnx"`` loads an ONNX Runtime session
+                from ``exports_onnx_dir()``, which must have been built with
+                ``model.export("onnx", ...)`` beforehand; ``precision`` is
+                ignored in that mode, since the exported file's own precision
+                is what runs.
+            onnx_precision: only used when ``runtime="onnx"``. Selects which
+                exported file to load. If omitted and exactly one export exists
+                for this checkpoint, it is used automatically; if more than one
+                exists, raises.
 
         Returns:
             Model ready for inference. Weights are loaded lazily on the first
@@ -287,13 +324,20 @@ class Model:
             Run inference in FP16:
             >>> model = Model.from_dir("outputs/2024-01-01/12-00-00", precision="fp16")
         """
-        return Model.from_dir2(model_dir, precision=precision)
+        return Model.from_dir2(
+            model_dir,
+            precision=precision,
+            runtime=runtime,
+            onnx_precision=onnx_precision,
+        )
 
     @staticmethod
     def from_dir2(
         model_dir: str | Path,
         hydra_overrides: list[str] | None = None,
         precision: _Precision = "fp32",
+        runtime: str = "eager",
+        onnx_precision: _OnnxPrecision | None = None,
     ) -> Model:
         """Internal version of from_dir that supports hydra_overrides. Not sure whether to
         promote this to public API yet."""
@@ -311,7 +355,17 @@ class Model:
         else:
             config = ModelConfig.from_yaml_file(model_dir / "config.yaml")
 
-        return Model(model_dir, config, precision=precision)
+        model = Model(model_dir, config, precision=precision)
+
+        if runtime == "eager":
+            return model
+        elif runtime == "onnx":
+            model._attach_onnx_runtime(onnx_precision)
+            return model
+        else:
+            raise ValueError(
+                f"Unsupported runtime: '{runtime}'. Use 'eager' or 'onnx'."
+            )
 
     def __init__(
         self, model_dir: str | Path, config: ModelConfig, precision: _Precision = "fp32"
@@ -367,6 +421,12 @@ class Model:
             >>> model.compile()
             >>> result = model.predict_on_video_file("path/to/video.mp4")
         """
+        if self._runtime != "eager":
+            raise RuntimeError(
+                f"compile() is only supported for runtime='eager', but this model was "
+                f"loaded with runtime='{self._runtime}'. torch.compile() has no effect "
+                f"on an ONNX Runtime session."
+            )
         if self._compiled:
             return
         _check_torch_compile_supported()
@@ -400,6 +460,222 @@ class Model:
                 skip_data_module=True,
             )
 
+    def _attach_onnx_runtime(self, onnx_precision: _OnnxPrecision | None) -> None:
+        """Replace the model's forward pass with an ONNX Runtime session.
+
+        Locates the export for this model's checkpoint inside
+        ``exports_onnx_dir()`` and rebinds ``self.model.forward`` to run through
+        it. Rebinding ``forward`` rather than wrapping the module keeps every
+        existing prediction path working, including those that call
+        ``get_loss_inputs_labeled`` directly instead of going through
+        ``__call__``.
+
+        Args:
+            onnx_precision: which export to load, or None to auto-select when
+                exactly one export exists for this checkpoint.
+
+        Raises:
+            FileNotFoundError: if no matching export exists.
+            ValueError: if multiple exports exist and ``onnx_precision`` is None.
+            RuntimeError: if the model fails to load, or if ONNX Runtime silently
+                fell back to CPU on a CUDA machine.
+        """
+        # Imported lazily: onnxruntime is an optional dependency, and a
+        # module-level import would make it mandatory for every eager user.
+        import onnxruntime as ort
+
+        self._load()
+        if self.model is None:
+            raise RuntimeError('model failed to load; self.model is None after _load()')
+
+        stem = self._ckpt_stem()
+        export_dir = self.exports_onnx_dir()
+        pattern = (
+            f"{stem}_{onnx_precision}.onnx"
+            if onnx_precision is not None
+            else f"{stem}_*.onnx"
+        )
+        candidates = sorted(export_dir.glob(pattern))
+
+        if len(candidates) == 0:
+            raise FileNotFoundError(
+                f"No ONNX export found for checkpoint '{stem}'"
+                + (f" with onnx_precision='{onnx_precision}'" if onnx_precision else "")
+                + f" in {export_dir}. Run model.export('onnx') first."
+            )
+        if len(candidates) > 1:
+            found = [c.name for c in candidates]
+            raise ValueError(
+                f"Multiple ONNX exports found: {found}. "
+                "Pass onnx_precision= to disambiguate."
+            )
+
+        onnx_path = candidates[0]
+        session = ort.InferenceSession(
+            str(onnx_path), providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+        )
+
+        # Guard against a silent fallback to CPU. onnxruntime does not raise if
+        # CUDAExecutionProvider fails to load (e.g. onnxruntime-gpu's CUDA/cuDNN
+        # major version doesn't match the installed PyTorch/CUDA) -- it just runs
+        # on CPU instead, which "works" but is drastically slower with no
+        # indication why. Fail loudly here instead.
+        providers = session.get_providers()
+        if torch.cuda.is_available() and "CUDAExecutionProvider" not in providers:
+            raise RuntimeError(
+                "ONNX Runtime failed to load CUDAExecutionProvider even though a CUDA "
+                "device is available -- inference would silently run on CPU instead. "
+                "This is usually a CUDA/cuDNN major version mismatch between "
+                "onnxruntime-gpu and your installed PyTorch. See the installation "
+                "section of docs/source/user_guide_advanced/increasing_inference_speed.rst "
+                "for how to check and fix this."
+            )
+
+        # Bind at the precision the exported graph declares, not a hardcoded
+        # fp32 -- an fp16 export rejects fp32 input buffers.
+        input_meta = session.get_inputs()[0]
+        input_name = input_meta.name
+        output_name = session.get_outputs()[0].name
+        input_np_dtype = _ORT_TYPE_TO_NUMPY[input_meta.type]
+        input_torch_dtype = torch.from_numpy(np.empty(0, dtype=input_np_dtype)).dtype
+        cuda_available = "CUDAExecutionProvider" in providers
+
+        def onnx_forward(images: torch.Tensor) -> torch.Tensor:
+            images = images.to(input_torch_dtype).contiguous()
+            if cuda_available and images.is_cuda:
+                # Zero-copy path: hand ORT the tensor's existing device pointer.
+                io_binding = session.io_binding()
+                device_id = images.device.index or 0
+                io_binding.bind_input(
+                    name=input_name,
+                    device_type="cuda",
+                    device_id=device_id,
+                    element_type=input_np_dtype,
+                    shape=tuple(images.shape),
+                    buffer_ptr=images.data_ptr(),
+                )
+                io_binding.bind_output(
+                    name=output_name, device_type="cuda", device_id=device_id
+                )
+                session.run_with_iobinding(io_binding)
+                output = io_binding.copy_outputs_to_cpu()[0]
+            else:
+                # CPU session, or a CPU input tensor on a CUDA-capable session.
+                output = session.run([output_name], {input_name: images.cpu().numpy()})[0]
+            return torch.from_numpy(output).to(images.device)
+
+        # Same rebinding pattern as compile(); see the note there on why the
+        # union-typed forward signature needs the ignore.
+        self.model.forward = onnx_forward  # type: ignore[method-assign]
+        self._runtime = "onnx"
+        logger.info(f'loaded ONNX runtime session from {onnx_path}')
+
+    def _ckpt_stem(self) -> str:
+        """Return the filename stem of this model's checkpoint.
+
+        Used to name and locate ONNX exports. Shared by ``export()`` and
+        ``_attach_onnx_runtime()`` so the two always agree on which checkpoint
+        an export corresponds to.
+
+        Raises:
+            FileNotFoundError: if no checkpoint file is found in ``model_dir``.
+        """
+        ckpt_file = io_utils.ckpt_path_from_base_path(
+            base_path=str(self.model_dir), model_name=self.cfg.model.model_name
+        )
+        if ckpt_file is None:
+            raise FileNotFoundError(
+                "Checkpoint file not found, have you trained for enough epochs?"
+            )
+        return Path(ckpt_file).stem
+
+    def export(self, runtime: str, onnx_precision: _OnnxPrecision = "fp16") -> Path:
+        """Export the model to an optimized inference format.
+
+        Currently supports ``runtime="onnx"``. Writes to a fixed location inside
+        the model directory (``exports_onnx_dir() / "{ckpt_stem}_{onnx_precision}.onnx"``)
+        and returns the path to the exported file. Export paths are not
+        user-configurable by design -- ``from_dir(runtime="onnx")`` reads from
+        this same location.
+
+        Args:
+            runtime: export target. Only ``"onnx"`` is currently supported.
+            onnx_precision: weight precision baked into the exported file, either
+                ``"fp32"`` or ``"fp16"``. Distinct from ``self.precision``, which
+                controls autocast precision for eager inference only.
+
+        Returns:
+            Path to the exported ``.onnx`` file.
+
+        Raises:
+            ValueError: if ``runtime`` or ``onnx_precision`` is unsupported.
+            FileNotFoundError: if no checkpoint file is found in ``model_dir``.
+            RuntimeError: if the model fails to load.
+
+        Examples:
+            >>> model = Model.from_dir("outputs/2024-01-01/12-00-00")
+            >>> model.export("onnx", onnx_precision="fp16")
+        """
+        if runtime != "onnx":
+            raise ValueError(
+                f"Unsupported export runtime: '{runtime}'. "
+                "Only 'onnx' is currently supported."
+            )
+        if onnx_precision not in ("fp32", "fp16"):
+            raise ValueError(
+                f"Unsupported onnx_precision: '{onnx_precision}'. Use 'fp32' or 'fp16'."
+            )
+
+        # Weights are lazy-loaded; tracing needs a real forward pass.
+        self._load()
+        if self.model is None:
+            raise RuntimeError('model failed to load; self.model is None after _load()')
+
+        onnx_path = self.exports_onnx_dir() / f"{self._ckpt_stem()}_{onnx_precision}.onnx"
+        onnx_path.parent.mkdir(parents=True, exist_ok=True)
+
+        resize_h = self.cfg.data.image_resize_dims.height
+        resize_w = self.cfg.data.image_resize_dims.width
+
+        # Dummy input shape depends on model type. Context models take a temporal
+        # stack and multiview models take a per-view stack; see predict_frame and
+        # predict_on_video_file_multiview for the corresponding runtime shapes.
+        if self.config.is_multi_view():
+            num_views = len(self.cfg.data.view_names)
+            shape = (1, num_views, 3, resize_h, resize_w)
+        elif self.model.do_context:
+            shape = (1, _CONTEXT_SEQUENCE_LENGTH, 3, resize_h, resize_w)
+        else:
+            shape = (1, 3, resize_h, resize_w)
+
+        # .half() mutates in place and returns self, so exporting fp16 from a
+        # live Model would silently leave self.model in half precision for any
+        # subsequent eager call. Trace a copy instead.
+        module_to_export = self.model
+        dummy = torch.randn(*shape, device=self.model.device)
+        if onnx_precision == "fp16":
+            module_to_export = copy.deepcopy(self.model).half()
+            dummy = dummy.half()
+
+        module_to_export.eval()
+        torch.onnx.export(
+            module_to_export,
+            dummy,
+            str(onnx_path),
+            input_names=["images"],
+            output_names=["heatmaps"],
+            dynamic_axes={"images": {0: "batch"}, "heatmaps": {0: "batch"}},
+            opset_version=17,
+            do_constant_folding=True,
+        )
+
+        if onnx_precision == "fp16":
+            del module_to_export
+            torch.cuda.empty_cache()
+
+        logger.info(f'exported {onnx_precision} ONNX model to {onnx_path}')
+        return onnx_path
+
     def image_preds_dir(self) -> Path:
         """Return the directory where image/CSV predictions are saved."""
         return self.model_dir / "image_preds"
@@ -419,6 +695,10 @@ class Model:
     def cropped_videos_dir(self) -> Path:
         """Return the directory where cropzoom-cropped videos are saved."""
         return self.model_dir / "cropped_videos"
+
+    def exports_onnx_dir(self) -> Path:
+        """Return the directory where ONNX exports are saved."""
+        return self.model_dir / "exports_onnx"
 
     def cropped_csv_file_path(self, csv_file_path: str | Path) -> Path:
         """Return the path where a cropzoom-adjusted CSV file will be saved.

--- a/lightning_pose/cli/commands/__init__.py
+++ b/lightning_pose/cli/commands/__init__.py
@@ -1,11 +1,12 @@
 """Command modules for the lightning-pose CLI."""
 
-from . import create_bbox, crop, predict, remap, run_app, smooth_bbox, train
+from . import create_bbox, crop, export, predict, remap, run_app, smooth_bbox, train
 
 # List of all available commands
 COMMANDS = {
     'train': train,
     'predict': predict,
+    'export': export,
     'create_bbox': create_bbox,
     'smooth_bbox': smooth_bbox,
     'crop': crop,

--- a/lightning_pose/cli/commands/export.py
+++ b/lightning_pose/cli/commands/export.py
@@ -1,0 +1,81 @@
+"""Export command for the lightning-pose CLI."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import textwrap
+from typing import Any
+
+from .. import types
+
+logger = logging.getLogger(__name__)
+
+# Export targets. Only ONNX today; TensorRT is a planned follow-up that will
+# consume the same .onnx artifact through a different execution provider.
+_RUNTIME_CHOICES = ("onnx",)
+
+# Weight precisions the exporter supports. Deliberately narrower than
+# --precision on `litpose predict`: this is the precision baked into the
+# exported file, not the autocast precision used for eager inference.
+_ONNX_PRECISION_CHOICES = ("fp32", "fp16")
+
+
+def register_parser(subparsers: Any) -> argparse.ArgumentParser:
+    """Register the export command parser."""
+    export_parser = subparsers.add_parser(
+        "export",
+        description=textwrap.dedent(
+            """\
+        Exports a trained model to an optimized inference format.
+
+          Exports are written to a fixed location inside the model directory::
+
+            <model_dir>/
+            └── exports_onnx/
+                └── <checkpoint_stem>_<onnx_precision>.onnx
+
+          The export path is not configurable. `litpose predict --runtime onnx`
+          reads from this same location.
+        """
+        ),
+        usage="litpose export <model_dir> [OPTIONS]",
+    )
+    export_parser.add_argument(
+        "model_dir", type=types.existing_model_dir, help="path to a model directory"
+    )
+    export_parser.add_argument(
+        "--runtime",
+        choices=sorted(_RUNTIME_CHOICES),
+        default="onnx",
+        help="inference format to export to. Default: onnx.",
+    )
+    export_parser.add_argument(
+        "--onnx-precision",
+        choices=sorted(_ONNX_PRECISION_CHOICES),
+        default="fp16",
+        help=(
+            "weight precision baked into the exported file. Unlike "
+            "`litpose predict --precision`, this changes the exported weights "
+            "themselves rather than the precision of a forward pass. "
+            "Default: fp16."
+        ),
+    )
+    return export_parser
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Return an ArgumentParser for the `litpose export` subcommand (for docs)."""
+    parser = argparse.ArgumentParser(prog="litpose")
+    subparsers = parser.add_subparsers(dest="command")
+    return register_parser(subparsers)
+
+
+def handle(args: argparse.Namespace) -> None:
+    """Handle the export command."""
+    # Delay this import because it's slow.
+    from lightning_pose.api import Model
+
+    model = Model.from_dir(args.model_dir)
+    output_path = model.export(args.runtime, onnx_precision=args.onnx_precision)
+    logger.info(f'export written to {output_path}')

--- a/lightning_pose/cli/commands/predict.py
+++ b/lightning_pose/cli/commands/predict.py
@@ -22,6 +22,15 @@ if TYPE_CHECKING:
 # strings PyTorch Lightning's Trainer actually expects.
 _PRECISION_CHOICES = ("fp32", "fp16", "bf16")
 
+# Inference backends accepted by --runtime. "eager" runs the loaded PyTorch
+# checkpoint; "onnx" runs an ONNX Runtime session previously built with
+# `litpose export`.
+_RUNTIME_CHOICES = ("eager", "onnx")
+
+# Selects which exported file --runtime onnx loads. Distinct from --precision:
+# this is the precision baked into the .onnx file, not autocast precision.
+_ONNX_PRECISION_CHOICES = ("fp32", "fp16")
+
 
 def register_parser(subparsers: Any) -> argparse.ArgumentParser:
     """Register the predict command parser."""
@@ -110,6 +119,29 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
     )
 
     predict_parser.add_argument(
+        "--runtime",
+        choices=sorted(_RUNTIME_CHOICES),
+        default="eager",
+        help=(
+            "inference backend. 'eager' (default) runs the trained checkpoint. "
+            "'onnx' runs an ONNX Runtime session, which must have been built "
+            "first with `litpose export`. With --runtime onnx, --precision is "
+            "ignored -- the exported file's own precision is what runs."
+        ),
+    )
+
+    predict_parser.add_argument(
+        "--onnx-precision",
+        choices=sorted(_ONNX_PRECISION_CHOICES),
+        default=None,
+        help=(
+            "which ONNX export to load. Only used with --runtime onnx. If "
+            "omitted and exactly one export exists, it is used automatically; "
+            "if several exist, pass this to disambiguate."
+        ),
+    )
+
+    predict_parser.add_argument(
         "--compile",
         action="store_true",
         default=False,
@@ -145,10 +177,22 @@ def handle(args: argparse.Namespace) -> None:
     # Delay this import because it's slow.
     from lightning_pose.api import Model
 
+    # Checked before constructing the model so the user gets this message rather
+    # than the equivalent RuntimeError from Model.compile(), which would surface
+    # as a raw traceback well after the ONNX session had already been built.
+    if args.compile and args.runtime != "eager":
+        raise ValueError(
+            f"--compile is only supported with --runtime eager, but --runtime "
+            f"{args.runtime} was given. torch.compile() has no effect on an "
+            f"ONNX Runtime session."
+        )
+
     model = Model.from_dir2(
         args.model_dir,
         hydra_overrides=args.overrides,
         precision=args.precision,
+        runtime=args.runtime,
+        onnx_precision=args.onnx_precision,
     )
     input_paths = [Path(p) for p in args.input_path]
 

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -1,5 +1,6 @@
 import copy
 import shutil
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -688,6 +689,22 @@ class TestOnnxRuntime:
             patch("onnxruntime.InferenceSession", return_value=fake_session),
             patch("torch.cuda.is_available", return_value=True),
             pytest.raises(RuntimeError, match="CUDAExecutionProvider"),
+        ):
+            Model.from_dir(model.model_dir, runtime="onnx")
+
+    def test_missing_onnxruntime_raises_install_hint(self, tmp_path, request):
+        """A missing optional dependency explains how to install it.
+
+        Simulated rather than skipped, so the message is covered on machines
+        that do have onnxruntime.
+        """
+        model = _setup_test_model(tmp_path, request)
+        model.exports_onnx_dir().mkdir(parents=True, exist_ok=True)
+        (model.exports_onnx_dir() / f"{model._ckpt_stem()}_fp16.onnx").touch()
+
+        with (
+            patch.dict(sys.modules, {"onnxruntime": None}),
+            pytest.raises(ImportError, match="pip install onnxruntime-gpu"),
         ):
             Model.from_dir(model.model_dir, runtime="onnx")
 

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -512,3 +512,217 @@ class TestCompile:
         model.predict_frame(frame)
         # ... and predict_on_label_csv runs the configured batch size.
         model.predict_on_label_csv(Path(toy_data_dir) / "CollectedData.csv")
+
+
+def _onnxruntime_available() -> bool:
+    """Whether the optional onnxruntime dependency is importable."""
+    try:
+        import onnxruntime  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+requires_onnxruntime = pytest.mark.skipif(
+    not _onnxruntime_available(),
+    reason=(
+        "onnxruntime is an optional dependency. Export and runtime tests need it "
+        "installed; see docs/source/user_guide_advanced/increasing_inference_speed.rst."
+    ),
+)
+
+
+class TestExport:
+    """Test the export method."""
+
+    pytestmark = pytest.mark.gpu
+
+    def test_export_rejects_unknown_runtime(self, tmp_path, request):
+        """export() rejects a runtime other than 'onnx' before loading anything."""
+        model = _setup_test_model(tmp_path, request)
+        with pytest.raises(ValueError, match="Unsupported export runtime"):
+            model.export("tensorrt")
+        assert model.model is None
+
+    def test_export_rejects_unknown_onnx_precision(self, tmp_path, request):
+        """export() rejects bf16, which ONNX export does not support."""
+        model = _setup_test_model(tmp_path, request)
+        with pytest.raises(ValueError, match="Unsupported onnx_precision"):
+            model.export("onnx", onnx_precision="bf16")
+        assert model.model is None
+
+    @requires_onnxruntime
+    @pytest.mark.parametrize("onnx_precision", ["fp32", "fp16"])
+    def test_export_writes_expected_path(self, tmp_path, request, onnx_precision):
+        """export() writes {ckpt_stem}_{onnx_precision}.onnx into exports_onnx/."""
+        model = _setup_test_model(tmp_path, request)
+        output_path = model.export("onnx", onnx_precision=onnx_precision)
+
+        assert output_path.is_file()
+        assert output_path.parent == model.exports_onnx_dir()
+        assert output_path.parent == model.model_dir / "exports_onnx"
+        assert output_path.name == f"{model._ckpt_stem()}_{onnx_precision}.onnx"
+        assert output_path.stat().st_size > 0
+
+    @requires_onnxruntime
+    def test_export_loads_model_lazily(self, tmp_path, request):
+        """export() loads the checkpoint itself, so it works before any prediction."""
+        model = _setup_test_model(tmp_path, request)
+        assert model.model is None
+        model.export("onnx", onnx_precision="fp32")
+        assert model.model is not None
+
+    @requires_onnxruntime
+    def test_export_works_when_weights_already_loaded(self, tmp_path, request):
+        """export() is unaffected by whether _load() already ran (lazy-load interaction)."""
+        model = _setup_test_model(tmp_path, request)
+        model._load()
+        assert model.model is not None
+        output_path = model.export("onnx", onnx_precision="fp32")
+        assert output_path.is_file()
+
+    @requires_onnxruntime
+    def test_fp16_export_leaves_live_model_in_fp32(self, tmp_path, request):
+        """An fp16 export must not half() the in-memory model.
+
+        torch's .half() mutates in place and returns self, so tracing the live
+        module would silently leave every subsequent eager call running in half
+        precision. export() traces a copy instead.
+        """
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp16")
+
+        assert model.model is not None
+        dtypes = {p.dtype for p in model.model.parameters()}
+        assert dtypes == {torch.float32}, f"live model was mutated to {dtypes}"
+
+    @requires_onnxruntime
+    def test_export_multiview(self, tmp_path, request):
+        """A multiview model exports with its per-view dummy input shape."""
+        model = _setup_test_model(tmp_path, request, multiview=True)
+        output_path = model.export("onnx", onnx_precision="fp32")
+        assert output_path.is_file()
+        assert output_path.stat().st_size > 0
+
+
+class TestOnnxRuntime:
+    """Test loading a model with runtime='onnx'."""
+
+    pytestmark = pytest.mark.gpu
+
+    def test_from_dir_rejects_unknown_runtime(self, tmp_path, request):
+        """from_dir() rejects a runtime other than 'eager' or 'onnx'."""
+        model = _setup_test_model(tmp_path, request)
+        with pytest.raises(ValueError, match="Unsupported runtime"):
+            Model.from_dir(model.model_dir, runtime="tensorrt")
+
+    def test_from_dir_raises_when_no_export_exists(self, tmp_path, request):
+        """runtime='onnx' with no export points the user at export()."""
+        model = _setup_test_model(tmp_path, request)
+        with pytest.raises(FileNotFoundError, match=r"Run model\.export\('onnx'\) first"):
+            Model.from_dir(model.model_dir, runtime="onnx")
+
+    @requires_onnxruntime
+    def test_from_dir_auto_selects_sole_export(self, tmp_path, request):
+        """onnx_precision may be omitted when exactly one export exists."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp32")
+
+        onnx_model = Model.from_dir(model.model_dir, runtime="onnx")
+        assert onnx_model._runtime == "onnx"
+
+    @requires_onnxruntime
+    def test_from_dir_raises_when_multiple_exports_exist(self, tmp_path, request):
+        """Ambiguous exports raise rather than picking one arbitrarily."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp32")
+        model.export("onnx", onnx_precision="fp16")
+
+        with pytest.raises(ValueError, match="Multiple ONNX exports found"):
+            Model.from_dir(model.model_dir, runtime="onnx")
+
+    @requires_onnxruntime
+    def test_from_dir_selects_requested_precision(self, tmp_path, request):
+        """onnx_precision disambiguates when several exports exist."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp32")
+        model.export("onnx", onnx_precision="fp16")
+
+        onnx_model = Model.from_dir(
+            model.model_dir, runtime="onnx", onnx_precision="fp16"
+        )
+        assert onnx_model._runtime == "onnx"
+
+    @requires_onnxruntime
+    def test_export_and_load_agree_on_checkpoint(self, tmp_path, request):
+        """Loading finds exactly the file exporting produced.
+
+        Both sides resolve the checkpoint through io_utils.ckpt_path_from_base_path
+        via _ckpt_stem(); this pins that they cannot drift apart.
+        """
+        model = _setup_test_model(tmp_path, request)
+        exported = model.export("onnx", onnx_precision="fp32")
+
+        loaded = Model.from_dir(model.model_dir, runtime="onnx")
+        found = sorted(loaded.exports_onnx_dir().glob(f"{loaded._ckpt_stem()}_*.onnx"))
+        assert found == [exported]
+
+    def test_provider_guard_raises_on_silent_cpu_fallback(self, tmp_path, request):
+        """A CUDA machine that loses CUDAExecutionProvider must fail loudly.
+
+        onnxruntime falls back to CPU without raising, which "works" but is
+        drastically slower with no indication why. Mocked rather than skipped so
+        the guard is covered even where CUDA is genuinely available.
+        """
+        pytest.importorskip("onnxruntime")
+        model = _setup_test_model(tmp_path, request)
+
+        # A stub export file is enough -- the session is mocked out below.
+        model.exports_onnx_dir().mkdir(parents=True, exist_ok=True)
+        (model.exports_onnx_dir() / f"{model._ckpt_stem()}_fp16.onnx").touch()
+
+        fake_session = MagicMock()
+        fake_session.get_providers.return_value = ["CPUExecutionProvider"]
+
+        with (
+            patch("onnxruntime.InferenceSession", return_value=fake_session),
+            patch("torch.cuda.is_available", return_value=True),
+            pytest.raises(RuntimeError, match="CUDAExecutionProvider"),
+        ):
+            Model.from_dir(model.model_dir, runtime="onnx")
+
+    @requires_onnxruntime
+    def test_compile_raises_on_onnx_runtime(self, tmp_path, request):
+        """compile() is rejected on an ONNX-backed model rather than silently no-op."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp32")
+
+        onnx_model = Model.from_dir(model.model_dir, runtime="onnx")
+        with pytest.raises(RuntimeError, match="only supported for runtime='eager'"):
+            onnx_model.compile()
+        assert not onnx_model._compiled
+
+    @requires_onnxruntime
+    def test_onnx_matches_eager_predictions(self, tmp_path, request, toy_data_dir):
+        """fp32 ONNX predictions match eager ones to well under a pixel.
+
+        Separate tmp_path subdirectories because _setup_test_model copies the
+        model tree and asserts no prediction outputs exist yet.
+        """
+        csv_file = Path(toy_data_dir) / "CollectedData.csv"
+
+        eager_model = _setup_test_model(tmp_path / "eager", request)
+        onnx_source = _setup_test_model(tmp_path / "onnx", request)
+        onnx_source.export("onnx", onnx_precision="fp32")
+        onnx_model = Model.from_dir(onnx_source.model_dir, runtime="onnx")
+
+        eager_preds = eager_model.predict_on_label_csv(csv_file).predictions
+        onnx_preds = onnx_model.predict_on_label_csv(csv_file).predictions
+
+        xy_cols = [c for c in eager_preds.columns if c[-1] in ("x", "y")]
+        deviation = np.abs(
+            eager_preds[xy_cols].to_numpy(dtype=float)
+            - onnx_preds[xy_cols].to_numpy(dtype=float)
+        )
+        max_deviation = np.nanmax(deviation)
+        assert max_deviation < 0.1, f"max pixel deviation {max_deviation:.4f} >= 0.1"

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -615,7 +615,7 @@ class TestOnnxRuntime:
         """from_dir() rejects a runtime other than 'eager' or 'onnx'."""
         model = _setup_test_model(tmp_path, request)
         with pytest.raises(ValueError, match="Unsupported runtime"):
-            Model.from_dir(model.model_dir, runtime="tensorrt")
+            Model.from_dir(model.model_dir, runtime="tensorrt")  # type: ignore[arg-type]
 
     def test_from_dir_raises_when_no_export_exists(self, tmp_path, request):
         """runtime='onnx' with no export points the user at export()."""
@@ -704,7 +704,7 @@ class TestOnnxRuntime:
 
         with (
             patch.dict(sys.modules, {"onnxruntime": None}),
-            pytest.raises(ImportError, match="pip install onnxruntime-gpu"),
+            pytest.raises(ImportError, match="increasing_inference_speed"),
         ):
             Model.from_dir(model.model_dir, runtime="onnx")
 
@@ -914,7 +914,7 @@ class TestOnnxRuntimeUnit:
         self._prepare_export(model)
         with (
             patch.dict(sys.modules, {"onnxruntime": None}),
-            pytest.raises(ImportError, match="pip install onnxruntime-gpu"),
+            pytest.raises(ImportError, match="increasing_inference_speed"),
         ):
             model._attach_onnx_runtime(None)
 

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -743,3 +743,238 @@ class TestOnnxRuntime:
         )
         max_deviation = np.nanmax(deviation)
         assert max_deviation < 0.1, f"max pixel deviation {max_deviation:.4f} >= 0.1"
+
+
+def _make_mock_model(tmp_path, *, multiview=False, context=False, num_views=2):
+    """A Model with mocked config and weights, usable without a GPU or onnxruntime.
+
+    ``model`` is set directly so ``_load()`` short-circuits, letting the export
+    and runtime code paths be exercised without a real checkpoint.
+    """
+    config = MagicMock()
+    config.is_multi_view.return_value = multiview
+    config.cfg.data.image_resize_dims.height = 128
+    config.cfg.data.image_resize_dims.width = 128
+    config.cfg.data.view_names = [f"view{i}" for i in range(num_views)]
+    config.cfg.model.model_name = "test_model"
+
+    model = Model(tmp_path, config)
+    model.model = MagicMock()
+    model.model.device = torch.device("cpu")
+    model.model.do_context = context
+    return model
+
+
+def _fake_ort(providers=("CUDAExecutionProvider", "CPUExecutionProvider"),
+              input_type="tensor(float)", output=None):
+    """Stand-in onnxruntime module whose InferenceSession returns a MagicMock.
+
+    Lets the ONNX runtime code path be tested on machines without onnxruntime
+    installed -- which includes CI, where the real dependency is absent and the
+    @requires_onnxruntime tests above are skipped.
+    """
+    session = MagicMock()
+    session.get_providers.return_value = list(providers)
+
+    inp = MagicMock()
+    inp.name = "images"
+    inp.type = input_type
+    session.get_inputs.return_value = [inp]
+
+    out = MagicMock()
+    out.name = "heatmaps"
+    session.get_outputs.return_value = [out]
+
+    if output is None:
+        output = np.zeros((1, 2, 4, 4), dtype=np.float32)
+    session.run.return_value = [output]
+
+    module = MagicMock()
+    module.InferenceSession.return_value = session
+    return module, session
+
+
+@pytest.fixture()
+def mock_ckpt():
+    """Pin checkpoint resolution to a fixed stem without touching the filesystem."""
+    with patch(
+        "lightning_pose.api.model.io_utils.ckpt_path_from_base_path",
+        return_value="/some/dir/epoch=1-step=2-best.ckpt",
+    ):
+        yield
+
+
+class TestExportUnit:
+    """Export tests that need neither a GPU nor onnxruntime.
+
+    The @requires_onnxruntime tests above are skipped wherever the optional
+    dependency isn't installed, which leaves export() uncovered on CI. These
+    mock torch.onnx.export instead so the logic around it stays covered.
+    """
+
+    def test_ckpt_stem_raises_when_no_checkpoint(self, tmp_path):
+        """An untrained model directory gets a clear error, not a TypeError."""
+        model = _make_mock_model(tmp_path)
+        with (
+            patch(
+                "lightning_pose.api.model.io_utils.ckpt_path_from_base_path",
+                return_value=None,
+            ),
+            pytest.raises(FileNotFoundError, match="Checkpoint file not found"),
+        ):
+            model._ckpt_stem()
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_shape",
+        [
+            ({}, (1, 3, 128, 128)),
+            ({"multiview": True}, (1, 2, 3, 128, 128)),
+            ({"context": True}, (1, 5, 3, 128, 128)),
+        ],
+        ids=["singleview", "multiview", "context"],
+    )
+    def test_export_dummy_input_shape(self, tmp_path, mock_ckpt, kwargs, expected_shape):
+        """Dummy input shape differs across singleview, multiview and context models."""
+        model = _make_mock_model(tmp_path, **kwargs)
+        with patch("torch.onnx.export") as mock_export:
+            model.export("onnx", onnx_precision="fp32")
+        dummy = mock_export.call_args.args[1]
+        assert tuple(dummy.shape) == expected_shape
+
+    def test_export_returns_path_under_exports_onnx_dir(self, tmp_path, mock_ckpt):
+        """The returned path is {ckpt_stem}_{onnx_precision}.onnx inside exports_onnx/."""
+        model = _make_mock_model(tmp_path)
+        with patch("torch.onnx.export"):
+            output_path = model.export("onnx", onnx_precision="fp32")
+        assert output_path == model.exports_onnx_dir() / "epoch=1-step=2-best_fp32.onnx"
+        assert model.exports_onnx_dir().is_dir()
+
+    def test_export_fp16_traces_a_copy_not_the_live_model(self, tmp_path, mock_ckpt):
+        """fp16 export halves a deepcopy, leaving the in-memory model alone."""
+        model = _make_mock_model(tmp_path)
+        original = model.model
+        with patch("torch.onnx.export") as mock_export:
+            model.export("onnx", onnx_precision="fp16")
+        traced = mock_export.call_args.args[0]
+        dummy = mock_export.call_args.args[1]
+        assert dummy.dtype == torch.float16
+        assert traced is not original
+        assert model.model is original
+
+    def test_export_fp32_traces_the_live_model(self, tmp_path, mock_ckpt):
+        """fp32 export needs no copy, so it traces the module directly."""
+        model = _make_mock_model(tmp_path)
+        with patch("torch.onnx.export") as mock_export:
+            model.export("onnx", onnx_precision="fp32")
+        assert mock_export.call_args.args[0] is model.model
+        assert mock_export.call_args.args[1].dtype == torch.float32
+
+    def test_export_raises_when_model_fails_to_load(self, tmp_path, mock_ckpt):
+        """A model that stays None after _load() raises rather than crashing later."""
+        model = _make_mock_model(tmp_path)
+        model.model = None
+        with (
+            patch.object(model, "_load"),
+            pytest.raises(RuntimeError, match="model failed to load"),
+        ):
+            model.export("onnx")
+
+
+class TestOnnxRuntimeUnit:
+    """Runtime-attach tests using a fake onnxruntime module.
+
+    Same rationale as TestExportUnit: keeps _attach_onnx_runtime covered where
+    the real dependency isn't installed.
+    """
+
+    def _prepare_export(self, model, precision="fp16"):
+        """Create a stub .onnx file matching the mocked checkpoint stem."""
+        model.exports_onnx_dir().mkdir(parents=True, exist_ok=True)
+        path = model.exports_onnx_dir() / f"epoch=1-step=2-best_{precision}.onnx"
+        path.touch()
+        return path
+
+    def test_attach_raises_when_no_export(self, tmp_path, mock_ckpt):
+        """Missing export points at export(), without importing onnxruntime."""
+        model = _make_mock_model(tmp_path)
+        with pytest.raises(FileNotFoundError, match=r"Run model\.export\('onnx'\) first"):
+            model._attach_onnx_runtime(None)
+
+    def test_attach_raises_when_multiple_exports(self, tmp_path, mock_ckpt):
+        """Ambiguous exports raise instead of picking one arbitrarily."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_export(model, "fp16")
+        self._prepare_export(model, "fp32")
+        with pytest.raises(ValueError, match="Multiple ONNX exports found"):
+            model._attach_onnx_runtime(None)
+
+    def test_attach_missing_dependency_explains_install(self, tmp_path, mock_ckpt):
+        """A missing optional dependency explains how to install it."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_export(model)
+        with (
+            patch.dict(sys.modules, {"onnxruntime": None}),
+            pytest.raises(ImportError, match="pip install onnxruntime-gpu"),
+        ):
+            model._attach_onnx_runtime(None)
+
+    def test_attach_provider_guard_fires_on_cpu_fallback(self, tmp_path, mock_ckpt):
+        """Losing CUDAExecutionProvider on a CUDA machine raises, not silently CPU."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_export(model)
+        fake_module, _ = _fake_ort(providers=["CPUExecutionProvider"])
+        with (
+            patch.dict(sys.modules, {"onnxruntime": fake_module}),
+            patch("torch.cuda.is_available", return_value=True),
+            pytest.raises(RuntimeError, match="CUDAExecutionProvider"),
+        ):
+            model._attach_onnx_runtime(None)
+
+    def test_attach_sets_runtime_and_rebinds_forward(self, tmp_path, mock_ckpt):
+        """Successful attach marks _runtime and replaces forward."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_export(model)
+        original_forward = model.model.forward
+        fake_module, _ = _fake_ort()
+        with patch.dict(sys.modules, {"onnxruntime": fake_module}):
+            model._attach_onnx_runtime(None)
+        assert model._runtime == "onnx"
+        assert model.model.forward is not original_forward
+
+    def test_onnx_forward_runs_through_session(self, tmp_path, mock_ckpt):
+        """The rebound forward feeds the session and returns a tensor."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_export(model)
+        fake_module, session = _fake_ort()
+        with patch.dict(sys.modules, {"onnxruntime": fake_module}):
+            model._attach_onnx_runtime(None)
+
+        result = model.model.forward(torch.randn(1, 3, 128, 128))
+        session.run.assert_called_once()
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == (1, 2, 4, 4)
+
+    def test_onnx_forward_casts_input_to_export_dtype(self, tmp_path, mock_ckpt):
+        """An fp16 export receives fp16 buffers, not hardcoded fp32."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_export(model)
+        fake_module, session = _fake_ort(
+            input_type="tensor(float16)",
+            output=np.zeros((1, 2, 4, 4), dtype=np.float16),
+        )
+        with patch.dict(sys.modules, {"onnxruntime": fake_module}):
+            model._attach_onnx_runtime(None)
+
+        model.model.forward(torch.randn(1, 3, 128, 128))
+        fed = session.run.call_args.args[1]["images"]
+        assert fed.dtype == np.float16
+
+    def test_attach_selects_requested_precision(self, tmp_path, mock_ckpt):
+        """onnx_precision picks a specific file when several exist."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_export(model, "fp16")
+        fp32_path = self._prepare_export(model, "fp32")
+        fake_module, _ = _fake_ort()
+        with patch.dict(sys.modules, {"onnxruntime": fake_module}):
+            model._attach_onnx_runtime("fp32")
+        assert fake_module.InferenceSession.call_args.args[0] == str(fp32_path)

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -518,7 +518,7 @@ class TestCompile:
 def _onnxruntime_available() -> bool:
     """Whether the optional onnxruntime dependency is importable."""
     try:
-        import onnxruntime  # noqa: F401
+        import onnxruntime  # noqa: F401  # type: ignore[import-not-found]
     except ImportError:
         return False
     return True
@@ -549,7 +549,7 @@ class TestExport:
         """export() rejects bf16, which ONNX export does not support."""
         model = _setup_test_model(tmp_path, request)
         with pytest.raises(ValueError, match="Unsupported onnx_precision"):
-            model.export("onnx", onnx_precision="bf16")
+            model.export("onnx", onnx_precision="bf16")  # type: ignore[arg-type]
         assert model.model is None
 
     @requires_onnxruntime
@@ -838,7 +838,7 @@ class TestExportUnit:
         model = _make_mock_model(tmp_path, **kwargs)
         with patch("torch.onnx.export") as mock_export:
             model.export("onnx", onnx_precision="fp32")
-        dummy = mock_export.call_args.args[1]
+        dummy = mock_export.call_args.args[1][0]
         assert tuple(dummy.shape) == expected_shape
 
     def test_export_returns_path_under_exports_onnx_dir(self, tmp_path, mock_ckpt):
@@ -856,7 +856,7 @@ class TestExportUnit:
         with patch("torch.onnx.export") as mock_export:
             model.export("onnx", onnx_precision="fp16")
         traced = mock_export.call_args.args[0]
-        dummy = mock_export.call_args.args[1]
+        dummy = mock_export.call_args.args[1][0]
         assert dummy.dtype == torch.float16
         assert traced is not original
         assert model.model is original
@@ -867,7 +867,7 @@ class TestExportUnit:
         with patch("torch.onnx.export") as mock_export:
             model.export("onnx", onnx_precision="fp32")
         assert mock_export.call_args.args[0] is model.model
-        assert mock_export.call_args.args[1].dtype == torch.float32
+        assert mock_export.call_args.args[1][0].dtype == torch.float32
 
     def test_export_raises_when_model_fails_to_load(self, tmp_path, mock_ckpt):
         """A model that stays None after _load() raises rather than crashing later."""
@@ -934,6 +934,7 @@ class TestOnnxRuntimeUnit:
         """Successful attach marks _runtime and replaces forward."""
         model = _make_mock_model(tmp_path)
         self._prepare_export(model)
+        assert model.model is not None
         original_forward = model.model.forward
         fake_module, _ = _fake_ort()
         with patch.dict(sys.modules, {"onnxruntime": fake_module}):
@@ -949,7 +950,8 @@ class TestOnnxRuntimeUnit:
         with patch.dict(sys.modules, {"onnxruntime": fake_module}):
             model._attach_onnx_runtime(None)
 
-        result = model.model.forward(torch.randn(1, 3, 128, 128))
+        assert model.model is not None
+        result = model.model.forward(torch.randn(1, 3, 128, 128))  # type: ignore[arg-type]
         session.run.assert_called_once()
         assert isinstance(result, torch.Tensor)
         assert result.shape == (1, 2, 4, 4)
@@ -965,7 +967,8 @@ class TestOnnxRuntimeUnit:
         with patch.dict(sys.modules, {"onnxruntime": fake_module}):
             model._attach_onnx_runtime(None)
 
-        model.model.forward(torch.randn(1, 3, 128, 128))
+        assert model.model is not None
+        model.model.forward(torch.randn(1, 3, 128, 128))  # type: ignore[arg-type]
         fed = session.run.call_args.args[1]["images"]
         assert fed.dtype == np.float16
 

--- a/tests/cli/test_export.py
+++ b/tests/cli/test_export.py
@@ -1,0 +1,117 @@
+"""Test the export CLI command argument parsing."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lightning_pose.cli.commands.export import get_parser, handle
+
+
+class TestGetParser:
+    """Test the get_parser function."""
+
+    def test_returns_argument_parser(self):
+        """Returns an ArgumentParser instance."""
+        assert isinstance(get_parser(), argparse.ArgumentParser)
+
+    def test_prog_is_litpose_export(self):
+        """Returned parser has prog set to 'litpose export'."""
+        assert get_parser().prog == 'litpose export'
+
+
+class TestExportParser:
+    """Test the export subcommand argument parsing."""
+
+    def test_valid_args(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['export', str(model_dir)])
+        assert args.model_dir == model_dir
+
+    def test_missing_model_dir_exits(self, parser, tmp_path):
+        with pytest.raises(SystemExit):
+            parser.parse_args(['export', str(tmp_path / 'missing')])
+
+    def test_runtime_default_is_onnx(self, parser, tmp_path):
+        """--runtime defaults to onnx, the only supported target today."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['export', str(model_dir)])
+        assert args.runtime == 'onnx'
+
+    def test_runtime_rejects_tensorrt(self, parser, tmp_path):
+        """TensorRT is a planned follow-up and must not parse yet."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        with pytest.raises(SystemExit):
+            parser.parse_args(['export', str(model_dir), '--runtime', 'tensorrt'])
+
+    def test_onnx_precision_default_is_fp16(self, parser, tmp_path):
+        """--onnx-precision defaults to fp16."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['export', str(model_dir)])
+        assert args.onnx_precision == 'fp16'
+
+    def test_onnx_precision_fp32(self, parser, tmp_path):
+        """--onnx-precision fp32 is parsed into onnx_precision."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['export', str(model_dir), '--onnx-precision', 'fp32']
+        )
+        assert args.onnx_precision == 'fp32'
+
+    def test_onnx_precision_rejects_bf16(self, parser, tmp_path):
+        """bf16 is valid for `predict --precision` but not for ONNX export."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                ['export', str(model_dir), '--onnx-precision', 'bf16']
+            )
+
+
+class TestHandle:
+    """Test the handle function."""
+
+    @pytest.fixture
+    def mock_model(self):
+        """Mock Model returned by Model.from_dir."""
+        return MagicMock()
+
+    def _make_args(self, tmp_path, runtime='onnx', onnx_precision='fp16'):
+        return argparse.Namespace(
+            model_dir=tmp_path / 'model',
+            runtime=runtime,
+            onnx_precision=onnx_precision,
+        )
+
+    def test_handle_calls_export(self, tmp_path, mock_model):
+        """handle() forwards runtime and onnx_precision to Model.export."""
+        args = self._make_args(tmp_path)
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        mock_model.export.assert_called_once_with('onnx', onnx_precision='fp16')
+
+    def test_handle_passes_fp32(self, tmp_path, mock_model):
+        """handle() honors --onnx-precision fp32."""
+        args = self._make_args(tmp_path, onnx_precision='fp32')
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        mock_model.export.assert_called_once_with('onnx', onnx_precision='fp32')
+
+    def test_handle_loads_model_eagerly(self, tmp_path, mock_model):
+        """handle() loads the model with the default eager runtime, not runtime=onnx.
+
+        Exporting reads the trained checkpoint; loading through an ONNX session
+        here would be circular.
+        """
+        args = self._make_args(tmp_path)
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        MockModel.from_dir.assert_called_once_with(args.model_dir)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -18,7 +18,8 @@ class TestBuildParser:
             a for a in parser._actions if hasattr(a, '_name_parser_map')
         )
         assert set(subparsers_action._name_parser_map.keys()) == {  # type: ignore[attr-defined]
-            'train', 'predict', 'create_bbox', 'smooth_bbox', 'crop', 'remap', 'run_app',
+            'train', 'predict', 'export', 'create_bbox', 'smooth_bbox', 'crop', 'remap',
+            'run_app',
         }
 
     def test_build_parser_has_debug_flag(self):

--- a/tests/cli/test_predict.py
+++ b/tests/cli/test_predict.py
@@ -65,11 +65,57 @@ class TestPredictParser:
         args = parser.parse_args(['predict', str(model_dir), 'video.mp4', '--compile'])
         assert args.compile
 
-    def test_compile_default_is_false(self, parser, tmp_path):
+
+    def test_runtime_default_is_eager(self, parser, tmp_path):
+        """--runtime defaults to eager."""
         model_dir = tmp_path / 'model'
         model_dir.mkdir()
         args = parser.parse_args(['predict', str(model_dir), 'video.mp4'])
-        assert not args.compile
+        assert args.runtime == 'eager'
+
+    def test_runtime_onnx(self, parser, tmp_path):
+        """--runtime onnx is parsed."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['predict', str(model_dir), 'video.mp4', '--runtime', 'onnx']
+        )
+        assert args.runtime == 'onnx'
+
+    def test_runtime_rejects_unknown_value(self, parser, tmp_path):
+        """--runtime tensorrt exits; TensorRT is a planned follow-up, not supported."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                ['predict', str(model_dir), 'video.mp4', '--runtime', 'tensorrt']
+            )
+
+    def test_onnx_precision_default_is_none(self, parser, tmp_path):
+        """--onnx-precision defaults to None so a sole export is auto-selected."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['predict', str(model_dir), 'video.mp4'])
+        assert args.onnx_precision is None
+
+    def test_onnx_precision_arg(self, parser, tmp_path):
+        """--onnx-precision is parsed into onnx_precision."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args([
+            'predict', str(model_dir), 'video.mp4',
+            '--runtime', 'onnx', '--onnx-precision', 'fp16',
+        ])
+        assert args.onnx_precision == 'fp16'
+
+    def test_onnx_precision_rejects_bf16(self, parser, tmp_path):
+        """bf16 is valid for --precision but not for --onnx-precision."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        with pytest.raises(SystemExit):
+            parser.parse_args([
+                'predict', str(model_dir), 'video.mp4', '--onnx-precision', 'bf16',
+            ])
 
     def test_overrides(self, parser, tmp_path):
         model_dir = tmp_path / 'model'
@@ -180,6 +226,8 @@ class TestHandle:
             bbox_dir=bbox_dir,
             precision='fp32',
             compile=False,
+            runtime='eager',
+            onnx_precision=None,
         )
 
     def test_handle_threads_bbox_dir_to_predict_multi_type(self, tmp_path, mock_model):
@@ -246,3 +294,50 @@ class TestHandle:
             MockModel.from_dir2.return_value = mock_model
             handle(args)
         mock_model.compile.assert_called_once_with()
+
+    def test_handle_threads_runtime_to_from_dir2(self, tmp_path, mock_model):
+        """handle() forwards --runtime and --onnx-precision to Model.from_dir2."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        args.runtime = 'onnx'
+        args.onnx_precision = 'fp16'
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.cli.commands.predict._predict_multi_type'),
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            handle(args)
+        call_kwargs = MockModel.from_dir2.call_args.kwargs
+        assert call_kwargs['runtime'] == 'onnx'
+        assert call_kwargs['onnx_precision'] == 'fp16'
+
+    def test_handle_defaults_to_eager_runtime(self, tmp_path, mock_model):
+        """handle() passes runtime='eager' and onnx_precision=None by default."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.cli.commands.predict._predict_multi_type'),
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            handle(args)
+        call_kwargs = MockModel.from_dir2.call_args.kwargs
+        assert call_kwargs['runtime'] == 'eager'
+        assert call_kwargs['onnx_precision'] is None
+
+    def test_handle_rejects_compile_with_onnx_runtime(self, tmp_path, mock_model):
+        """--compile with --runtime onnx fails before the model is constructed.
+
+        Checked in the CLI so the user sees this message rather than the
+        equivalent RuntimeError from Model.compile(), which would surface as a
+        raw traceback after the ONNX session had already been built.
+        """
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        args.compile = True
+        args.runtime = 'onnx'
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.cli.commands.predict._predict_multi_type'),
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            with pytest.raises(ValueError, match='only supported with --runtime eager'):
+                handle(args)
+        MockModel.from_dir2.assert_not_called()


### PR DESCRIPTION
Closes #470.

Adds ONNX export and inference-runtime support to the Model API and the CLI. TensorRT is deliberately out of scope.

## What's here

- `Model.export("onnx", onnx_precision=...)` writes to `exports_onnx_dir()` as `{ckpt_stem}_{onnx_precision}.onnx`.
- `Model.from_dir(..., runtime="onnx", onnx_precision=...)` builds an ONNX Runtime session and rebinds `forward`, mirroring `compile()` so paths that call `get_loss_inputs_labeled` directly are covered.
- New `_runtime` attribute; `compile()` raises when `_runtime != "eager"`.
- `litpose export <model_dir> --runtime onnx --onnx-precision fp16`, plus `--runtime` / `--onnx-precision` on `litpose predict`. `--compile` with `--runtime onnx` is rejected in the CLI before the model is built, so the message matches the `compile()` guard rather than surfacing as a traceback.
- Provider guard raising when CUDA is available but `CUDAExecutionProvider` didn't load.
- Docs: `onnxruntime-gpu` installation section, ONNX section rewritten around the new API, `exports_onnx/` added to the model-directory reference. The TensorRT snippet was rewired to define its own variables, since it previously continued from the manual recipe that this PR removes.

## Three things I'd like your call on

**1. Context models.** The issue covers singleview and multiview dummy-input shapes. Context (MHCRNN) models need a third, `(1, T, 3, H, W)`. I added that branch with `T = 5`, matching the convention documented in `predict_frame`. But you may prefer `export()` to refuse context models outright rather than produce an export whose temporal behavior nobody has validated. Easy to switch to a `NotImplementedError`.

**2. `heatmap.py:211` registers `torch.tensor` results as constants in the trace.** Torch warns this "might cause the trace to be incorrect." The accuracy test passes at the config's resize dimensions, so it looks benign there — but that only covers the one resolution we tested. If that constant is shape-derived, an export reused at a different input resolution could be silently wrong. You know that head better than I do.

**3. CPU fallback.** The issue's `onnx_forward` hardcodes `device_type="cuda"`, but the provider guard only fires when `torch.cuda.is_available()`, so a CPU-only machine would build a session fine and then fail on first forward. I added a CPU branch. If ONNX should just be GPU-only, dropping it simplifies the code.

## Two corrections to the sketch

**`.half()` mutates in place.** `module_to_export = module_to_export.half()` returns `self`, so exporting fp16 from a live `Model` would leave `self.model` in half precision for every later eager call on that object. `export()` traces a `deepcopy` instead. Covered by `test_fp16_export_leaves_live_model_in_fp32`.

**`element_type=np.float32` is hardcoded.** An fp16 export expects fp16 input buffers. Input dtype is now read from the session's input metadata.

Two smaller ones: checkpoint resolution moved into a shared `_ckpt_stem()` with a `None` guard, so an untrained model directory raises the same `FileNotFoundError` as `_load()` rather than a `TypeError` from `Path(None)`; and `import onnxruntime` is deferred into `_attach_onnx_runtime()` so it stays optional for eager users.

## Testing

`tests/cli/`: 120 passed. `tests/api/test_model.py -k "Export or OnnxRuntime or Compile"`: 24 passed on a Tesla T4 (torch 2.8.0+cu128, onnxruntime 1.28.0, `CUDAExecutionProvider` confirmed active).

Covers export paths for both precisions, auto-selection with zero/one/multiple exports, export-vs-load checkpoint agreement, the lazy-load interaction, `compile()` rejection under `runtime="onnx"`, a mocked provider-guard test, and singleview + multiview. `test_onnx_matches_eager_predictions` confirms max pixel deviation under 0.1px against the eager model on real frames.

## Follow-up, not in this PR

Torch 2.9 makes the `dynamo=True` exporter the default and the current TorchScript path is deprecated. Works on 2.8, but worth its own issue.
