### PR TITLE
Add TensorRT export and inference runtime support

### DIFF
--- a/docs/source/directory_structure_reference/model_dir_structure.rst
+++ b/docs/source/directory_structure_reference/model_dir_structure.rst
@@ -15,6 +15,9 @@ Model Directory Structure
    ├── tb_logs/ ...
    ├── exports_onnx/
    │   └── epoch=214-step=12685-best_fp16.onnx
+   ├── exports_trt/
+   │   └── epoch=214-step=12685-best_fp16/
+   │       └── trt_metadata.json
    ├── video_preds/
    │   ├── session0_view0.mp4/
    │   |   └── predictions.csv
@@ -29,6 +32,7 @@ Detailed descriptions
 
 * ``tb_logs/``: model weights
 * ``exports_onnx/``: ONNX exports produced by ``litpose export`` or ``Model.export("onnx", ...)``, one file per exported checkpoint and precision, named ``<checkpoint_stem>_<onnx_precision>.onnx``. Read back by ``litpose predict --runtime onnx`` or ``Model.from_dir(..., runtime="onnx")``. See :ref:`Increasing Inference Speed <usage_onnx_runtime>`.
+* ``exports_trt/``: TensorRT engine caches produced by ``litpose export --runtime tensorrt`` or ``Model.export("tensorrt", ...)``, one directory per exported checkpoint and precision, named ``<checkpoint_stem>_<onnx_precision>/``, built from the matching ``exports_onnx/`` file. Read back by ``litpose predict --runtime tensorrt`` or ``Model.from_dir(..., runtime="tensorrt")``. See :ref:`Increasing Inference Speed <usage_tensorrt>`.
 * ``video_preds/``: predictions and metrics from videos. The config field ``eval.test_videos_directory`` points to a directory of videos; if ``eval.predict_vids_after_training`` is set to ``true``, all videos in the indicated direcotry will be run through the model upon training completion and results stored here.
 * ``video_preds/labeled_videos/``: labeled mp4s. The config field ``eval.test_videos_directory`` points to a directory of videos; if ``eval.save_vids_after_training`` is set to ``true``, all videos in the indicated direcotry will be run through the model upon training completion and results stored here.
 * ``predictions.csv``: predictions on labeled data. The right-most column records the train/val/test split that each example belongs to.

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -287,64 +287,114 @@ several do.
 TensorRT
 --------
 
-TensorRT engines are built from the same ``.onnx`` file that ``model.export("onnx")``
-produces, using onnxruntime's ``TensorrtExecutionProvider`` instead of
-``CUDAExecutionProvider``. There is no ``runtime="tensorrt"`` yet, so the session is built
-by hand:
+.. _tensorrt_installation:
+
+Installation
+~~~~~~~~~~~~~
+
+TensorRT and ``onnxruntime-gpu`` need matching major versions, and ``pip install
+tensorrt`` / ``pip install onnxruntime-gpu`` each default independently to whatever is
+newest -- so they don't necessarily agree with each other, or with your PyTorch install's
+CUDA version. Check what onnxruntime expects before installing TensorRT:
+
+.. code-block:: console
+
+    python -c "import onnxruntime; print(onnxruntime.__version__)"
+
+The combination we verified working is ``onnxruntime-gpu`` 1.28.0 with
+``pip install "tensorrt-cu12<11"`` (lands on TensorRT 10.16.1.11, providing
+``libnvinfer.so.10``). A newer, unpinned ``pip install tensorrt`` can land on TensorRT
+11.x (``libnvinfer.so.11``) instead, which fails at session-creation time with a
+missing-symbol error rather than a clear version-mismatch message.
+
+TensorRT's shared libraries also need to be on ``LD_LIBRARY_PATH`` at runtime:
+
+.. code-block:: bash
+
+    export LD_LIBRARY_PATH=/path/to/site-packages/tensorrt_libs:$LD_LIBRARY_PATH
+
+Building a TensorRT engine starts from the ``.onnx`` file produced by ``model.export(
+"onnx", ...)`` -- the ``onnx`` package is needed to create that file, but not to build
+the engine from it afterward. A machine that only builds/runs TensorRT engines from an
+already-exported ``.onnx`` file needs ``onnxruntime-gpu`` and ``tensorrt`` alone.
+
+Usage
+~~~~~
+
+TensorRT builds its engine from an existing ONNX export, so export to ONNX first if you
+haven't already:
 
 .. code-block:: python
-
-    import onnxruntime as ort
 
     from lightning_pose.api import Model
 
     model = Model.from_dir("path/to/model_dir")
-    onnx_path = model.export("onnx", onnx_precision="fp32")
-    resize_h = model.cfg.data.image_resize_dims.height
-    resize_w = model.cfg.data.image_resize_dims.width
+    model.export("onnx", onnx_precision="fp16")
+    model.export("tensorrt", onnx_precision="fp16", max_batch_size=8)
 
-    trt_options = {
-        "trt_engine_cache_enable": True,
-        "trt_engine_cache_path": "/path/to/trt_cache",
-        "trt_fp16_enable": True,  # set False to retain FP32 precision
-        "trt_profile_min_shapes": f"images:1x3x{resize_h}x{resize_w}",
-        "trt_profile_opt_shapes": f"images:1x3x{resize_h}x{resize_w}",
-        "trt_profile_max_shapes": f"images:1x3x{resize_h}x{resize_w}",
-    }
-    session = ort.InferenceSession(
-        str(onnx_path),
-        providers=[
-            ("TensorrtExecutionProvider", trt_options),
-            "CUDAExecutionProvider",
-            "CPUExecutionProvider",
-        ],
+    trt_model = Model.from_dir(
+        "path/to/model_dir", runtime="tensorrt", onnx_precision="fp16"
     )
-    # Always confirm TensorRT actually engaged -- onnxruntime silently falls back to
-    # CUDAExecutionProvider if TensorRT can't be used, e.g. a missing library.
-    assert "TensorrtExecutionProvider" in session.get_providers()
+    result = trt_model.predict_on_video_file("path/to/video.mp4")
 
-The first inference call builds and autotunes an engine for the shapes in the profile above,
-which can take anywhere from several seconds to a few minutes depending on the model. The
-engine is cached to ``trt_engine_cache_path`` and reused on subsequent runs with the same
-shapes.
+The same from the CLI:
 
-Getting TensorRT installed and working took some real trial and error, mostly around matching
-library versions:
+.. code-block:: console
 
-- ``pip install tensorrt`` and ``pip install onnxruntime-gpu`` can each default to newer
-  CUDA/TensorRT major versions that don't match each other or your PyTorch install. We needed
-  ``pip install "tensorrt-cu12<11"`` (landing on TensorRT 10.16.1.11) to match onnxruntime
-  1.28.0's expected ``libnvinfer.so.10``.
-- TensorRT's shared libraries need to be on ``LD_LIBRARY_PATH`` at runtime, e.g.:
+    litpose export /path/to/model_dir --runtime onnx --onnx-precision fp16
+    litpose export /path/to/model_dir --runtime tensorrt --onnx-precision fp16 --max-batch-size 8
+    litpose predict /path/to/model_dir /path/to/video.mp4 --runtime tensorrt --onnx-precision fp16
 
-  .. code-block:: bash
+``max_batch_size`` sets the upper end of the dynamic-shape batch profile the engine is
+built for -- inference at a larger batch size fails. ``opt_batch_size`` (defaults to
+``max_batch_size``) is the batch size the engine is tuned to run fastest at; correctness
+holds for any batch size in ``[1, max_batch_size]``, but performance is best near
+``opt_batch_size``.
 
-      export LD_LIBRARY_PATH=/path/to/site-packages/tensorrt_libs:$LD_LIBRARY_PATH
+The engine cache is written alongside the ONNX exports:
 
-- Always check ``session.get_providers()`` after creating the session. If TensorRT can't
-  load (e.g. a missing library), onnxruntime silently falls back to
-  ``CUDAExecutionProvider`` rather than raising an error -- your code will still run and
-  produce plausible-looking numbers, just not the ones you think.
+.. code-block:: text
+
+    model_dir/
+    ├── config.yaml
+    ├── tb_logs/.../checkpoints/epoch=214-step=12685-best.ckpt
+    ├── exports_onnx/
+    │   └── epoch=214-step=12685-best_fp16.onnx
+    └── exports_trt/
+        └── epoch=214-step=12685-best_fp16/
+            ├── trt_metadata.json
+            └── ...                          # engine cache files (managed by onnxruntime)
+
+The first call to ``model.export("tensorrt", ...)`` builds and autotunes the engine, which
+can take anywhere from several seconds to a few minutes. ``trt_metadata.json`` records the
+GPU name, TensorRT/onnxruntime versions, and batch profile the engine was built with --
+``Model.from_dir(..., runtime="tensorrt")`` reads this back and warns if the current GPU
+doesn't match, since (unlike an ``.onnx`` file) a built engine is tied to the exact GPU
+architecture it was built on and is not portable across machines.
+
+.. note::
+
+   Building always requires a real GPU with a working TensorRT/onnxruntime install --
+   there is no CPU fallback tier for ``runtime="tensorrt"``. If
+   ``TensorrtExecutionProvider`` can't load, this raises rather than silently running on
+   ``CUDAExecutionProvider`` or CPU (unlike plain ONNX Runtime, which does have a CPU
+   tier -- see the note in the ONNX Runtime section above about checking
+   ``session.get_providers()``).
+
+.. note::
+
+   The accuracy check earlier on this page used TensorRT at FP32. At FP16, quantization
+   can shift the heatmap's predicted peak by a few pixels on keypoints the model has no
+   real opinion about -- a near-uniform heatmap, likelihood near the noise floor -- a
+   "peak-flipping" effect that happens under any precision or kernel change (it
+   reproduces on the already-merged ONNX FP16 path too, given a real dataset rather than
+   a handful of hand-picked frames) and isn't specific to TensorRT. On
+   confidently-tracked keypoints it stays small: repeated FP16 engine builds during
+   testing measured mean deviation around 0.2-0.3px, though TensorRT's own build-time
+   autotuning adds some run-to-run variance on top -- engine builds aren't perfectly
+   deterministic, so don't expect bit-identical predictions from two separately-built
+   engines either.
+
 
 .. _caveats:
 

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -307,10 +307,14 @@ The combination we verified working is ``onnxruntime-gpu`` 1.28.0 with
 11.x (``libnvinfer.so.11``) instead, which fails at session-creation time with a
 missing-symbol error rather than a clear version-mismatch message.
 
+For the full installation matrix (which TensorRT version pairs with which CUDA/cuDNN), see NVIDIA's `TensorRT install guide <https://docs.nvidia.com/deeplearning/tensorrt/latest/installing-tensorrt/installing.html>`_. The ``<11`` pin above matches what onnxruntime-gpu's TensorRT execution provider currently requires. If your onnxruntime-gpu version differs from the one this doc was written against, check onnxruntime's own `TensorRT EP requirements table <https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#requirements>`_ first -- it's the maintained source of truth for onnxruntime-gpu <-> TensorRT <-> CUDA compatibility, including versions released after this page was written.
+
 TensorRT's shared libraries also need to be on ``LD_LIBRARY_PATH`` at runtime:
 
 .. code-block:: bash
 
+    # find your site-packages path:
+    #   python -c "import tensorrt_libs, os; print(os.path.dirname(tensorrt_libs.__file__))"
     export LD_LIBRARY_PATH=/path/to/site-packages/tensorrt_libs:$LD_LIBRARY_PATH
 
 Building a TensorRT engine starts from the ``.onnx`` file produced by ``model.export(
@@ -330,7 +334,7 @@ haven't already:
 
     model = Model.from_dir("path/to/model_dir")
     model.export("onnx", onnx_precision="fp16")
-    model.export("tensorrt", onnx_precision="fp16", max_batch_size=8)
+    model.export("tensorrt", onnx_precision="fp16", max_batch_size=32)
 
     trt_model = Model.from_dir(
         "path/to/model_dir", runtime="tensorrt", onnx_precision="fp16"
@@ -342,7 +346,7 @@ The same from the CLI:
 .. code-block:: console
 
     litpose export /path/to/model_dir --runtime onnx --onnx-precision fp16
-    litpose export /path/to/model_dir --runtime tensorrt --onnx-precision fp16 --max-batch-size 8
+    litpose export /path/to/model_dir --runtime tensorrt --onnx-precision fp16 --max-batch-size 32
     litpose predict /path/to/model_dir /path/to/video.mp4 --runtime tensorrt --onnx-precision fp16
 
 ``max_batch_size`` sets the upper end of the dynamic-shape batch profile the engine is

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -75,9 +75,7 @@ _CONTEXT_SEQUENCE_LENGTH = 5
 # autocast precision used for eager inference.
 _OnnxPrecision = Literal["fp32", "fp16"]
 
-# Inference runtimes accepted by Model.from_dir(runtime=...). "tensorrt" is a
-# planned addition that will consume the same exported .onnx file through a
-# different execution provider.
+# Inference runtimes accepted by Model.from_dir(runtime=...).
 _Runtime = Literal["eager", "onnx", "tensorrt"]
 
 # Maps onnxruntime's tensor type strings to numpy dtypes. Used to bind input

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import copy
+import json
 import logging
+import warnings
 from pathlib import Path
 from typing import Any, Literal, cast, get_args
 
@@ -76,7 +78,7 @@ _OnnxPrecision = Literal["fp32", "fp16"]
 # Inference runtimes accepted by Model.from_dir(runtime=...). "tensorrt" is a
 # planned addition that will consume the same exported .onnx file through a
 # different execution provider.
-_Runtime = Literal["eager", "onnx"]
+_Runtime = Literal["eager", "onnx", "tensorrt"]
 
 # Maps onnxruntime's tensor type strings to numpy dtypes. Used to bind input
 # buffers at whatever precision the exported file actually expects, rather than
@@ -228,6 +230,76 @@ def load_model_from_checkpoint(
     return model
 
 
+def _tensorrt_version() -> str | None:
+    """Return the installed ``tensorrt`` package version, or None if absent."""
+    try:
+        import tensorrt  # type: ignore[import-not-found]
+
+        return tensorrt.__version__
+    except ImportError:
+        return None
+
+
+def _onnxruntime_version() -> str | None:
+    """Return the installed ``onnxruntime`` package version, or None if absent."""
+    try:
+        import onnxruntime  # type: ignore[import-not-found]
+
+        return onnxruntime.__version__
+    except ImportError:
+        return None
+
+
+def _build_onnx_forward(session: Any) -> Any:
+    """Build a forward-replacement closure that runs inference through an ONNX
+    Runtime session, regardless of which execution provider backs it.
+
+    Shared by ``Model._attach_onnx_runtime()`` and
+    ``Model._attach_tensorrt_runtime()`` -- the session-driven forward pass
+    (io_binding setup, dtype detection, CPU/GPU branching) is identical for
+    both; only the ``providers`` passed to ``InferenceSession`` differs. The
+    returned callable is assigned directly to ``self.model.forward`` (rather
+    than wrapping the module) so every existing prediction path keeps working,
+    including those that call ``get_loss_inputs_labeled`` directly instead of
+    going through ``__call__``. Because ``Model.model``'s type is a union of
+    several model classes with genuinely different ``forward`` signatures,
+    callers assign this with a ``# type: ignore[method-assign]``.
+    """
+    providers = session.get_providers()
+    input_meta = session.get_inputs()[0]
+    input_name = input_meta.name
+    output_name = session.get_outputs()[0].name
+    input_np_dtype = _ORT_TYPE_TO_NUMPY[input_meta.type]
+    input_torch_dtype = torch.from_numpy(np.empty(0, dtype=input_np_dtype)).dtype
+    cuda_available = (
+        "CUDAExecutionProvider" in providers or "TensorrtExecutionProvider" in providers
+    )
+
+    def onnx_forward(images: torch.Tensor) -> torch.Tensor:
+        images = images.to(input_torch_dtype).contiguous()
+        if cuda_available and images.is_cuda:
+            io_binding = session.io_binding()
+            device_id = images.device.index or 0
+            io_binding.bind_input(
+                name=input_name,
+                device_type="cuda",
+                device_id=device_id,
+                element_type=input_np_dtype,
+                shape=tuple(images.shape),
+                buffer_ptr=images.data_ptr(),
+            )
+            io_binding.bind_output(
+                name=output_name, device_type="cuda", device_id=device_id
+            )
+            session.run_with_iobinding(io_binding)
+            output = io_binding.copy_outputs_to_cpu()[0]
+        else:
+            output = session.run([output_name], {input_name: images.cpu().numpy()})[0]
+        return torch.from_numpy(output).to(images.device)
+
+    return onnx_forward
+
+
 class Model:
     """High-level interface for inference with a trained lightning-pose model.
 
@@ -308,13 +380,18 @@ class Model:
             runtime: inference backend. ``"eager"`` (default) loads the trained
                 checkpoint as usual. ``"onnx"`` loads an ONNX Runtime session
                 from ``exports_onnx_dir()``, which must have been built with
-                ``model.export("onnx", ...)`` beforehand; ``precision`` is
-                ignored in that mode, since the exported file's own precision
-                is what runs.
-            onnx_precision: only used when ``runtime="onnx"``. Selects which
-                exported file to load. If omitted and exactly one export exists
-                for this checkpoint, it is used automatically; if more than one
-                exists, raises.
+                ``model.export("onnx", ...)`` beforehand. ``"tensorrt"`` loads
+                a TensorRT engine from ``exports_trt_dir()``, built with
+                ``model.export("tensorrt", ...)`` beforehand (which itself
+                requires an existing ``"onnx"`` export for the same
+                ``onnx_precision``). ``precision`` is ignored in both
+                non-eager modes, since the exported file's own precision is
+                what runs.
+            onnx_precision: only used when ``runtime="onnx"`` or
+                ``runtime="tensorrt"``. Selects which exported file (or, for
+                tensorrt, which engine cache) to load. If omitted and exactly
+                one export exists for this checkpoint, it is used
+                automatically; if more than one exists, raises.
 
         Returns:
             Model ready for inference. Weights are loaded lazily on the first
@@ -366,6 +443,9 @@ class Model:
             return model
         elif runtime == "onnx":
             model._attach_onnx_runtime(onnx_precision)
+            return model
+        elif runtime == "tensorrt":
+            model._attach_tensorrt_runtime(onnx_precision)
             return model
         else:
             supported = ", ".join(repr(r) for r in get_args(_Runtime))
@@ -466,6 +546,39 @@ class Model:
                 skip_data_module=True,
             )
 
+    def _find_onnx_export(self, onnx_precision: _OnnxPrecision | None) -> Path:
+        """Locate the ONNX export for this checkpoint, disambiguating by precision.
+
+        Shared by ``_attach_onnx_runtime()`` and ``_export_tensorrt()``, which
+        builds its engine from an existing ONNX export rather than re-tracing
+        the model.
+
+        Raises:
+            FileNotFoundError: if no matching export exists.
+            ValueError: if multiple exports exist and ``onnx_precision`` is None.
+        """
+        stem = self._ckpt_stem()
+        export_dir = self.exports_onnx_dir()
+        pattern = (
+            f"{stem}_{onnx_precision}.onnx"
+            if onnx_precision is not None
+            else f"{stem}_*.onnx"
+        )
+        candidates = sorted(export_dir.glob(pattern))
+        if len(candidates) == 0:
+            raise FileNotFoundError(
+                f"No ONNX export found for checkpoint '{stem}'"
+                + (f" with onnx_precision='{onnx_precision}'" if onnx_precision else "")
+                + f" in {export_dir}. Run model.export('onnx') first."
+            )
+        if len(candidates) > 1:
+            found = [c.name for c in candidates]
+            raise ValueError(
+                f"Multiple ONNX exports found: {found}. "
+                "Pass onnx_precision= to disambiguate."
+            )
+        return candidates[0]
+
     def _attach_onnx_runtime(self, onnx_precision: _OnnxPrecision | None) -> None:
         """Replace the model's forward pass with an ONNX Runtime session.
 
@@ -490,29 +603,7 @@ class Model:
         # weights: a user who forgot to run export() should get that message
         # regardless of whether the optional dependency is installed, and
         # there's no reason to pay for _load() on a path that can't succeed.
-        stem = self._ckpt_stem()
-        export_dir = self.exports_onnx_dir()
-        pattern = (
-            f"{stem}_{onnx_precision}.onnx"
-            if onnx_precision is not None
-            else f"{stem}_*.onnx"
-        )
-        candidates = sorted(export_dir.glob(pattern))
-
-        if len(candidates) == 0:
-            raise FileNotFoundError(
-                f"No ONNX export found for checkpoint '{stem}'"
-                + (f" with onnx_precision='{onnx_precision}'" if onnx_precision else "")
-                + f" in {export_dir}. Run model.export('onnx') first."
-            )
-        if len(candidates) > 1:
-            found = [c.name for c in candidates]
-            raise ValueError(
-                f"Multiple ONNX exports found: {found}. "
-                "Pass onnx_precision= to disambiguate."
-            )
-
-        onnx_path = candidates[0]
+        onnx_path = self._find_onnx_export(onnx_precision)
 
         # Imported lazily: onnxruntime is an optional dependency, and a
         # module-level import would make it mandatory for every eager user.
@@ -554,44 +645,117 @@ class Model:
                 "user_guide_advanced/increasing_inference_speed.html#onnx-installation"
             )
 
-        # Bind at the precision the exported graph declares, not a hardcoded
-        # fp32 -- an fp16 export rejects fp32 input buffers.
-        input_meta = session.get_inputs()[0]
-        input_name = input_meta.name
-        output_name = session.get_outputs()[0].name
-        input_np_dtype = _ORT_TYPE_TO_NUMPY[input_meta.type]
-        input_torch_dtype = torch.from_numpy(np.empty(0, dtype=input_np_dtype)).dtype
-        cuda_available = "CUDAExecutionProvider" in providers
-
-        def onnx_forward(images: torch.Tensor) -> torch.Tensor:
-            images = images.to(input_torch_dtype).contiguous()
-            if cuda_available and images.is_cuda:
-                # Zero-copy path: hand ORT the tensor's existing device pointer.
-                io_binding = session.io_binding()
-                device_id = images.device.index or 0
-                io_binding.bind_input(
-                    name=input_name,
-                    device_type="cuda",
-                    device_id=device_id,
-                    element_type=input_np_dtype,
-                    shape=tuple(images.shape),
-                    buffer_ptr=images.data_ptr(),
-                )
-                io_binding.bind_output(
-                    name=output_name, device_type="cuda", device_id=device_id
-                )
-                session.run_with_iobinding(io_binding)
-                output = io_binding.copy_outputs_to_cpu()[0]
-            else:
-                # CPU session, or a CPU input tensor on a CUDA-capable session.
-                output = session.run([output_name], {input_name: images.cpu().numpy()})[0]
-            return torch.from_numpy(output).to(images.device)
-
-        # Same rebinding pattern as compile(); see the note there on why the
-        # union-typed forward signature needs the ignore.
-        self.model.forward = onnx_forward  # type: ignore[method-assign]
+        self.model.forward = _build_onnx_forward(session)  # type: ignore[method-assign]
         self._runtime = "onnx"
         logger.info(f'loaded ONNX runtime session from {onnx_path}')
+
+    def _find_trt_cache(self, onnx_precision: _OnnxPrecision | None) -> Path:
+        """Locate the TensorRT engine cache directory for this checkpoint.
+
+        Analogous to ``_find_onnx_export()``.
+
+        Raises:
+            FileNotFoundError: if no matching cache exists.
+            ValueError: if multiple caches exist and ``onnx_precision`` is None.
+        """
+        stem = self._ckpt_stem()
+        trt_dir = self.exports_trt_dir()
+        pattern = f"{stem}_{onnx_precision}" if onnx_precision is not None else f"{stem}_*"
+        candidates = sorted(p for p in trt_dir.glob(pattern) if p.is_dir())
+        if len(candidates) == 0:
+            raise FileNotFoundError(
+                f"No TensorRT export found for checkpoint '{stem}'"
+                + (f" with onnx_precision='{onnx_precision}'" if onnx_precision else "")
+                + f" in {trt_dir}. Run model.export('tensorrt', ...) first."
+            )
+        if len(candidates) > 1:
+            found = [c.name for c in candidates]
+            raise ValueError(
+                f"Multiple TensorRT exports found: {found}. "
+                "Pass onnx_precision= to disambiguate."
+            )
+        return candidates[0]
+
+    def _attach_tensorrt_runtime(self, onnx_precision: _OnnxPrecision | None) -> None:
+        """Replace the model's forward pass with a TensorRT-backed ONNX Runtime session.
+
+        Stricter than ``_attach_onnx_runtime()``: TensorRT has no CPU execution
+        path, so this raises immediately if no CUDA device is available. It
+        also raises (rather than warns, unlike ONNX's CPU fallback) if the
+        session falls back to CUDAExecutionProvider instead of engaging
+        TensorRT -- landing on plain CUDA here silently defeats the entire
+        reason the caller asked for ``runtime="tensorrt"``.
+
+        Raises:
+            FileNotFoundError: if no matching engine cache exists.
+            ValueError: if multiple caches exist and ``onnx_precision`` is None.
+            RuntimeError: if no CUDA device is available, if the session fails
+                to load TensorrtExecutionProvider, or if the model fails to load.
+        """
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "runtime='tensorrt' requires a CUDA-capable GPU; none is "
+                "available. TensorRT has no CPU execution path -- use "
+                "runtime='onnx' or runtime='eager' instead."
+            )
+
+        cache_dir = self._find_trt_cache(onnx_precision)
+        metadata_path = cache_dir / "trt_metadata.json"
+        resolved_onnx_precision = onnx_precision
+        if metadata_path.exists():
+            metadata = json.loads(metadata_path.read_text())
+            current_gpu = torch.cuda.get_device_name(0)
+            recorded_gpu = metadata.get("gpu_name")
+            if recorded_gpu is not None and recorded_gpu != current_gpu:
+                warnings.warn(
+                    f"TensorRT engine at {cache_dir} was built on "
+                    f"'{recorded_gpu}' but is running on '{current_gpu}'. "
+                    "onnxruntime will rebuild the engine on first inference, "
+                    "which can take several minutes.",
+                    stacklevel=2,
+                )
+            if resolved_onnx_precision is None:
+                resolved_onnx_precision = metadata.get("onnx_precision")
+
+        onnx_path = self._find_onnx_export(resolved_onnx_precision)
+
+        try:
+            import onnxruntime as ort  # type: ignore[import-not-found]
+        except ImportError as e:
+            raise ImportError(
+                "onnxruntime is required for runtime='tensorrt' but is not "
+                "installed. See https://lightning-pose.readthedocs.io/en/latest/"
+                "source/user_guide_advanced/increasing_inference_speed.html"
+                "#onnx-installation for installation instructions."
+            ) from e
+
+        trt_options = {
+            "trt_engine_cache_enable": True,
+            "trt_engine_cache_path": str(cache_dir),
+            "trt_fp16_enable": resolved_onnx_precision == "fp16",
+        }
+        session = ort.InferenceSession(
+            str(onnx_path),
+            providers=[("TensorrtExecutionProvider", trt_options), "CUDAExecutionProvider"],
+        )
+        if "TensorrtExecutionProvider" not in session.get_providers():
+            raise RuntimeError(
+                "ONNX Runtime failed to load TensorrtExecutionProvider -- "
+                "inference would silently run on CUDAExecutionProvider instead, "
+                "without the TensorRT speedup you asked for. This is usually a "
+                "missing/mismatched TensorRT install or a missing "
+                "LD_LIBRARY_PATH entry. See "
+                "https://lightning-pose.readthedocs.io/en/latest/source/"
+                "user_guide_advanced/increasing_inference_speed.html"
+                "#tensorrt-installation"
+            )
+
+        self._load()
+        if self.model is None:
+            raise RuntimeError('model failed to load; self.model is None after _load()')
+        self.model.forward = _build_onnx_forward(session)  # type: ignore[method-assign]
+        self._runtime = "tensorrt"
+        logger.info(f'loaded TensorRT engine session from {cache_dir}')
 
     def _ckpt_stem(self) -> str:
         """Return the filename stem of this model's checkpoint.
@@ -612,17 +776,34 @@ class Model:
             )
         return Path(ckpt_file).stem
 
-    def export(self, runtime: str, onnx_precision: _OnnxPrecision = "fp16") -> Path:
+    def export(
+        self,
+        runtime: str,
+        onnx_precision: _OnnxPrecision = "fp16",
+        max_batch_size: int = 8,
+        opt_batch_size: int | None = None,
+    ) -> Path:
         """Export the model to an optimized inference format.
 
-        Currently supports ``runtime="onnx"``. Writes to a fixed location inside
+        Supports ``runtime="onnx"`` and ``runtime="tensorrt"``. Writes to a fixed location inside
         the model directory (``exports_onnx_dir() / "{ckpt_stem}_{onnx_precision}.onnx"``)
         and returns the path to the exported file. Export paths are not
         user-configurable by design -- ``from_dir(runtime="onnx")`` reads from
         this same location.
 
         Args:
-            runtime: export target. Only ``"onnx"`` is currently supported.
+            runtime: export target, ``"onnx"`` or ``"tensorrt"``. TensorRT
+                builds its engine from an existing ONNX export rather than
+                re-tracing the model -- run ``export("onnx", ...)`` first for
+                the same ``onnx_precision``.
+            max_batch_size: only used for ``runtime="tensorrt"``. Upper bound
+                of the dynamic-shape batch profile the engine is built for;
+                inference at a batch size above this fails. Default 8.
+            opt_batch_size: only used for ``runtime="tensorrt"``. Batch size
+                the engine is optimized for; defaults to ``max_batch_size``.
+                Correctness holds for any batch size in
+                ``[1, max_batch_size]``, but performance is best near this
+                value.
             onnx_precision: weight precision baked into the exported file, either
                 ``"fp32"`` or ``"fp16"``. Distinct from ``self.precision``, which
                 controls autocast precision for eager inference only.
@@ -632,23 +813,26 @@ class Model:
 
         Raises:
             ValueError: if ``runtime`` or ``onnx_precision`` is unsupported.
-            FileNotFoundError: if no checkpoint file is found in ``model_dir``.
+            FileNotFoundError: if no checkpoint file is found in
+                ``model_dir`` (``runtime="onnx"``), or if the required ONNX
+                export doesn't exist yet (``runtime="tensorrt"``).
             RuntimeError: if the model fails to load.
 
         Examples:
             >>> model = Model.from_dir("outputs/2024-01-01/12-00-00")
             >>> model.export("onnx", onnx_precision="fp16")
+            >>> model.export("tensorrt", onnx_precision="fp16", max_batch_size=16)
         """
-        if runtime != "onnx":
+        if runtime not in ("onnx", "tensorrt"):
             raise ValueError(
-                f"Unsupported export runtime: '{runtime}'. "
-                "Only 'onnx' is currently supported."
+                f"Unsupported export runtime: '{runtime}'. Use 'onnx' or 'tensorrt'."
             )
         if onnx_precision not in ("fp32", "fp16"):
             raise ValueError(
                 f"Unsupported onnx_precision: '{onnx_precision}'. Use 'fp32' or 'fp16'."
             )
-
+        if runtime == "tensorrt":
+            return self._export_tensorrt(onnx_precision, max_batch_size, opt_batch_size)
         # Weights are lazy-loaded; tracing needs a real forward pass.
         self._load()
         if self.model is None:
@@ -703,6 +887,119 @@ class Model:
         logger.info(f'exported {onnx_precision} ONNX model to {onnx_path}')
         return onnx_path
 
+    def _export_tensorrt(
+        self,
+        onnx_precision: _OnnxPrecision,
+        max_batch_size: int,
+        opt_batch_size: int | None,
+    ) -> Path:
+        """Build a TensorRT engine cache from an existing ONNX export.
+
+        Unlike ONNX export, this does not call ``self._load()`` or touch the
+        trained torch weights at all -- verified empirically (T4, 2026-08-06)
+        that onnxruntime's TensorrtExecutionProvider builds the engine purely
+        from the ``.onnx`` file, which already has the weights baked in. The
+        input shape needed for the dynamic-shape batch profile is read
+        directly off the ONNX graph's own input metadata, rather than
+        re-deriving it from ``self.cfg``/``self.model.do_context`` the way the
+        ONNX export branch above does -- this avoids reimplementing the
+        singleview/multiview/context shape branching a second time.
+
+        Raises:
+            FileNotFoundError: if the matching ONNX export doesn't exist yet.
+            RuntimeError: if the build doesn't engage TensorrtExecutionProvider.
+        """
+        try:
+            onnx_path = self._find_onnx_export(onnx_precision)
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"No ONNX export found for onnx_precision='{onnx_precision}'. "
+                f"Run model.export('onnx', onnx_precision='{onnx_precision}') "
+                "first."
+            ) from e
+
+        try:
+            import onnxruntime as ort  # type: ignore[import-not-found]
+        except ImportError as e:
+            raise ImportError(
+                "onnxruntime is required to build a TensorRT engine but is not "
+                "installed. See https://lightning-pose.readthedocs.io/en/latest/"
+                "source/user_guide_advanced/increasing_inference_speed.html"
+                "#onnx-installation for installation instructions."
+            ) from e
+
+        opt_batch_size = opt_batch_size or max_batch_size
+        stem = self._ckpt_stem()
+        cache_dir = self.exports_trt_dir() / f"{stem}_{onnx_precision}"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Read the input shape straight off the ONNX graph rather than
+        # recomputing it from self.cfg -- see docstring above.
+        probe_session = ort.InferenceSession(
+            str(onnx_path), providers=["CPUExecutionProvider"]
+        )
+        input_meta = probe_session.get_inputs()[0]
+        input_name = input_meta.name
+        shape_suffix = "x".join(str(d) for d in input_meta.shape[1:])
+        del probe_session
+
+        trt_options = {
+            "trt_engine_cache_enable": True,
+            "trt_engine_cache_path": str(cache_dir),
+            "trt_fp16_enable": onnx_precision == "fp16",
+            "trt_profile_min_shapes": f"{input_name}:1x{shape_suffix}",
+            "trt_profile_opt_shapes": f"{input_name}:{opt_batch_size}x{shape_suffix}",
+            "trt_profile_max_shapes": f"{input_name}:{max_batch_size}x{shape_suffix}",
+        }
+        session = ort.InferenceSession(
+            str(onnx_path),
+            providers=[("TensorrtExecutionProvider", trt_options), "CUDAExecutionProvider"],
+        )
+        if "TensorrtExecutionProvider" not in session.get_providers():
+            raise RuntimeError(
+                "TensorRT engine build failed to use TensorrtExecutionProvider. "
+                "This usually means a missing/mismatched TensorRT install. See "
+                "https://lightning-pose.readthedocs.io/en/latest/source/"
+                "user_guide_advanced/increasing_inference_speed.html"
+                "#tensorrt-installation"
+            )
+        del session
+
+        self._write_trt_metadata(cache_dir, onnx_precision, max_batch_size, opt_batch_size)
+        logger.info(f'built TensorRT engine cache at {cache_dir}')
+        return cache_dir
+
+    def _write_trt_metadata(
+        self,
+        cache_dir: Path,
+        onnx_precision: _OnnxPrecision,
+        max_batch_size: int,
+        opt_batch_size: int,
+    ) -> None:
+        """Write a sidecar recording the exact environment a TensorRT engine was built in.
+
+        Unlike the ``.onnx`` file, a TensorRT engine cache is tied to the exact
+        GPU architecture, TensorRT version, and batch profile it was built
+        with -- it is not portable across machines. ``_attach_tensorrt_runtime()``
+        reads this back and warns on a GPU-name mismatch, so a mismatch
+        produces a clear message instead of a confusing onnxruntime failure or
+        an unexpected silent rebuild.
+        """
+        import datetime
+
+        metadata = {
+            "gpu_name": (
+                torch.cuda.get_device_name(0) if torch.cuda.is_available() else None
+            ),
+            "tensorrt_version": _tensorrt_version(),
+            "onnxruntime_version": _onnxruntime_version(),
+            "onnx_precision": onnx_precision,
+            "max_batch_size": max_batch_size,
+            "opt_batch_size": opt_batch_size,
+            "built_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        (cache_dir / "trt_metadata.json").write_text(json.dumps(metadata, indent=2))
+
     def image_preds_dir(self) -> Path:
         """Return the directory where image/CSV predictions are saved."""
         return self.model_dir / "image_preds"
@@ -726,6 +1023,10 @@ class Model:
     def exports_onnx_dir(self) -> Path:
         """Return the directory where ONNX exports are saved."""
         return self.model_dir / "exports_onnx"
+
+    def exports_trt_dir(self) -> Path:
+        """Return the directory where TensorRT engine caches are saved."""
+        return self.model_dir / "exports_trt"
 
     def cropped_csv_file_path(self, csv_file_path: str | Path) -> Path:
         """Return the path where a cropzoom-adjusted CSV file will be saved.

--- a/lightning_pose/cli/commands/export.py
+++ b/lightning_pose/cli/commands/export.py
@@ -11,13 +11,14 @@ from .. import types
 
 logger = logging.getLogger(__name__)
 
-# Export targets. Only ONNX today; TensorRT is a planned follow-up that will
-# consume the same .onnx artifact through a different execution provider.
-_RUNTIME_CHOICES = ("onnx",)
+# Export targets. TensorRT builds its engine from the same .onnx artifact
+# "onnx" produces, through a different execution provider.
+_RUNTIME_CHOICES = ("onnx", "tensorrt")
 
 # Weight precisions the exporter supports. Deliberately narrower than
 # --precision on `litpose predict`: this is the precision baked into the
-# exported file, not the autocast precision used for eager inference.
+# exported file, not the autocast precision used for eager inference. For
+# --runtime tensorrt, this selects which existing ONNX export to build from.
 _ONNX_PRECISION_CHOICES = ("fp32", "fp16")
 
 
@@ -32,11 +33,18 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
           Exports are written to a fixed location inside the model directory::
 
             <model_dir>/
-            └── exports_onnx/
-                └── <checkpoint_stem>_<onnx_precision>.onnx
+            |-- exports_onnx/
+            |   `-- <checkpoint_stem>_<onnx_precision>.onnx
+            `-- exports_trt/
+                `-- <checkpoint_stem>_<onnx_precision>/
+                    `-- trt_metadata.json
 
           The export path is not configurable. `litpose predict --runtime onnx`
-          reads from this same location.
+          or `--runtime tensorrt` reads from these same locations.
+
+          TensorRT builds its engine from an existing ONNX export rather than
+          re-tracing the model -- run `--runtime onnx` first for the same
+          --onnx-precision.
         """
         ),
         usage="litpose export <model_dir> [OPTIONS]",
@@ -57,8 +65,30 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
         help=(
             "weight precision baked into the exported file. Unlike "
             "`litpose predict --precision`, this changes the exported weights "
-            "themselves rather than the precision of a forward pass. "
-            "Default: fp16."
+            "themselves rather than the precision of a forward pass. For "
+            "--runtime tensorrt, selects which existing ONNX export to build "
+            "the engine from. Default: fp16."
+        ),
+    )
+    export_parser.add_argument(
+        "--max-batch-size",
+        type=int,
+        default=8,
+        help=(
+            "only used with --runtime tensorrt. Upper bound of the "
+            "dynamic-shape batch profile the engine is built for; inference "
+            "at a batch size above this fails. Default: 8."
+        ),
+    )
+    export_parser.add_argument(
+        "--opt-batch-size",
+        type=int,
+        default=None,
+        help=(
+            "only used with --runtime tensorrt. Batch size the engine is "
+            "optimized for; defaults to --max-batch-size. Correctness holds "
+            "for any batch size in [1, max-batch-size], but performance is "
+            "best near this value."
         ),
     )
     return export_parser
@@ -77,5 +107,10 @@ def handle(args: argparse.Namespace) -> None:
     from lightning_pose.api import Model
 
     model = Model.from_dir(args.model_dir)
-    output_path = model.export(args.runtime, onnx_precision=args.onnx_precision)
+    output_path = model.export(
+        args.runtime,
+        onnx_precision=args.onnx_precision,
+        max_batch_size=args.max_batch_size,
+        opt_batch_size=args.opt_batch_size,
+    )
     logger.info(f'export written to {output_path}')

--- a/lightning_pose/cli/commands/predict.py
+++ b/lightning_pose/cli/commands/predict.py
@@ -23,9 +23,9 @@ if TYPE_CHECKING:
 _PRECISION_CHOICES = ("fp32", "fp16", "bf16")
 
 # Inference backends accepted by --runtime. "eager" runs the loaded PyTorch
-# checkpoint; "onnx" runs an ONNX Runtime session previously built with
-# `litpose export`.
-_RUNTIME_CHOICES = ("eager", "onnx")
+# checkpoint; "onnx" and "tensorrt" run a session previously built with
+# `litpose export --runtime onnx` / `--runtime tensorrt`.
+_RUNTIME_CHOICES = ("eager", "onnx", "tensorrt")
 
 # Selects which exported file --runtime onnx loads. Distinct from --precision:
 # this is the precision baked into the .onnx file, not autocast precision.
@@ -124,9 +124,10 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
         default="eager",
         help=(
             "inference backend. 'eager' (default) runs the trained checkpoint. "
-            "'onnx' runs an ONNX Runtime session, which must have been built "
-            "first with `litpose export`. With --runtime onnx, --precision is "
-            "ignored -- the exported file's own precision is what runs."
+            "'onnx' and 'tensorrt' run a session previously built with "
+            "`litpose export --runtime onnx` / `--runtime tensorrt`. With "
+            "--runtime onnx or --runtime tensorrt, --precision is ignored -- "
+            "the exported file's own precision is what runs."
         ),
     )
 
@@ -135,9 +136,10 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
         choices=sorted(_ONNX_PRECISION_CHOICES),
         default=None,
         help=(
-            "which ONNX export to load. Only used with --runtime onnx. If "
-            "omitted and exactly one export exists, it is used automatically; "
-            "if several exist, pass this to disambiguate."
+            "which ONNX export to load (or, for --runtime tensorrt, which "
+            "engine cache). Only used with --runtime onnx or --runtime "
+            "tensorrt. If omitted and exactly one export exists, it is used "
+            "automatically; if several exist, pass this to disambiguate."
         ),
     )
 
@@ -184,7 +186,7 @@ def handle(args: argparse.Namespace) -> None:
         raise ValueError(
             f"--compile is only supported with --runtime eager, but --runtime "
             f"{args.runtime} was given. torch.compile() has no effect on an "
-            f"ONNX Runtime session."
+            f"ONNX Runtime or TensorRT session."
         )
 
     model = Model.from_dir2(

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -542,7 +543,7 @@ class TestExport:
         """export() rejects a runtime other than 'onnx' before loading anything."""
         model = _setup_test_model(tmp_path, request)
         with pytest.raises(ValueError, match="Unsupported export runtime"):
-            model.export("tensorrt")
+            model.export("coreml")
         assert model.model is None
 
     def test_export_rejects_unknown_onnx_precision(self, tmp_path, request):
@@ -606,6 +607,81 @@ class TestExport:
         assert output_path.stat().st_size > 0
 
 
+class TestTensorRTExport:
+    """Test the export('tensorrt', ...) method."""
+
+    pytestmark = pytest.mark.gpu
+
+    def test_export_tensorrt_requires_existing_onnx_export(self, tmp_path, request):
+        """export('tensorrt') points at export('onnx') rather than silently exporting one."""
+        model = _setup_test_model(tmp_path, request)
+        with pytest.raises(FileNotFoundError, match=r"Run model\.export\('onnx'"):
+            model.export("tensorrt", onnx_precision="fp16")
+
+    @requires_onnxruntime
+    def test_export_tensorrt_writes_expected_path(self, tmp_path, request):
+        """export('tensorrt') writes exports_trt/{ckpt_stem}_{onnx_precision}/."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp16")
+        cache_dir = model.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+        assert cache_dir.is_dir()
+        assert cache_dir.parent == model.exports_trt_dir()
+        assert cache_dir.parent == model.model_dir / "exports_trt"
+        assert cache_dir.name == f"{model._ckpt_stem()}_fp16"
+        assert (cache_dir / "trt_metadata.json").is_file()
+
+    @requires_onnxruntime
+    def test_export_tensorrt_metadata_contents(self, tmp_path, request):
+        """trt_metadata.json records exactly what the build used."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp16")
+        cache_dir = model.export(
+            "tensorrt", onnx_precision="fp16", max_batch_size=4, opt_batch_size=2
+        )
+        metadata = json.loads((cache_dir / "trt_metadata.json").read_text())
+        assert metadata["onnx_precision"] == "fp16"
+        assert metadata["max_batch_size"] == 4
+        assert metadata["opt_batch_size"] == 2
+        assert metadata["gpu_name"]
+        assert metadata["tensorrt_version"]
+        assert metadata["onnxruntime_version"]
+        assert metadata["built_at"]
+
+    @requires_onnxruntime
+    def test_export_tensorrt_opt_batch_size_defaults_to_max(self, tmp_path, request):
+        """opt_batch_size defaults to max_batch_size when not given separately."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp16")
+        cache_dir = model.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+        metadata = json.loads((cache_dir / "trt_metadata.json").read_text())
+        assert metadata["opt_batch_size"] == 4
+
+    @requires_onnxruntime
+    def test_export_tensorrt_does_not_load_torch_weights(self, tmp_path, request):
+        """export('tensorrt') builds purely from the .onnx file.
+
+        Verified empirically (T4, 2026-08-06) that the engine build needs no
+        torch weights at all -- shape info comes from the ONNX graph's own
+        input metadata, not self.cfg/self.model.do_context. A separate Model
+        instance is used so this really tests _export_tensorrt rather than
+        leftover state from the onnx export that had to run first.
+        """
+        onnx_source = _setup_test_model(tmp_path / "onnx_source", request)
+        onnx_source.export("onnx", onnx_precision="fp16")
+        trt_model = Model.from_dir(onnx_source.model_dir)
+        assert trt_model.model is None
+        trt_model.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+        assert trt_model.model is None
+
+    @requires_onnxruntime
+    def test_export_tensorrt_multiview(self, tmp_path, request):
+        """A multiview model builds a TensorRT engine from its per-view ONNX export."""
+        model = _setup_test_model(tmp_path, request, multiview=True)
+        model.export("onnx", onnx_precision="fp16")
+        cache_dir = model.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+        assert (cache_dir / "trt_metadata.json").is_file()
+
+
 class TestOnnxRuntime:
     """Test loading a model with runtime='onnx'."""
 
@@ -615,7 +691,7 @@ class TestOnnxRuntime:
         """from_dir() rejects a runtime other than 'eager' or 'onnx'."""
         model = _setup_test_model(tmp_path, request)
         with pytest.raises(ValueError, match="Unsupported runtime"):
-            Model.from_dir(model.model_dir, runtime="tensorrt")  # type: ignore[arg-type]
+            Model.from_dir(model.model_dir, runtime="coreml")  # type: ignore[arg-type]
 
     def test_from_dir_raises_when_no_export_exists(self, tmp_path, request):
         """runtime='onnx' with no export points the user at export()."""
@@ -743,6 +819,133 @@ class TestOnnxRuntime:
         )
         max_deviation = np.nanmax(deviation)
         assert max_deviation < 0.1, f"max pixel deviation {max_deviation:.4f} >= 0.1"
+
+
+class TestTensorRTRuntime:
+    """Test loading a model with runtime='tensorrt'."""
+
+    pytestmark = pytest.mark.gpu
+
+    def test_from_dir_raises_when_no_trt_export_exists(self, tmp_path, request):
+        """runtime='tensorrt' with no engine cache points the user at export()."""
+        model = _setup_test_model(tmp_path, request)
+        with pytest.raises(
+            FileNotFoundError, match=r"Run model\.export\('tensorrt', \.\.\.\) first"
+        ):
+            Model.from_dir(model.model_dir, runtime="tensorrt")
+
+    def test_from_dir_tensorrt_raises_without_cuda(self, tmp_path, request):
+        """No CPU fallback for TensorRT -- fails immediately, not after a slow attempt."""
+        model = _setup_test_model(tmp_path, request)
+        with (
+            patch("torch.cuda.is_available", return_value=False),
+            pytest.raises(RuntimeError, match="requires a CUDA-capable GPU"),
+        ):
+            Model.from_dir(model.model_dir, runtime="tensorrt")
+
+    @requires_onnxruntime
+    def test_from_dir_tensorrt_sets_runtime(self, tmp_path, request):
+        """A real end-to-end export + load correctly marks _runtime."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp16")
+        model.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+        trt_model = Model.from_dir(
+            model.model_dir, runtime="tensorrt", onnx_precision="fp16"
+        )
+        assert trt_model._runtime == "tensorrt"
+
+    @requires_onnxruntime
+    def test_compile_raises_on_tensorrt_runtime(self, tmp_path, request):
+        """compile() is rejected on a TensorRT-backed model rather than silently no-op."""
+        model = _setup_test_model(tmp_path, request)
+        model.export("onnx", onnx_precision="fp16")
+        model.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+        trt_model = Model.from_dir(
+            model.model_dir, runtime="tensorrt", onnx_precision="fp16"
+        )
+        with pytest.raises(RuntimeError, match="only supported for runtime='eager'"):
+            trt_model.compile()
+        assert not trt_model._compiled
+
+    @requires_onnxruntime
+    def test_tensorrt_fp32_matches_eager_predictions(
+        self, tmp_path, request, toy_data_dir
+    ):
+        """TensorRT fp32 predictions match eager fp32 almost exactly.
+
+        Isolates the export/engine-build pipeline's own correctness from
+        precision-reduction noise: fp32 uses the same numerics as eager, so
+        a large deviation here would mean a real bug, not fp16 rounding.
+        """
+        csv_file = Path(toy_data_dir) / "CollectedData.csv"
+        eager_model = _setup_test_model(tmp_path / "eager", request)
+        trt_source = _setup_test_model(tmp_path / "trt", request)
+        trt_source.export("onnx", onnx_precision="fp32")
+        trt_source.export("tensorrt", onnx_precision="fp32", max_batch_size=4)
+        trt_model = Model.from_dir(
+            trt_source.model_dir, runtime="tensorrt", onnx_precision="fp32"
+        )
+        eager_preds = eager_model.predict_on_label_csv(csv_file).predictions
+        trt_preds = trt_model.predict_on_label_csv(csv_file).predictions
+        xy_cols = [c for c in eager_preds.columns if c[-1] in ("x", "y")]
+        deviation = np.abs(
+            eager_preds[xy_cols].to_numpy(dtype=float)
+            - trt_preds[xy_cols].to_numpy(dtype=float)
+        )
+        max_deviation = np.nanmax(deviation)
+        assert max_deviation < 0.01, f"max pixel deviation {max_deviation:.4f} >= 0.01"
+
+    @requires_onnxruntime
+    def test_tensorrt_fp16_matches_eager_predictions(
+        self, tmp_path, request, toy_data_dir
+    ):
+        """TensorRT fp16 mean deviation from eager fp32 stays small on confident keypoints.
+
+        fp16 quantization can shift the heatmap argmax by several pixels on
+        keypoints the model has no real opinion about (near-uniform heatmap,
+        likelihood near the ~1/n_pixels noise floor). This peak-flipping
+        happens under any precision or kernel change -- including the
+        already-merged ONNX fp16 path on the full (non-toy) dataset -- and
+        is not specific to TensorRT, so keypoints below likelihood 0.1 (no
+        real peak) are excluded here.
+
+        Even among the remaining confidently-tracked keypoints, TensorRT's
+        kernel autotuning makes engine builds non-deterministic: repeated
+        builds of the identical export measured max deviation anywhere from
+        ~0.5px to ~2.0px, i.e. the max is not a stable statistic on this
+        small (~18-value) toy sample. Mean deviation was stable across the
+        same repeated builds (~0.2-0.3px), so this test asserts on the mean
+        instead -- 1.0px leaves several-fold headroom while still catching
+        real breakage (a broken export/engine blows up the mean, not just
+        one keypoint's max -- see test_tensorrt_fp32_matches_eager_predictions
+        for a tight, precision-independent correctness check).
+        """
+        csv_file = Path(toy_data_dir) / "CollectedData.csv"
+        eager_model = _setup_test_model(tmp_path / "eager", request)
+        trt_source = _setup_test_model(tmp_path / "trt", request)
+        trt_source.export("onnx", onnx_precision="fp16")
+        trt_source.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+        trt_model = Model.from_dir(
+            trt_source.model_dir, runtime="tensorrt", onnx_precision="fp16"
+        )
+        eager_preds = eager_model.predict_on_label_csv(csv_file).predictions
+        trt_preds = trt_model.predict_on_label_csv(csv_file).predictions
+        xy_cols = [c for c in eager_preds.columns if c[-1] in ("x", "y")]
+        deviations = []
+        for col in xy_cols:
+            bp = col[-2]
+            lik_col = [
+                c
+                for c in eager_preds.columns
+                if c[-2] == bp and c[-1] == "likelihood"
+            ][0]
+            mask = eager_preds[lik_col] >= 0.1
+            dev = (eager_preds.loc[mask, col] - trt_preds.loc[mask, col]).abs()
+            deviations.extend(dev.tolist())
+        deviations = np.array(deviations, dtype=float)
+        assert len(deviations) > 0, "no confidently-tracked keypoints in toy data"
+        mean_deviation = np.nanmean(deviations)
+        assert mean_deviation < 1.0, f"mean pixel deviation {mean_deviation:.4f} >= 1.0"
 
 
 def _make_mock_model(tmp_path, *, multiview=False, context=False, num_views=2):
@@ -880,6 +1083,80 @@ class TestExportUnit:
             model.export("onnx")
 
 
+class TestTensorRTExportUnit:
+    """export('tensorrt', ...) tests that need neither a GPU nor onnxruntime."""
+
+    def _prepare_onnx_export(self, model, precision="fp16"):
+        """Create a stub .onnx file matching the mocked checkpoint stem."""
+        model.exports_onnx_dir().mkdir(parents=True, exist_ok=True)
+        path = model.exports_onnx_dir() / f"epoch=1-step=2-best_{precision}.onnx"
+        path.touch()
+        return path
+
+    def test_export_tensorrt_requires_existing_onnx_export(self, tmp_path, mock_ckpt):
+        """No matching .onnx export raises before importing onnxruntime."""
+        model = _make_mock_model(tmp_path)
+        with pytest.raises(FileNotFoundError, match=r"Run model\.export\('onnx'"):
+            model.export("tensorrt", onnx_precision="fp16")
+
+    def test_export_tensorrt_reads_shape_from_onnx_graph(self, tmp_path, mock_ckpt):
+        """The batch profile is built from the ONNX graph's own input shape,
+        not self.cfg -- see _export_tensorrt's docstring for why.
+        """
+        model = _make_mock_model(tmp_path)
+        self._prepare_onnx_export(model)
+        fake_module, probe_session = _fake_ort()
+        fake_module.__version__ = "1.28.0"
+        probe_session.get_inputs.return_value[0].shape = ["batch", 3, 256, 256]
+        build_session = MagicMock()
+        build_session.get_providers.return_value = ["TensorrtExecutionProvider"]
+        fake_module.InferenceSession.side_effect = [probe_session, build_session]
+        with patch.dict(sys.modules, {"onnxruntime": fake_module}):
+            model.export(
+                "tensorrt", onnx_precision="fp16", max_batch_size=4, opt_batch_size=2
+            )
+        build_kwargs = fake_module.InferenceSession.call_args_list[1]
+        trt_options = build_kwargs.kwargs["providers"][0][1]
+        assert trt_options["trt_profile_min_shapes"] == "images:1x3x256x256"
+        assert trt_options["trt_profile_opt_shapes"] == "images:2x3x256x256"
+        assert trt_options["trt_profile_max_shapes"] == "images:4x3x256x256"
+
+    def test_export_tensorrt_writes_metadata(self, tmp_path, mock_ckpt):
+        """trt_metadata.json is written with the expected keys."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_onnx_export(model)
+        fake_module, probe_session = _fake_ort()
+        fake_module.__version__ = "1.28.0"
+        build_session = MagicMock()
+        build_session.get_providers.return_value = ["TensorrtExecutionProvider"]
+        fake_module.InferenceSession.side_effect = [probe_session, build_session]
+        with (
+            patch.dict(sys.modules, {"onnxruntime": fake_module}),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_name", return_value="Fake GPU"),
+        ):
+            cache_dir = model.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+        metadata = json.loads((cache_dir / "trt_metadata.json").read_text())
+        assert metadata["gpu_name"] == "Fake GPU"
+        assert metadata["onnx_precision"] == "fp16"
+        assert metadata["max_batch_size"] == 4
+        assert metadata["opt_batch_size"] == 4
+
+    def test_export_tensorrt_provider_guard_raises(self, tmp_path, mock_ckpt):
+        """A build that doesn't engage TensorrtExecutionProvider raises."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_onnx_export(model)
+        fake_module, probe_session = _fake_ort()
+        build_session = MagicMock()
+        build_session.get_providers.return_value = ["CUDAExecutionProvider"]
+        fake_module.InferenceSession.side_effect = [probe_session, build_session]
+        with (
+            patch.dict(sys.modules, {"onnxruntime": fake_module}),
+            pytest.raises(RuntimeError, match="TensorrtExecutionProvider"),
+        ):
+            model.export("tensorrt", onnx_precision="fp16", max_batch_size=4)
+
+
 class TestOnnxRuntimeUnit:
     """Runtime-attach tests using a fake onnxruntime module.
 
@@ -981,3 +1258,137 @@ class TestOnnxRuntimeUnit:
         with patch.dict(sys.modules, {"onnxruntime": fake_module}):
             model._attach_onnx_runtime("fp32")
         assert fake_module.InferenceSession.call_args.args[0] == str(fp32_path)
+
+
+class TestTensorRTRuntimeUnit:
+    """runtime='tensorrt' attach tests using a fake onnxruntime module."""
+
+    def _prepare_onnx_export(self, model, precision="fp16"):
+        model.exports_onnx_dir().mkdir(parents=True, exist_ok=True)
+        path = model.exports_onnx_dir() / f"epoch=1-step=2-best_{precision}.onnx"
+        path.touch()
+        return path
+
+    def _prepare_trt_cache(self, model, precision="fp16", gpu_name="Fake GPU"):
+        cache_dir = model.exports_trt_dir() / f"epoch=1-step=2-best_{precision}"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        metadata = {
+            "gpu_name": gpu_name,
+            "tensorrt_version": "10.0.0",
+            "onnxruntime_version": "1.28.0",
+            "onnx_precision": precision,
+            "max_batch_size": 4,
+            "opt_batch_size": 4,
+            "built_at": "2026-01-01T00:00:00+00:00",
+        }
+        (cache_dir / "trt_metadata.json").write_text(json.dumps(metadata))
+        return cache_dir
+
+    def test_attach_tensorrt_raises_without_cuda(self, tmp_path, mock_ckpt):
+        """No CPU fallback for TensorRT."""
+        model = _make_mock_model(tmp_path)
+        with (
+            patch("torch.cuda.is_available", return_value=False),
+            pytest.raises(RuntimeError, match="requires a CUDA-capable GPU"),
+        ):
+            model._attach_tensorrt_runtime(None)
+
+    def test_attach_tensorrt_raises_when_no_cache(self, tmp_path, mock_ckpt):
+        """Missing engine cache points at export('tensorrt', ...)."""
+        model = _make_mock_model(tmp_path)
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            pytest.raises(
+                FileNotFoundError, match=r"Run model\.export\('tensorrt', \.\.\.\) first"
+            ),
+        ):
+            model._attach_tensorrt_runtime(None)
+
+    def test_attach_tensorrt_raises_when_multiple_caches(self, tmp_path, mock_ckpt):
+        """Ambiguous caches raise instead of picking one arbitrarily."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_trt_cache(model, "fp16")
+        self._prepare_trt_cache(model, "fp32")
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            pytest.raises(ValueError, match="Multiple TensorRT exports found"),
+        ):
+            model._attach_tensorrt_runtime(None)
+
+    def test_attach_tensorrt_gpu_mismatch_warns(self, tmp_path, mock_ckpt):
+        """A GPU-name mismatch warns rather than silently rebuilding unnoticed."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_onnx_export(model)
+        self._prepare_trt_cache(model, gpu_name="Some Other GPU")
+        fake_module, _ = _fake_ort(providers=["TensorrtExecutionProvider"])
+        with (
+            patch.dict(sys.modules, {"onnxruntime": fake_module}),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_name", return_value="Fake GPU"),
+            pytest.warns(UserWarning, match="was built on"),
+        ):
+            model._attach_tensorrt_runtime(None)
+
+    def test_attach_tensorrt_provider_guard_raises_on_cuda_fallback(self, tmp_path, mock_ckpt):
+        """Landing on CUDAExecutionProvider instead of TensorRT raises, not warns.
+
+        Unlike ONNX's CPU fallback, there is no acceptable degraded tier here.
+        """
+        model = _make_mock_model(tmp_path)
+        self._prepare_onnx_export(model)
+        self._prepare_trt_cache(model)
+        fake_module, _ = _fake_ort(providers=["CUDAExecutionProvider"])
+        with (
+            patch.dict(sys.modules, {"onnxruntime": fake_module}),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_name", return_value="Fake GPU"),
+            pytest.raises(RuntimeError, match="TensorrtExecutionProvider"),
+        ):
+            model._attach_tensorrt_runtime(None)
+
+    def test_attach_tensorrt_missing_dependency_explains_install(self, tmp_path, mock_ckpt):
+        """A missing optional dependency explains how to install it."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_onnx_export(model)
+        self._prepare_trt_cache(model)
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_name", return_value="Fake GPU"),
+            patch.dict(sys.modules, {"onnxruntime": None}),
+            pytest.raises(ImportError, match="increasing_inference_speed"),
+        ):
+            model._attach_tensorrt_runtime(None)
+
+    def test_attach_tensorrt_sets_runtime_and_rebinds_forward(self, tmp_path, mock_ckpt):
+        """Successful attach marks _runtime and replaces forward."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_onnx_export(model)
+        self._prepare_trt_cache(model)
+        assert model.model is not None
+        original_forward = model.model.forward
+        fake_module, _ = _fake_ort(providers=["TensorrtExecutionProvider"])
+        with (
+            patch.dict(sys.modules, {"onnxruntime": fake_module}),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_name", return_value="Fake GPU"),
+        ):
+            model._attach_tensorrt_runtime(None)
+        assert model._runtime == "tensorrt"
+        assert model.model.forward is not original_forward
+
+    def test_attach_tensorrt_selects_requested_precision(self, tmp_path, mock_ckpt):
+        """onnx_precision disambiguates when several caches exist."""
+        model = _make_mock_model(tmp_path)
+        self._prepare_onnx_export(model, "fp16")
+        self._prepare_onnx_export(model, "fp32")
+        self._prepare_trt_cache(model, "fp16")
+        self._prepare_trt_cache(model, "fp32")
+        fake_module, _ = _fake_ort(providers=["TensorrtExecutionProvider"])
+        with (
+            patch.dict(sys.modules, {"onnxruntime": fake_module}),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_name", return_value="Fake GPU"),
+        ):
+            model._attach_tensorrt_runtime("fp32")
+        onnx_call = fake_module.InferenceSession.call_args
+        assert "fp32" in onnx_call.args[0]

--- a/tests/cli/test_export.py
+++ b/tests/cli/test_export.py
@@ -34,18 +34,25 @@ class TestExportParser:
             parser.parse_args(['export', str(tmp_path / 'missing')])
 
     def test_runtime_default_is_onnx(self, parser, tmp_path):
-        """--runtime defaults to onnx, the only supported target today."""
+        """--runtime defaults to onnx."""
         model_dir = tmp_path / 'model'
         model_dir.mkdir()
         args = parser.parse_args(['export', str(model_dir)])
         assert args.runtime == 'onnx'
 
-    def test_runtime_rejects_tensorrt(self, parser, tmp_path):
-        """TensorRT is a planned follow-up and must not parse yet."""
+    def test_runtime_accepts_tensorrt(self, parser, tmp_path):
+        """--runtime tensorrt is parsed."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['export', str(model_dir), '--runtime', 'tensorrt'])
+        assert args.runtime == 'tensorrt'
+
+    def test_runtime_rejects_unknown_value(self, parser, tmp_path):
+        """A runtime other than onnx/tensorrt exits."""
         model_dir = tmp_path / 'model'
         model_dir.mkdir()
         with pytest.raises(SystemExit):
-            parser.parse_args(['export', str(model_dir), '--runtime', 'tensorrt'])
+            parser.parse_args(['export', str(model_dir), '--runtime', 'coreml'])
 
     def test_onnx_precision_default_is_fp16(self, parser, tmp_path):
         """--onnx-precision defaults to fp16."""
@@ -72,6 +79,38 @@ class TestExportParser:
                 ['export', str(model_dir), '--onnx-precision', 'bf16']
             )
 
+    def test_max_batch_size_default_is_8(self, parser, tmp_path):
+        """--max-batch-size defaults to 8."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['export', str(model_dir)])
+        assert args.max_batch_size == 8
+
+    def test_max_batch_size_custom(self, parser, tmp_path):
+        """--max-batch-size is parsed as an int."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['export', str(model_dir), '--max-batch-size', '32']
+        )
+        assert args.max_batch_size == 32
+
+    def test_opt_batch_size_default_is_none(self, parser, tmp_path):
+        """--opt-batch-size defaults to None (falls back to max_batch_size in export())."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['export', str(model_dir)])
+        assert args.opt_batch_size is None
+
+    def test_opt_batch_size_custom(self, parser, tmp_path):
+        """--opt-batch-size is parsed as an int."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['export', str(model_dir), '--opt-batch-size', '4']
+        )
+        assert args.opt_batch_size == 4
+
 
 class TestHandle:
     """Test the handle function."""
@@ -81,20 +120,27 @@ class TestHandle:
         """Mock Model returned by Model.from_dir."""
         return MagicMock()
 
-    def _make_args(self, tmp_path, runtime='onnx', onnx_precision='fp16'):
+    def _make_args(
+        self, tmp_path, runtime='onnx', onnx_precision='fp16',
+        max_batch_size=8, opt_batch_size=None,
+    ):
         return argparse.Namespace(
             model_dir=tmp_path / 'model',
             runtime=runtime,
             onnx_precision=onnx_precision,
+            max_batch_size=max_batch_size,
+            opt_batch_size=opt_batch_size,
         )
 
     def test_handle_calls_export(self, tmp_path, mock_model):
-        """handle() forwards runtime and onnx_precision to Model.export."""
+        """handle() forwards runtime, onnx_precision, and batch sizes to Model.export."""
         args = self._make_args(tmp_path)
         with patch('lightning_pose.api.Model') as MockModel:
             MockModel.from_dir.return_value = mock_model
             handle(args)
-        mock_model.export.assert_called_once_with('onnx', onnx_precision='fp16')
+        mock_model.export.assert_called_once_with(
+            'onnx', onnx_precision='fp16', max_batch_size=8, opt_batch_size=None,
+        )
 
     def test_handle_passes_fp32(self, tmp_path, mock_model):
         """handle() honors --onnx-precision fp32."""
@@ -102,7 +148,31 @@ class TestHandle:
         with patch('lightning_pose.api.Model') as MockModel:
             MockModel.from_dir.return_value = mock_model
             handle(args)
-        mock_model.export.assert_called_once_with('onnx', onnx_precision='fp32')
+        mock_model.export.assert_called_once_with(
+            'onnx', onnx_precision='fp32', max_batch_size=8, opt_batch_size=None,
+        )
+
+    def test_handle_passes_tensorrt_runtime(self, tmp_path, mock_model):
+        """handle() forwards --runtime tensorrt to Model.export."""
+        args = self._make_args(tmp_path, runtime='tensorrt')
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        mock_model.export.assert_called_once_with(
+            'tensorrt', onnx_precision='fp16', max_batch_size=8, opt_batch_size=None,
+        )
+
+    def test_handle_passes_custom_batch_sizes(self, tmp_path, mock_model):
+        """handle() forwards --max-batch-size and --opt-batch-size to Model.export."""
+        args = self._make_args(
+            tmp_path, runtime='tensorrt', max_batch_size=32, opt_batch_size=16,
+        )
+        with patch('lightning_pose.api.Model') as MockModel:
+            MockModel.from_dir.return_value = mock_model
+            handle(args)
+        mock_model.export.assert_called_once_with(
+            'tensorrt', onnx_precision='fp16', max_batch_size=32, opt_batch_size=16,
+        )
 
     def test_handle_loads_model_eagerly(self, tmp_path, mock_model):
         """handle() loads the model with the default eager runtime, not runtime=onnx.

--- a/tests/cli/test_predict.py
+++ b/tests/cli/test_predict.py
@@ -82,13 +82,22 @@ class TestPredictParser:
         )
         assert args.runtime == 'onnx'
 
+    def test_runtime_tensorrt(self, parser, tmp_path):
+        """--runtime tensorrt is parsed."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['predict', str(model_dir), 'video.mp4', '--runtime', 'tensorrt']
+        )
+        assert args.runtime == 'tensorrt'
+
     def test_runtime_rejects_unknown_value(self, parser, tmp_path):
-        """--runtime tensorrt exits; TensorRT is a planned follow-up, not supported."""
+        """A runtime other than eager/onnx/tensorrt exits."""
         model_dir = tmp_path / 'model'
         model_dir.mkdir()
         with pytest.raises(SystemExit):
             parser.parse_args(
-                ['predict', str(model_dir), 'video.mp4', '--runtime', 'tensorrt']
+                ['predict', str(model_dir), 'video.mp4', '--runtime', 'coreml']
             )
 
     def test_onnx_precision_default_is_none(self, parser, tmp_path):
@@ -341,3 +350,32 @@ class TestHandle:
             with pytest.raises(ValueError, match='only supported with --runtime eager'):
                 handle(args)
         MockModel.from_dir2.assert_not_called()
+
+    def test_handle_rejects_compile_with_tensorrt_runtime(self, tmp_path, mock_model):
+        """--compile with --runtime tensorrt fails the same way as --runtime onnx."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        args.compile = True
+        args.runtime = 'tensorrt'
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.cli.commands.predict._predict_multi_type'),
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            with pytest.raises(ValueError, match='only supported with --runtime eager'):
+                handle(args)
+        MockModel.from_dir2.assert_not_called()
+
+    def test_handle_threads_tensorrt_runtime_to_from_dir2(self, tmp_path, mock_model):
+        """handle() forwards --runtime tensorrt to Model.from_dir2 same as onnx."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        args.runtime = 'tensorrt'
+        args.onnx_precision = 'fp16'
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.cli.commands.predict._predict_multi_type'),
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            handle(args)
+        call_kwargs = MockModel.from_dir2.call_args.kwargs
+        assert call_kwargs['runtime'] == 'tensorrt'
+        assert call_kwargs['onnx_precision'] == 'fp16'


### PR DESCRIPTION
Closes #472.

Adds TensorRT export and inference runtime support, mirroring the structure from #470/#471 (ONNX export/runtime) and #467/#469 (torch.compile).

## API / CLI

- `Model.export("tensorrt", onnx_precision="fp16", max_batch_size=8, opt_batch_size=None)` builds a TensorRT engine cache from an existing ONNX export (via `onnxruntime`'s `TensorrtExecutionProvider`), written to `exports_trt/<checkpoint_stem>_<onnx_precision>/`.
- `Model.from_dir(model_dir, runtime="tensorrt", onnx_precision="fp16")` loads that engine and rebinds `forward`, same pattern as `runtime="onnx"`.
- `litpose export --runtime tensorrt --onnx-precision fp16 --max-batch-size 8 --opt-batch-size ...` / `litpose predict ... --runtime tensorrt --onnx-precision fp16` on the CLI side.
- A `trt_metadata.json` sidecar records GPU name, TensorRT/onnxruntime versions, and batch profile; `from_dir(runtime="tensorrt")` warns on a GPU-name mismatch, since engine caches are tied to the exact GPU they were built on (unlike the portable `.onnx` file).
- Shared the ONNX/TensorRT `forward`-rebinding closure into one `_build_onnx_forward()` helper used by both runtimes, per the optional suggestion in #470.

## Deviations from the issue's sketch (disclosed, not blockers)

- `_export_tensorrt()` doesn't call `self._load()` and never touches the trained torch weights -- confirmed empirically that the `TensorrtExecutionProvider` builds purely from the `.onnx` file (which already has weights baked in). Input shape for the dynamic-shape batch profile is read directly off the ONNX graph's own input metadata instead of re-deriving it from `self.cfg`/`self.model.do_context`, avoiding a second singleview/multiview/context branching implementation.
- The `onnx` package is required to *create* the `.onnx` file but not to build a TensorRT engine from an already-exported one -- confirmed by uninstalling it on a throwaway job and running the suite. Documented with that split rather than blanket "install onnx and onnxruntime-gpu."
- No CPU fallback tier for `runtime="tensorrt"` at all (raises immediately if no CUDA), stricter than ONNX Runtime's CPU tier -- there's no reasonable degraded mode for a GPU-built engine.

## Accuracy testing -- found something worth flagging

Following #471's precedent (`toy_data_dir`, threshold `<0.1px`) for the accuracy test didn't hold up under investigation, so I dug in rather than just loosening the number:

- **`test_tensorrt_fp32_matches_eager_predictions`** (new): TensorRT at FP32 vs eager is essentially exact -- max deviation 0.0038px across all keypoints, unfiltered. This isolates the export/engine-build pipeline's own correctness from precision noise. Threshold `<0.01px`.
- **`test_tensorrt_fp16_matches_eager_predictions`**: at FP16, an initial run failed at 2.74px max. Root-caused (not just loosened) via a breakdown script: every large deviation traced to keypoints at near-zero eager likelihood (~0.0003, i.e. the heatmap has no real peak) -- the same "peak-flipping" phenomenon already documented for the merged ONNX FP16 path on the full (non-toy) dataset, just showing up here because this toy fixture checkpoint leaves several bodyparts permanently at chance confidence. Filtering to confidently-tracked keypoints (eager likelihood >= 0.1) and repeating the fp16 export+build 3 more times showed the **max** is unstable run-to-run (0.52px / 1.95px / 0.92px) -- TensorRT's kernel autotuning makes engine builds non-deterministic -- while the **mean** stayed stable (~0.2-0.3px) across the same runs. So this test asserts on mean deviation (`<1.0px`, headroom over the observed range) rather than max, with the reasoning in the docstring.

Both findings, plus the "why mean not max" and "why FP16 differs from the FP32 accuracy check earlier on the docs page" reasoning, are also written into `increasing_inference_speed.rst`'s TensorRT section rather than left implicit.

## Testing

- `pyright`: 0 errors (project-wide)
- `ruff check`: clean
- `pre-commit run`: clean
- GPU (T4, `tests/api/test_model.py -q`, no marker filter, to catch collateral damage): 85/85 passed
- CPU (`tests/cli/test_export.py tests/cli/test_predict.py tests/api/test_model.py -m "not gpu"`): 81/81 passed
- Docs: `docutils` clean, full `sphinx-build` clean (verified the `#tensorrt-installation` anchor and both `exports_trt/` mentions render in the built HTML)

## Docs

- New "TensorRT" Installation/Usage subsections in `increasing_inference_speed.rst` (version-matching guidance, `LD_LIBRARY_PATH`, the `onnx`-not-required-to-build finding, the new API usage, the accuracy caveat above).
- `exports_trt/` entry added to `model_dir_structure.rst`.
