### PR TITLE
Add PyNvVideoCodec decoder backend for video prediction (--decoder flag)

### DIFF
--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -346,6 +346,61 @@ library versions:
   ``CUDAExecutionProvider`` rather than raising an error -- your code will still run and
   produce plausible-looking numbers, just not the ones you think.
 
+.. _pynvvc_decoding:
+
+PyNvVideoCodec (Video Decoding)
+--------------------------------
+
+Everything above speeds up the *model's forward pass*. This section covers a separate,
+complementary axis: how the video frames themselves get decoded off disk before they ever
+reach the model. By default, ``litpose predict`` decodes video with DALI's GPU video reader.
+PyNvVideoCodec (direct NVIDIA Video Codec SDK / NVDEC bindings) is an alternative decoder
+backend that talks to the hardware decoder more directly, skipping DALI's pipeline/graph
+framework overhead.
+
+On a T4, decoding the same video with PyNvVideoCodec measured **8.76x faster** than DALI's GPU
+reader (3735.7 vs 426.5 fps, 7 timed runs). This is a decode-throughput-only number, not an
+end-to-end ``litpose predict`` speedup -- how much it moves the needle overall depends on how
+much of your pipeline's time is spent decoding vs. running the model (see the data-loading
+caveat below).
+
+Installation
+~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    pip install PyNvVideoCodec
+
+Requires an NVIDIA GPU from the Turing generation or newer (Turing/Ampere/Ada/Hopper/Blackwell)
+and driver version 530.41.03 or newer on Linux. If PyNvVideoCodec can't decode a given video on
+the current machine (unsupported GPU generation, driver too old, package not installed, or an
+unsupported video format), ``litpose predict`` automatically falls back to DALI rather than
+erroring -- see below.
+
+Usage
+~~~~~
+
+``--decoder`` is independent of ``--runtime``/``--compile`` above -- it only controls how video
+frames are read, not how the model runs on them. From the CLI:
+
+.. code-block:: console
+
+    litpose predict /path/to/model_dir /path/to/video.mp4 --decoder pynvvc
+    litpose predict /path/to/model_dir /path/to/video.mp4 --decoder dali
+
+Or from the API:
+
+.. code-block:: python
+
+    model = Model.from_dir("path/to/model_dir")
+    result = model.predict_on_video_file("path/to/video.mp4", decoder="pynvvc")
+
+Omitting ``--decoder`` (or passing ``decoder=None``) auto-selects PyNvVideoCodec when it's
+usable on the current machine for the given video, falling back to DALI otherwise -- no error,
+just a quieter/slower run. Explicitly requesting ``--decoder pynvvc`` on a machine where it
+isn't usable raises a clear error instead of silently falling back, so you know your run isn't
+using the backend you asked for.
+
 .. _caveats:
 
 Caveats
@@ -353,7 +408,7 @@ Caveats
 
 - **These are isolated forward-pass numbers, not end-to-end** ``litpose predict`` **timings.**
   Real inference also includes data loading (DALI) and postprocessing. These forward-pass
-  gains aren't guaranteed to translate 1:1 into end-to-end speedups as-is.
+  gains aren't guaranteed to translate 1:1 into end-to-end speedups as-is. See :ref:`PyNvVideoCodec <pynvvc_decoding>` above for a way to speed up the data-loading half of that gap.
 - **cuDNN TF32 was left on for the ResNet50 eager-FP32 baseline** (only matmul TF32 was
   disabled), so it's not a fully strict FP32 number -- doesn't change the direction of any
   result here.

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -5,12 +5,14 @@ Increasing Inference Speed
 ##########################
 
 In addition to :ref:`running inference at reduced precision <mixed_precision>`, Lightning Pose
-models can be accelerated further with three additional techniques:
+models can be accelerated further with additional techniques that speed up model processing --
 `torch.compile() <https://pytorch.org/docs/stable/generated/torch.compile.html>`_,
 `ONNX Runtime <https://onnxruntime.ai/>`_, and
-`TensorRT <https://developer.nvidia.com/tensorrt>`_. This page benchmarks all four options
-together (including eager FP16 for reference) and walks through how to use each one, assuming
-you've already trained a model with ``litpose train``.
+`TensorRT <https://developer.nvidia.com/tensorrt>`_ -- and with hardware-accelerated video
+decoding -- :ref:`PyNvVideoCodec <pynvvc_decoding>`. This page benchmarks the model-processing
+techniques together (including eager FP16 for reference) and walks through how to use each one,
+assuming you've already trained a model with ``litpose train``; see the
+:ref:`PyNvVideoCodec section <pynvvc_decoding>` below for the video-decoding benchmarks and usage.
 
 **TL;DR**
 
@@ -24,10 +26,6 @@ you've already trained a model with ``litpose train``.
   max deviation was under 0.08px in every case, consistent with ordinary floating-point kernel
   differences and far below any dataset's typical pixel error (see
   :ref:`Accuracy check <accuracy_check>` below).
-- **These numbers are isolated forward-pass speedups** (no data loading), same methodology as
-  the mixed-precision speed numbers. See the :ref:`caveat <caveats>` at the bottom of this page
-  about the gap between forward-pass and end-to-end ``litpose predict`` speed.
-
 Overview
 ========
 
@@ -43,6 +41,13 @@ Overview
 - **TensorRT** -- same ONNX export, but run through onnxruntime's ``TensorrtExecutionProvider``,
   which builds an autotuned, hardware-specific inference engine. Most setup, biggest gains. See
   :ref:`Usage: TensorRT <usage_tensorrt>`.
+- **PyNvVideoCodec** -- hardware-accelerated video *decoding* via direct NVIDIA Video Codec SDK
+  bindings, as an alternative to DALI's video reader. Independent of the model-processing
+  techniques above -- see :ref:`PyNvVideoCodec (Video Decoding) <pynvvc_decoding>`.
+- **These techniques are complementary and can be combined** -- e.g. torch.compile() or
+  TensorRT for the model together with PyNvVideoCodec for decoding -- for the best end-to-end
+  throughput. Not yet benchmarked together on this page; a combined benchmark is planned for a
+  follow-up PR.
 
 Results
 =======

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -364,6 +364,18 @@ end-to-end ``litpose predict`` speedup -- how much it moves the needle overall d
 much of your pipeline's time is spent decoding vs. running the model (see the data-loading
 caveat below).
 
+.. note::
+
+   ``PreparePynvvc`` (the class backing ``--decoder pynvvc``) reads its window size from
+   the existing ``cfg.dali`` config section --
+   ``dali.base.predict.sequence_length`` / ``dali.context.predict.sequence_length`` --
+   rather than a separate ``cfg.pynvvc`` section. The name is a little confusing, since
+   this setting also governs how many frames PyNvVideoCodec reads per batch, but the
+   windowing semantics (frames per iteration, overlap for context/MHCRNN models) are
+   identical between the two decoder backends, so one config value covers both rather
+   than keeping two in sync. If you only ever use ``--decoder pynvvc`` and never DALI,
+   you still configure the window size via ``dali.*.predict.sequence_length``.
+
 Installation
 ~~~~~~~~~~~~
 

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -413,6 +413,60 @@ just a quieter/slower run. Explicitly requesting ``--decoder pynvvc`` on a machi
 isn't usable raises a clear error instead of silently falling back, so you know your run isn't
 using the backend you asked for.
 
+Decode speed: L4 and A100, single- and multi-view
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Decode-only throughput (no model), 7 timed runs each, 64-frame batches:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Config
+     - GPU
+     - DALI
+     - PyNvVideoCodec
+     - Speedup
+   * - Single-view (``mirror-mouse-fused``, 1 view)
+     - L4
+     - 1516 fps
+     - 4442 fps
+     - **2.93x**
+   * - Single-view (``mirror-mouse-fused``, 1 view)
+     - A100
+     - 1113 fps
+     - 3249 fps
+     - **2.92x**
+   * - Multi-view (``fly-anipose``, 6 views)
+     - L4
+     - 5347 fps
+     - 3674 fps
+     - 0.69x (slower)
+   * - Multi-view (``fly-anipose``, 6 views)
+     - A100
+     - 4487 fps
+     - 2684 fps
+     - 0.60x (slower)
+
+.. note::
+
+   The multi-view result reverses direction from single-view: PyNvVideoCodec is
+   clearly faster for a single video, but *slower* than DALI once 6 views are
+   involved. The current implementation reads each view's decoder sequentially in
+   a loop (one ``get_batch_frames()`` call after another, not concurrently) --
+   which is also exactly what ``--decoder pynvvc`` does in production for
+   multiview, so this is a real characteristic of the current implementation, not
+   a benchmark artifact. DALI's pipeline appears to handle multiple video streams
+   more efficiently under its own internal scheduling. For single-view video,
+   ``--decoder pynvvc`` is a clear win; for multiview, it's currently a net loss on
+   raw decode speed even though the model's forward pass itself still speeds up
+   with reduced precision (see the multiview forward-pass numbers above) --
+   something worth revisiting if concurrent per-view decoding is added later.
+
+   Separately, single-view decode speedup is notably lower on L4/A100 here
+   (~2.9x) than the T4 number above (8.76x) -- not yet investigated further, but
+   worth keeping in mind that the T4 number shouldn't be assumed to generalize to
+   newer GPUs.
+
 .. _caveats:
 
 Caveats

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -78,7 +78,7 @@ _OnnxPrecision = Literal["fp32", "fp16"]
 # Inference runtimes accepted by Model.from_dir(runtime=...). "tensorrt" is a
 # planned addition that will consume the same exported .onnx file through a
 # different execution provider.
-_Runtime = Literal["eager", "onnx"]
+_Runtime = Literal["eager", "onnx", "tensorrt"]
 # Video-decoding backends accepted by predict_on_video_file(_multiview)'s decoder=
 # kwarg. Independent of _Runtime -- decoder controls video ingestion, _Runtime
 # controls model execution.

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -75,9 +75,7 @@ _CONTEXT_SEQUENCE_LENGTH = 5
 # autocast precision used for eager inference.
 _OnnxPrecision = Literal["fp32", "fp16"]
 
-# Inference runtimes accepted by Model.from_dir(runtime=...). "tensorrt" is a
-# planned addition that will consume the same exported .onnx file through a
-# different execution provider.
+# Inference runtimes accepted by Model.from_dir(runtime=...).
 _Runtime = Literal["eager", "onnx", "tensorrt"]
 # Video-decoding backends accepted by predict_on_video_file(_multiview)'s decoder=
 # kwarg. Independent of _Runtime -- decoder controls video ingestion, _Runtime

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -77,6 +77,10 @@ _OnnxPrecision = Literal["fp32", "fp16"]
 # planned addition that will consume the same exported .onnx file through a
 # different execution provider.
 _Runtime = Literal["eager", "onnx"]
+# Video-decoding backends accepted by predict_on_video_file(_multiview)'s decoder=
+# kwarg. Independent of _Runtime -- decoder controls video ingestion, _Runtime
+# controls model execution.
+_Decoder = Literal["dali", "pynvvc"]
 
 # Maps onnxruntime's tensor type strings to numpy dtypes. Used to bind input
 # buffers at whatever precision the exported file actually expects, rather than
@@ -1143,6 +1147,7 @@ class Model:
         compute_metrics: bool = True,
         generate_labeled_video: bool = False,
         progress_file: Path | None = None,
+        decoder: _Decoder | None = None,
         bbox_file: str | Path | None = None,
     ) -> PredictionResult:
         """Predicts on a video file and computes unsupervised loss metrics if applicable.
@@ -1158,6 +1163,10 @@ class Model:
                 Defaults to False.
             progress_file (Path, optional): Path to a file to save progress information for the
                 App. Defaults to None.
+            decoder (optional): which video-decoding backend to use, "dali" or "pynvvc".
+                None (default) auto-selects pynvvc if it's usable on this machine for this
+                video, else falls back to dali. Independent of the model's runtime
+                (eager/onnx) and torch.compile -- this only controls video ingestion.
             bbox_file (str | Path, optional): Path to a per-frame bbox CSV (columns x, y, h, w;
                 one row per frame). When provided, each frame is cropped to its bounding box
                 before being passed to the model, and predictions are returned in the original
@@ -1196,6 +1205,7 @@ class Model:
             model=self,
             output_pred_file=str(prediction_csv_file),
             progress_file=progress_file,
+            decoder=decoder,
             bbox_file=bbox_file,
         )
         if generate_labeled_video:
@@ -1229,6 +1239,7 @@ class Model:
         compute_metrics: bool = True,
         generate_labeled_video: bool = False,
         progress_file: Path | None = None,
+        decoder: _Decoder | None = None,
     ) -> MultiviewPredictionResult:
         """Version of ``predict_on_video_file`` that accesses multiple camera views of each frame.
 
@@ -1241,6 +1252,9 @@ class Model:
             compute_metrics: whether to compute pixel error and loss metrics on predictions.
             generate_labeled_video: whether to save a labeled video.
             progress_file: path to a file to save progress information for the App.
+            decoder: which video-decoding backend to use, "dali" or "pynvvc". None (default)
+                auto-selects pynvvc if it's usable on this machine for this video, else falls
+                back to dali.
 
         Returns:
             object containing the predictions and metrics for each view.
@@ -1285,6 +1299,7 @@ class Model:
             model=self,
             output_pred_file=prediction_csv_file_list,
             progress_file=progress_file,
+            decoder=decoder,
         )
         if generate_labeled_video:
             for video_file, preds_df in zip(video_file_per_view, df_list, strict=True):

--- a/lightning_pose/cli/commands/predict.py
+++ b/lightning_pose/cli/commands/predict.py
@@ -7,7 +7,7 @@ import logging
 import textwrap
 from pathlib import Path
 from pprint import pformat
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from .. import types
 
@@ -26,6 +26,13 @@ _PRECISION_CHOICES = ("fp32", "fp16", "bf16")
 # checkpoint; "onnx" runs an ONNX Runtime session previously built with
 # `litpose export`.
 _RUNTIME_CHOICES = ("eager", "onnx")
+
+# Video-decoding backend accepted by --decoder. Independent of --runtime: decoder
+# controls video ingestion (DALI vs PyNvVideoCodec), while --runtime controls model
+# execution (eager vs onnx). Only applies to video inputs, not CSV/image predictions.
+_DECODER_CHOICES = ("dali", "pynvvc")
+
+_Decoder = Literal["dali", "pynvvc"]
 
 # Selects which exported file --runtime onnx loads. Distinct from --precision:
 # this is the precision baked into the .onnx file, not autocast precision.
@@ -142,6 +149,19 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
     )
 
     predict_parser.add_argument(
+        "--decoder",
+        choices=sorted(_DECODER_CHOICES),
+        default=None,
+        help=(
+            "video-decoding backend for video inputs. 'dali' or 'pynvvc'. If omitted "
+            "(default), auto-selects 'pynvvc' when it's usable on this machine for the "
+            "given video, else falls back to 'dali'. Independent of --runtime/--compile "
+            "-- this only controls video ingestion, not model execution. Ignored for "
+            "CSV/image inputs."
+        ),
+    )
+
+    predict_parser.add_argument(
         "--compile",
         action="store_true",
         default=False,
@@ -201,7 +221,8 @@ def handle(args: argparse.Namespace) -> None:
 
     if model.config.is_multi_view():
         _predict_multi_type_multi_view(
-            model, input_paths, args.skip_viz, not args.overwrite, progress_file=args.progress_file
+            model, input_paths, args.skip_viz, not args.overwrite,
+            progress_file=args.progress_file, decoder=args.decoder,
         )
     else:
         for p in input_paths:
@@ -209,6 +230,7 @@ def handle(args: argparse.Namespace) -> None:
                 model, p, args.skip_viz, not args.overwrite,
                 progress_file=args.progress_file,
                 bbox_dir=args.bbox_dir,
+                decoder=args.decoder,
             )
 
 
@@ -219,6 +241,7 @@ def _predict_multi_type(
     skip_existing: bool,
     progress_file: Path | None = None,
     bbox_dir: Path | None = None,
+    decoder: _Decoder | None = None,
 ) -> None:
     """Run prediction on a single path, dispatching to video, CSV, or directory handling.
 
@@ -244,6 +267,7 @@ def _predict_multi_type(
                 model, p, skip_viz, skip_existing,
                 progress_file=progress_file,
                 bbox_dir=bbox_dir,
+                decoder=decoder,
             )
 
     elif path.suffix == ".mp4":
@@ -258,6 +282,7 @@ def _predict_multi_type(
             generate_labeled_video=(not skip_viz),
             progress_file=progress_file,
             bbox_file=bbox_dir / f'{path.stem}_bbox.csv' if bbox_dir is not None else None,
+            decoder=decoder,
         )
     elif path.suffix == ".csv":
         # Check if prediction file already exists
@@ -282,6 +307,7 @@ def _predict_multi_type_multi_view(
     skip_viz: bool,
     skip_existing: bool,
     progress_file: Path | None = None,
+    decoder: _Decoder | None = None,
 ) -> None:
     """Run multi-view prediction on a list of paths (videos or directories).
 
@@ -328,6 +354,7 @@ def _predict_multi_type_multi_view(
                 video_file_per_view,
                 generate_labeled_video=not skip_viz,
                 progress_file=progress_file,
+                decoder=decoder,
             )
     # if we have a list of directories, we process the videos in each separately
     elif all(path.is_dir() for path in paths):
@@ -339,7 +366,8 @@ def _predict_multi_type_multi_view(
                 logger.info(f'processing directory {path}')
 
                 _predict_multi_type_multi_view(
-                    model, video_files, skip_viz, skip_existing, progress_file=progress_file
+                    model, video_files, skip_viz, skip_existing,
+                    progress_file=progress_file, decoder=decoder,
                 )
             else:
                 logger.info(f'skipping {path}: no videos found')

--- a/lightning_pose/data/bboxes.py
+++ b/lightning_pose/data/bboxes.py
@@ -26,7 +26,9 @@ dimensions; handle both single-view and multi-view):
 - :func:`model_to_frame_batch` — model → frame  (called after inference)
 """
 
+import pandas as pd
 import torch
+import torch.nn.functional as F
 from jaxtyping import Float
 
 from lightning_pose.data.datatypes import (
@@ -284,3 +286,58 @@ def model_to_frame_batch(
         model_keypoints_ = norm_to_frame(model_keypoints_, batch_dict['bbox'])
     # return new keypoints, reshaped to (batch, num_targets)
     return model_keypoints_.reshape((-1, num_targets))
+
+
+def crop_and_resize_frames(
+    frames: Float[torch.Tensor, "seq_len rgb h w"],
+    bbox_rows: pd.DataFrame,
+    resize_dims: list[int],
+) -> tuple[
+    Float[torch.Tensor, "seq_len rgb h_out w_out"],
+    Float[torch.Tensor, "seq_len xyhw"],
+]:
+    """Crop each frame to its per-frame bounding box and resize to a common size.
+
+    Shared by the DALI and pynvvc video-decoding backends: both hand this function a
+    full-resolution ``frames`` tensor plus one already-sliced-and-padded bbox row per
+    frame (cursor/step bookkeeping to select those rows lives in each backend's own
+    wrapper, not here — see ``LitDaliWrapper._apply_bbox_crop``).
+
+    Args:
+        frames: full-resolution frames, shape (seq_len, 3, H, W).
+        bbox_rows: DataFrame with columns ``["x", "y", "h", "w"]``, exactly ``seq_len``
+            rows, one per frame (already sliced/padded by the caller).
+        resize_dims: target ``[height, width]`` to resize each crop to.
+
+    Returns:
+        Tuple of (cropped+resized frames, actual bbox coordinates used per frame).
+        Bbox coordinates are clamped to frame bounds and may differ from the raw
+        ``bbox_rows`` values for edge frames (see negative x/y handling below).
+    """
+    seq_len = frames.shape[0]
+    frame_h, frame_w = frames.shape[2], frames.shape[3]
+    cropped_frames = []
+    bboxes = []
+    for i in range(seq_len):
+        row = bbox_rows.iloc[i]
+        # clamp to frame bounds: create_bbox can produce negative x/y for edge frames
+        # (centroid - bbox_size//2 < 0). negative pytorch slice indices count from the
+        # end rather than clamping, producing an empty crop.
+        x1 = max(0, int(row['x']))
+        y1 = max(0, int(row['y']))
+        x2 = max(x1 + 1, min(frame_w, int(row['x']) + int(row['w'])))
+        y2 = max(y1 + 1, min(frame_h, int(row['y']) + int(row['h'])))
+        frame_cropped = frames[i, :, y1:y2, x1:x2]
+        frame_resized = F.interpolate(
+            frame_cropped.unsqueeze(0),
+            size=resize_dims,
+            mode='bilinear',
+            align_corners=False,
+        ).squeeze(0)
+        cropped_frames.append(frame_resized)
+        bboxes.append(
+            torch.tensor(
+                [x1, y1, y2 - y1, x2 - x1], dtype=torch.float32, device=frames.device,
+            )
+        )
+    return torch.stack(cropped_frames), torch.stack(bboxes)

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -41,7 +41,6 @@ from typing import Any, Literal
 import numpy as np
 import pandas as pd
 import torch
-import torch.nn.functional as F
 from omegaconf import DictConfig, ListConfig
 
 try:
@@ -56,6 +55,7 @@ except ImportError as e:
     ) from e
 
 from lightning_pose.data import _IMAGENET_MEAN, _IMAGENET_STD
+from lightning_pose.data.bboxes import crop_and_resize_frames
 from lightning_pose.data.datatypes import (
     MultiviewUnlabeledBatchDict,
     UnlabeledBatchDict,
@@ -360,38 +360,14 @@ class LitDaliWrapper(DALIGenericIterator):
                 ignore_index=True,
             )
 
-        frame_h, frame_w = frames.shape[2], frames.shape[3]
-        cropped_frames = []
-        bboxes = []
-        for i in range(seq_len):
-            row = rows.iloc[i]
-            # clamp to frame bounds: create_bbox can produce negative x/y for edge frames
-            # (centroid - bbox_size//2 < 0). negative pytorch slice indices count from the
-            # end rather than clamping, producing an empty crop.
-            x1 = max(0, int(row['x']))
-            y1 = max(0, int(row['y']))
-            x2 = max(x1 + 1, min(frame_w, int(row['x']) + int(row['w'])))
-            y2 = max(y1 + 1, min(frame_h, int(row['y']) + int(row['h'])))
-            frame_cropped = frames[i, :, y1:y2, x1:x2]
-            frame_resized = F.interpolate(
-                frame_cropped.unsqueeze(0),
-                size=self.resize_dims,
-                mode='bilinear',
-                align_corners=False,
-            ).squeeze(0)
-            cropped_frames.append(frame_resized)
-            bboxes.append(
-                torch.tensor(
-                    [x1, y1, y2 - y1, x2 - x1], dtype=torch.float32, device=frames.device,
-                )
-            )
-
+        assert self.resize_dims is not None  # required when bbox_df set, see docstring
+        cropped_frames, bboxes = crop_and_resize_frames(frames, rows, self.resize_dims)
         self._frame_idx += step
 
         return UnlabeledBatchDict(
-            frames=torch.stack(cropped_frames),
+            frames=cropped_frames,
             transforms=batch_dict['transforms'],
-            bbox=torch.stack(bboxes),
+            bbox=bboxes,
             is_multiview=False,
         )
 

--- a/lightning_pose/data/pynvvc.py
+++ b/lightning_pose/data/pynvvc.py
@@ -1,0 +1,445 @@
+"""Data pipeline for video prediction based on PyNvVideoCodec (direct NVDEC access).
+
+Import warning
+--------------
+Same discipline as ``lightning_pose.data.dali``: ``pynvvideocodec`` is an unconditional
+but platform-gated dependency (Linux x86_64 only), so importing this module at the top
+level of any other module could raise ``ImportError``/``ModuleNotFoundError`` on other
+platforms. Always import from this module lazily, inside the function or method body
+that uses it::
+
+    def my_function(...):
+        from lightning_pose.data.pynvvc import PreparePynvvc  # lazy
+        ...
+
+The ``PyNvVideoCodec`` package itself is additionally deferred to inside
+``LitPynvvcWrapper.__init__`` and ``is_pynvvc_available`` specifically, rather than
+this module's top level, since ``import PyNvVideoCodec`` succeeds regardless of GPU
+generation or driver age (Turing/Ampere/Ada/Hopper/Blackwell only, driver >= 530.41.03
+on Linux) -- the failure only surfaces when a decoder is actually constructed.
+
+Architecture overview
+----------------------
+Mirrors ``lightning_pose.data.dali``'s two-phase construction: ``PreparePynvvc.__init__``
+validates inputs and precomputes windowing parameters; calling the instance
+(``__call__``) builds and returns a ready-to-iterate ``LitPynvvcWrapper``.
+
+Predict-only, unlike ``PrepareDALI``: this backend never runs ``random_shuffle`` or the
+``imgaug`` augmentation pipeline, since ``litpose predict`` already runs with both off.
+Training continues to go through DALI exclusively (``lightning_pose.data.dali``).
+
+CUDA stream synchronization
+----------------------------
+``PyNvVideoCodec.SimpleDecoder`` writes decoded frames asynchronously on its own
+internal CUDA stream and hands them back as DLPack buffers. If a consumer (this
+module's own resize/normalize step, or eventually the model's forward pass) reads
+those buffers on a different stream before the decode is actually finished, the read
+happens on stale/partial data -- silently. No crash, no NaN, just quietly wrong
+pixels feeding a plausible-looking keypoint prediction. ``LitPynvvcWrapper.__next__``
+guards against this with an explicit ``torch.cuda.current_stream().synchronize()``
+after building each batch's frame tensors and before returning them. This is the
+"safe but not necessarily optimal" fix flagged in issue #476 -- passing an explicit
+stream handle into the decoder constructor (if supported) would avoid the sync cost
+entirely, but that needs checking against the installed PyNvVideoCodec version and is
+tracked as a follow-up, not done here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn.functional as F
+from omegaconf import DictConfig, ListConfig
+
+from lightning_pose.data import _IMAGENET_MEAN, _IMAGENET_STD
+from lightning_pose.data.bboxes import crop_and_resize_frames
+from lightning_pose.data.datatypes import (
+    MultiviewUnlabeledBatchDict,
+    UnlabeledBatchDict,
+)
+from lightning_pose.data.utils import count_frames
+
+if TYPE_CHECKING:
+    import PyNvVideoCodec as nvc
+
+logger = logging.getLogger(__name__)
+
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
+
+
+def is_pynvvc_available(video_path: str, gpu_id: int = 0) -> bool:
+    """Best-effort check whether the pynvvc decoder backend can actually decode.
+
+    Unlike a plain ``import PyNvVideoCodec`` (which succeeds regardless of GPU
+    generation or driver age -- see module docstring), this attempts a real decoder
+    construction against ``video_path``, since NVDEC hardware-support failures only
+    surface there, not at import time. Intended to be called once per predict call
+    (e.g. by the CLI/API's auto-selection logic), not per-batch -- constructing a
+    ``SimpleDecoder`` has real setup cost.
+
+    Args:
+        video_path: path to a real, existing video file to probe decodability with.
+        gpu_id: CUDA device index to attempt decoding on.
+
+    Returns:
+        True if a decoder was constructed successfully, False on any exception
+        (unsupported GPU generation, driver too old, corrupt/unsupported container,
+        pynvvideocodec not installed, etc.) -- deliberately broad, since every
+        failure mode here should fall back to DALI rather than propagate.
+    """
+    try:
+        import PyNvVideoCodec as nvc  # lazy: avoids ImportError on cpu-only installs
+
+        decoder = nvc.SimpleDecoder(video_path, gpu_id=gpu_id, use_device_memory=True)
+        del decoder
+        return True
+    except Exception:
+        logger.debug("pynvvc decoder unavailable", exc_info=True)
+        return False
+
+
+class LitPynvvcWrapper:
+    """PyNvVideoCodec-backed iterator for Lightning Pose video prediction.
+
+    Mirrors ``LitDaliWrapper``'s public shape (iterable, ``__len__``, yields typed
+    batch dicts consumable by ``trainer.predict()``) but is not a
+    ``DALIGenericIterator`` subclass -- built directly on one
+    ``PyNvVideoCodec.SimpleDecoder`` per view instead of a DALI pipeline.
+
+    Predict-only: no ``random_shuffle``, no ``imgaug``. See
+    ``lightning_pose.data.dali.LitDaliWrapper`` for the train-time DALI path, which
+    this class does not replicate.
+    """
+
+    def __init__(
+        self,
+        filenames: list[list[str]],
+        resize_dims: list[int],
+        decode_resize_dims: list[int] | None,
+        sequence_length: int,
+        step: int,
+        do_context: bool,
+        num_iters: int,
+        multiview: bool,
+        bbox_df: pd.DataFrame | None = None,
+        gpu_id: int = 0,
+    ) -> None:
+        """
+        Args:
+            filenames: one single-element list per view, e.g. ``[["v0.mp4"]]`` for
+                single-view or ``[["v0.mp4"], ["v1.mp4"]]`` for multiview -- always
+                exactly one video per view (no multi-session batching in predict).
+            resize_dims: ``[height, width]`` the model expects as input. Used as the
+                post-crop resize target when ``bbox_df`` is set.
+            decode_resize_dims: ``[height, width]`` to resize decoded frames to
+                immediately after decode. ``None`` in bbox-crop mode (full-resolution
+                frames are needed for cropping); equal to ``resize_dims`` otherwise.
+            sequence_length: number of frames per batch/window.
+            step: frames to advance the read cursor between windows. Equals
+                ``sequence_length`` for non-overlapping ("base") windows, or
+                ``sequence_length - 4`` for context models' overlapping windows.
+            do_context: whether this is a 5-frame-context (MHCRNN-style) model.
+            num_iters: total number of batches this video will produce; precomputed
+                by ``PreparePynvvc.num_iters`` so Lightning can report progress.
+            multiview: whether this is a multiview prediction (one decoder per view,
+                read in lockstep since predict never shuffles).
+            bbox_df: optional per-frame bbox DataFrame (columns x, y, h, w); single-
+                view only (enforced upstream in ``predict_video``).
+            gpu_id: CUDA device index to decode on.
+        """
+        import PyNvVideoCodec as nvc  # lazy: avoids ImportError on cpu-only installs
+
+        self.resize_dims = resize_dims
+        self.decode_resize_dims = decode_resize_dims
+        self.sequence_length = sequence_length
+        self.step = step
+        self.do_context = do_context
+        self.num_iters = num_iters
+        self.multiview = multiview
+        self.bbox_df = bbox_df
+        self.gpu_id = gpu_id
+
+        self._decoders = [
+            nvc.SimpleDecoder(
+                view_list[0],
+                gpu_id=gpu_id,
+                use_device_memory=True,
+                # planar CHW per frame, so stacking sequence_length frames gives
+                # (seq_len, C, H, W) directly -- matches DALI's FCHW output layout.
+                output_color_type=nvc.OutputColorType.RGBP,  # type: ignore[attr-defined]
+            )
+            for view_list in filenames
+        ]
+        self._total_frames = len(self._decoders[0])
+
+        self._cursor = 0
+        self._iters_done = 0
+        # cursor into bbox_df; advances by the context-adjusted step per batch, same
+        # convention as LitDaliWrapper._frame_idx
+        self._frame_idx = 0
+
+    def __len__(self) -> int:
+        """Return the number of iterations (batches) in this dataloader."""
+        return self.num_iters
+
+    def __iter__(self) -> LitPynvvcWrapper:
+        return self
+
+    def _read_window(self, decoder: nvc.SimpleDecoder) -> torch.Tensor:
+        """Read ``sequence_length`` frames starting at ``self._cursor``.
+
+        Pads the final window by repeating the last real frame so every batch has a
+        static shape (matches DALI's ``pad_sequences=True`` / ``LastBatchPolicy.FILL``
+        behavior) -- this matters for torch.compile, which would otherwise eat a
+        recompilation stall on the last, oddly-shaped batch of every video.
+
+        NOTE: the fully-out-of-bounds branch (cursor already >= total_frames) is
+        untested against the real SimpleDecoder API -- verify with a short test video
+        before trusting this on an edge case video whose frame count doesn't divide
+        evenly by (sequence_length, step).
+        """
+        end = self._cursor + self.sequence_length
+        if end <= self._total_frames:
+            frames = list(decoder[self._cursor:end])
+        else:
+            frames = list(decoder[self._cursor:self._total_frames])
+            n_missing = end - self._total_frames
+            if len(frames) == 0:
+                frames = [decoder[self._total_frames - 1]]
+                n_missing -= 1
+            if n_missing > 0:
+                frames = frames + [frames[-1]] * n_missing
+        return torch.stack([torch.from_dlpack(f) for f in frames])  # (seq_len, C, H, W)
+
+    def _resize_normalize(self, frames: torch.Tensor) -> torch.Tensor:
+        """frames: (seq_len, C, H, W), decoder output (assumed uint8 -- verify on
+        first real run; if the installed PyNvVideoCodec version returns a different
+        dtype for RGBP output this silently produces a wrong [0,1] scale).
+
+        Returns float, optionally resized to ``decode_resize_dims``, [0,1]-scaled,
+        then ImageNet-normalized -- same order of operations as DALI's
+        ``fn.resize`` -> ``fn.crop_mirror_normalize`` in ``dali.py:video_pipe``.
+        """
+        frames = frames.float() / 255.0
+        if self.decode_resize_dims is not None:
+            frames = F.interpolate(
+                frames, size=self.decode_resize_dims, mode='bilinear', align_corners=False,
+            )
+        mean = torch.tensor(_IMAGENET_MEAN, device=frames.device).view(1, 3, 1, 1)
+        std = torch.tensor(_IMAGENET_STD, device=frames.device).view(1, 3, 1, 1)
+        return (frames - mean) / std
+
+    def __next__(self) -> UnlabeledBatchDict | MultiviewUnlabeledBatchDict:
+        """Fetch the next batch, applying per-frame bbox crop+resize when configured."""
+        if self._iters_done >= self.num_iters:
+            raise StopIteration
+        self._iters_done += 1
+
+        per_view_frames = [self._read_window(dec) for dec in self._decoders]
+        # Synchronize each decoder's internal CUDA stream against the current stream
+        # before anything (including our own resize/normalize below) reads the
+        # tensors. See module docstring -- this is the safe-but-costly guard against
+        # silently reading a not-yet-finished decode.
+        torch.cuda.current_stream().synchronize()
+
+        self._cursor += self.step
+
+        processed = [self._resize_normalize(f) for f in per_view_frames]
+
+        if not self.multiview:
+            frames = processed[0]
+            height, width = frames.shape[-2], frames.shape[-1]
+
+            if self.bbox_df is not None:
+                assert self.resize_dims is not None  # required whenever bbox_df is set
+                step = self.sequence_length - 4 if self.do_context else self.sequence_length
+                rows = self.bbox_df.iloc[self._frame_idx:self._frame_idx + self.sequence_length]
+                if len(rows) < self.sequence_length:
+                    last_row = self.bbox_df.iloc[[-1]]
+                    rows = pd.concat(
+                        [rows] + [last_row] * (self.sequence_length - len(rows)),
+                        ignore_index=True,
+                    )
+                cropped_frames, bboxes = crop_and_resize_frames(frames, rows, self.resize_dims)
+                self._frame_idx += step
+                return UnlabeledBatchDict(
+                    frames=cropped_frames,
+                    transforms=torch.tensor([-1.0]),
+                    bbox=bboxes,
+                    is_multiview=False,
+                )
+
+            bbox = torch.tensor(
+                [0, 0, height, width], device=frames.device, dtype=torch.float32,
+            ).repeat(frames.shape[0], 1)
+            return UnlabeledBatchDict(
+                frames=frames,
+                transforms=torch.tensor([-1.0]),
+                bbox=bbox,
+                is_multiview=False,
+            )
+
+        else:
+            frames = torch.stack(processed, dim=1)  # (seq_len, num_views, C, H, W)
+            height, width = frames.shape[-2], frames.shape[-1]
+            num_views = len(self._decoders)
+            bbox_per_view = torch.tensor(
+                [0, 0, height, width], device=frames.device, dtype=torch.float32,
+            )
+            bbox = bbox_per_view.repeat(num_views).unsqueeze(0).repeat(frames.shape[0], 1)
+            transforms = torch.tensor([-1.0]).repeat(num_views, 1, 1)
+            return MultiviewUnlabeledBatchDict(
+                frames=frames,
+                transforms=transforms,
+                bbox=bbox,
+                is_multiview=True,
+            )
+
+
+class PreparePynvvc:
+    """Factory for PyNvVideoCodec-backed inference dataloaders.
+
+    Predict-only counterpart to ``lightning_pose.data.dali.PrepareDALI`` -- only
+    needs the "predict" x {"base", "context"} combinations, since NVDEC inference
+    never shuffles or augments. Construction is split the same way as ``PrepareDALI``:
+    ``__init__`` validates inputs and precomputes windowing parameters; ``__call__``
+    builds and returns a ready-to-iterate ``LitPynvvcWrapper``.
+
+    Sequence-length source (open design question, flag for review): reuses
+    ``dali_config["base"]["predict"]["sequence_length"]`` /
+    ``dali_config["context"]["predict"]["sequence_length"]`` (i.e. the existing
+    ``cfg.dali`` section) rather than introducing a parallel ``cfg.pynvvc`` config
+    block, since the windowing semantics are decoder-agnostic. Worth confirming this
+    is actually what's wanted rather than a separate config section.
+    """
+
+    def __init__(
+        self,
+        model_type: Literal["base", "context"],
+        filenames: list[str] | list[list[str]],
+        resize_dims: list[int],
+        dali_config: dict | DictConfig | ListConfig,
+        gpu_id: int = 0,
+        bbox_df: pd.DataFrame | None = None,
+    ) -> None:
+        """
+        Args:
+            model_type: ``"base"`` for standard single-frame models, ``"context"``
+                for MHCRNN models that consume a temporal window.
+            filenames: for single-view, a single video path (as a length-1 list or
+                bare string); for multi-view, one video path per view.
+            resize_dims: ``[height, width]`` to resize frames to before feeding the
+                model. Also used as the post-crop resize target when ``bbox_df`` is
+                provided.
+            dali_config: same ``cfg.dali`` dict ``PrepareDALI`` reads from -- only
+                the ``predict.sequence_length`` values (base and context) are used.
+                See class docstring for why this reuses the DALI config section.
+            gpu_id: CUDA device index to decode on.
+            bbox_df: optional DataFrame with columns ``["x", "y", "h", "w"]``, one
+                row per frame. When provided, frames are decoded at full resolution
+                and ``LitPynvvcWrapper`` crops each to its bbox before resizing.
+
+        Raises:
+            FileNotFoundError: if any path in ``filenames`` does not exist or is not
+                a file.
+            NotImplementedError: if any view supplies more than one video (multi-
+                session batching is a DALI-train-only concept, not needed here).
+            ValueError: for multiview inputs, if views have differing frame counts
+                (which would desynchronize the per-view sequential reads), or for an
+                unknown ``model_type``.
+        """
+        if isinstance(filenames, list) and isinstance(filenames[0], list):
+            self.multiview = True
+        else:
+            self.multiview = False
+
+        filenames_2d: list[list[str]]
+        if isinstance(filenames[0], str):
+            filenames_2d = [filenames]  # type: ignore[list-item]
+        else:
+            filenames_2d = filenames  # type: ignore[assignment]
+
+        for view_list in filenames_2d:
+            if len(view_list) != 1:
+                raise NotImplementedError(
+                    "pynvvc predict backend supports exactly one video per view "
+                    f"(no multi-session batching); got {len(view_list)} videos for one view."
+                )
+            vid = view_list[0]
+            if not os.path.exists(vid) or not os.path.isfile(vid):
+                raise FileNotFoundError(f"{vid} is not a video file!")
+
+        view0_frame_count = count_frames(filenames_2d[0][0])
+        if self.multiview:
+            for view_idx, view_list in enumerate(filenames_2d[1:], start=1):
+                frame_count = count_frames(view_list[0])
+                if frame_count != view0_frame_count:
+                    raise ValueError(
+                        "Mismatched frame counts across views; multiview pynvvc reading "
+                        f"would desynchronize. view 0={view0_frame_count}, "
+                        f"view {view_idx}={frame_count}"
+                    )
+
+        self.model_type = model_type
+        self.filenames = filenames_2d
+        self.resize_dims = resize_dims
+        self.gpu_id = gpu_id
+        self.bbox_df = bbox_df
+        self.frame_count = view0_frame_count
+
+        if model_type == "base":
+            self.sequence_length = dali_config["base"]["predict"]["sequence_length"]  # type: ignore[arg-type]
+            self.step = self.sequence_length
+            self.do_context = False
+        elif model_type == "context":
+            self.sequence_length = dali_config["context"]["predict"]["sequence_length"]  # type: ignore[arg-type]
+            self.step = self.sequence_length - 4
+            self.do_context = True
+        else:
+            raise ValueError(f"unknown model_type: {model_type}")
+
+        # bbox-crop mode needs full-resolution decoded frames to crop from; the
+        # post-crop resize to resize_dims happens in crop_and_resize_frames instead.
+        self._decode_resize_dims: list[int] | None = (
+            None if self.bbox_df is not None else resize_dims
+        )
+
+    @property
+    def num_iters(self) -> int:
+        """Number of dataloader iterations required to process all frames.
+
+        Mirrors the specific branch of ``PrepareDALI.num_iters`` that applies to
+        prediction (single sequence at a time, batch_size=1): for context models
+        this is the "step == sequence_length - 4" case.
+        """
+        if self.model_type == "base":
+            return int(np.ceil(self.frame_count / self.sequence_length))
+        else:  # context
+            if self.step <= 0:
+                raise ValueError(
+                    "step cannot be 0, please modify "
+                    "cfg.dali.context.predict.sequence_length to be > 4"
+                )
+            data_except_first_batch = self.frame_count - self.sequence_length
+            return int(np.ceil(data_except_first_batch / self.step)) + 1
+
+    def __call__(self) -> LitPynvvcWrapper:
+        """Build and return a ready-to-iterate ``LitPynvvcWrapper``."""
+        return LitPynvvcWrapper(
+            filenames=self.filenames,
+            resize_dims=self.resize_dims,
+            decode_resize_dims=self._decode_resize_dims,
+            sequence_length=self.sequence_length,
+            step=self.step,
+            do_context=self.do_context,
+            num_iters=self.num_iters,
+            multiview=self.multiview,
+            bbox_df=self.bbox_df,
+            gpu_id=self.gpu_id,
+        )

--- a/lightning_pose/data/pynvvc.py
+++ b/lightning_pose/data/pynvvc.py
@@ -65,7 +65,10 @@ from lightning_pose.data.datatypes import (
 from lightning_pose.data.utils import count_frames
 
 if TYPE_CHECKING:
-    import PyNvVideoCodec as nvc
+    # PyNvVideoCodec is NVIDIA's proprietary decoder package -- not on a
+    # CI-reachable index, so pyright can never resolve it here (see module
+    # docstring for the runtime lazy-import discipline this mirrors).
+    import PyNvVideoCodec as nvc  # pyright: ignore[reportMissingImports]
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +97,10 @@ def is_pynvvc_available(video_path: str, gpu_id: int = 0) -> bool:
         failure mode here should fall back to DALI rather than propagate.
     """
     try:
-        import PyNvVideoCodec as nvc  # lazy: avoids ImportError on cpu-only installs
+        # Same reason as the module-level TYPE_CHECKING import above -- not on a
+        # CI-reachable index. Also lazy at runtime to avoid ImportError on cpu-only
+        # installs.
+        import PyNvVideoCodec as nvc  # pyright: ignore[reportMissingImports]
 
         decoder = nvc.SimpleDecoder(video_path, gpu_id=gpu_id, use_device_memory=True)
         del decoder
@@ -153,7 +159,10 @@ class LitPynvvcWrapper:
                 view only (enforced upstream in ``predict_video``).
             gpu_id: CUDA device index to decode on.
         """
-        import PyNvVideoCodec as nvc  # lazy: avoids ImportError on cpu-only installs
+        # Same reason as the module-level TYPE_CHECKING import above -- not on a
+        # CI-reachable index. Also lazy at runtime to avoid ImportError on cpu-only
+        # installs.
+        import PyNvVideoCodec as nvc  # pyright: ignore[reportMissingImports]
 
         self.resize_dims = resize_dims
         self.decode_resize_dims = decode_resize_dims

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -25,6 +25,7 @@ from lightning_pose.data.utils import count_frames
 
 if TYPE_CHECKING:
     from lightning_pose.api import Model
+    from lightning_pose.api.model import _Decoder
 
 logger = logging.getLogger(__name__)
 
@@ -396,7 +397,7 @@ def predict_video(
     model: Model,
     output_pred_file: str | None = None,
     progress_file: Path | None = None,
-    decoder: Literal["dali", "pynvvc"] | None = None,
+    decoder: _Decoder | None = None,
     bbox_file: str | Path | None = None,
 ) -> pd.DataFrame: ...
 
@@ -407,7 +408,7 @@ def predict_video(
     model: Model,
     output_pred_file: list[str] | None = None,
     progress_file: Path | None = None,
-    decoder: Literal["dali", "pynvvc"] | None = None,
+    decoder: _Decoder | None = None,
 ) -> list[pd.DataFrame]: ...
 
 
@@ -416,7 +417,7 @@ def predict_video(
     model: Model,
     output_pred_file: str | list[str] | None = None,
     progress_file: Path | None = None,
-    decoder: Literal["dali", "pynvvc"] | None = None,
+    decoder: _Decoder | None = None,
     bbox_file: str | Path | None = None,
 ) -> pd.DataFrame | list[pd.DataFrame]:
     """
@@ -525,9 +526,9 @@ def predict_video(
         )
         vid_pred_class = PreparePynvvc(
             model_type=model_type,
+            dali_config=model.config.cfg.dali,
             filenames=filenames,
             resize_dims=resize_dims,
-            dali_config=model.config.cfg.dali,
             bbox_df=bbox_df,
         )
     # get loader

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -396,6 +396,7 @@ def predict_video(
     model: Model,
     output_pred_file: str | None = None,
     progress_file: Path | None = None,
+    decoder: Literal["dali", "pynvvc"] | None = None,
     bbox_file: str | Path | None = None,
 ) -> pd.DataFrame: ...
 
@@ -406,6 +407,7 @@ def predict_video(
     model: Model,
     output_pred_file: list[str] | None = None,
     progress_file: Path | None = None,
+    decoder: Literal["dali", "pynvvc"] | None = None,
 ) -> list[pd.DataFrame]: ...
 
 
@@ -414,6 +416,7 @@ def predict_video(
     model: Model,
     output_pred_file: str | list[str] | None = None,
     progress_file: Path | None = None,
+    decoder: Literal["dali", "pynvvc"] | None = None,
     bbox_file: str | Path | None = None,
 ) -> pd.DataFrame | list[pd.DataFrame]:
     """
@@ -426,6 +429,10 @@ def predict_video(
         bbox_file: (optional) path to a bbox CSV (columns x, y, h, w; one row per frame).
             when provided, DALI delivers full-resolution frames and the wrapper crops each
             frame to the bbox before resizing to the model's input dims. single-view only.
+        decoder: (optional) which video-decoding backend to use: "dali" or "pynvvc".
+            None (default) auto-selects pynvvc if it's usable on this machine for this
+            video, else falls back to dali. Independent of the model's runtime
+            (eager/onnx) and --compile -- this only controls video ingestion.
     """
 
     is_multiview = not isinstance(video_file, str)
@@ -473,20 +480,56 @@ def predict_video(
     )
 
     filenames = [video_file] if not is_multiview else [[f] for f in video_file]
-    from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
-    vid_pred_class = PrepareDALI(
-        train_stage="predict",
-        model_type=model_type,
-        dali_config=model.config.cfg.dali,
-        # Important: This will be a list of lists for multiview.
-        # This will trigger dali to return multiview batches to predict_step.
-        filenames=filenames,
-        resize_dims=[
-            model.config.cfg.data.image_resize_dims.height,
-            model.config.cfg.data.image_resize_dims.width,
-        ],
-        bbox_df=bbox_df,
-    )
+    resize_dims = [
+        model.config.cfg.data.image_resize_dims.height,
+        model.config.cfg.data.image_resize_dims.width,
+    ]
+
+    # Decide which decoder backend to use: explicit choice, or auto-select pynvvc if
+    # it's actually usable (installed + this GPU/driver + this video decode
+    # successfully), else fall back to dali. Probed against the first view's video
+    # since is_pynvvc_available needs a real file to construct a trial decoder.
+    # Deliberately placed here rather than in the CLI handler, so every caller (CLI,
+    # direct Model API/notebook use) gets the same fail-fast behavior and log line for
+    # free -- same rationale as the backend log line below.
+    probe_video = video_file[0] if is_multiview else video_file
+    if decoder is None:
+        from lightning_pose.data.pynvvc import is_pynvvc_available
+        decoder = "pynvvc" if is_pynvvc_available(probe_video) else "dali"
+    elif decoder == "pynvvc":
+        from lightning_pose.data.pynvvc import is_pynvvc_available
+        if not is_pynvvc_available(probe_video):
+            raise RuntimeError(
+                "decoder='pynvvc' was requested but PyNvVideoCodec can't decode "
+                f"{probe_video!r} on this machine (unsupported GPU generation, driver "
+                "too old, pynvvideocodec not installed, or an unsupported video "
+                "format). Pass decoder='dali' or omit decoder to auto-select."
+            )
+    logger.info(f"predict_video: using '{decoder}' decoder backend")
+
+    if decoder == "dali":
+        from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
+        vid_pred_class = PrepareDALI(
+            train_stage="predict",
+            model_type=model_type,
+            dali_config=model.config.cfg.dali,
+            # Important: This will be a list of lists for multiview.
+            # This will trigger dali to return multiview batches to predict_step.
+            filenames=filenames,
+            resize_dims=resize_dims,
+            bbox_df=bbox_df,
+        )
+    else:  # pynvvc
+        from lightning_pose.data.pynvvc import (
+            PreparePynvvc,  # avoids ImportError on cpu-only installs
+        )
+        vid_pred_class = PreparePynvvc(
+            model_type=model_type,
+            filenames=filenames,
+            resize_dims=resize_dims,
+            dali_config=model.config.cfg.dali,
+            bbox_df=bbox_df,
+        )
     # get loader
     predict_loader = vid_pred_class()
 

--- a/tests/cli/test_predict.py
+++ b/tests/cli/test_predict.py
@@ -228,6 +228,7 @@ class TestHandle:
             compile=False,
             runtime='eager',
             onnx_precision=None,
+            decoder=None,
         )
 
     def test_handle_threads_bbox_dir_to_predict_multi_type(self, tmp_path, mock_model):

--- a/tests/cli/test_predict.py
+++ b/tests/cli/test_predict.py
@@ -91,6 +91,40 @@ class TestPredictParser:
                 ['predict', str(model_dir), 'video.mp4', '--runtime', 'tensorrt']
             )
 
+    def test_decoder_default_is_none(self, parser, tmp_path):
+        """--decoder defaults to None so predict_video() auto-selects."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['predict', str(model_dir), 'video.mp4'])
+        assert args.decoder is None
+
+    def test_decoder_pynvvc(self, parser, tmp_path):
+        """--decoder pynvvc is parsed."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['predict', str(model_dir), 'video.mp4', '--decoder', 'pynvvc']
+        )
+        assert args.decoder == 'pynvvc'
+
+    def test_decoder_dali(self, parser, tmp_path):
+        """--decoder dali is parsed."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(
+            ['predict', str(model_dir), 'video.mp4', '--decoder', 'dali']
+        )
+        assert args.decoder == 'dali'
+
+    def test_decoder_rejects_unknown_value(self, parser, tmp_path):
+        """--decoder nvdec exits; only dali/pynvvc are valid."""
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        with pytest.raises(SystemExit):
+            parser.parse_args(
+                ['predict', str(model_dir), 'video.mp4', '--decoder', 'nvdec']
+            )
+
     def test_onnx_precision_default_is_none(self, parser, tmp_path):
         """--onnx-precision defaults to None so a sole export is auto-selected."""
         model_dir = tmp_path / 'model'

--- a/tests/data/test_bboxes.py
+++ b/tests/data/test_bboxes.py
@@ -1,9 +1,11 @@
 """Tests for bbox coordinate transformation utilities."""
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 
 from lightning_pose.data.bboxes import (
+    crop_and_resize_frames,
     frame_to_model,
     frame_to_model_batch,
     frame_to_norm,
@@ -629,3 +631,64 @@ class TestModelToFrame:
         recovered = model_to_frame(model_kps, bbox_batch, model_width, model_height)
 
         assert torch.allclose(recovered, keypoints, atol=1e-6)
+
+
+class TestCropAndResizeFrames:
+    """Test the function crop_and_resize_frames."""
+
+    def test_basic_crop_and_resize_shape(self):
+        """In-bounds bbox: output shapes match resize_dims, bbox values are unclamped."""
+        seq_len = 2
+        frames = torch.rand(seq_len, 3, 50, 50)
+        bbox_rows = pd.DataFrame({
+            'x': [10, 10], 'y': [10, 10], 'h': [20, 20], 'w': [20, 20],
+        })
+        cropped, bboxes = crop_and_resize_frames(frames, bbox_rows, [64, 64])
+        assert cropped.shape == (seq_len, 3, 64, 64)
+        assert bboxes.shape == (seq_len, 4)
+        for i in range(seq_len):
+            assert torch.equal(bboxes[i], torch.tensor([10., 10., 20., 20.]))
+
+    def test_negative_xy_clamped_to_zero(self):
+        """A bbox origin outside the frame (negative x/y) is clamped to 0, shrinking w/h."""
+        frames = torch.rand(1, 3, 50, 50)
+        bbox_rows = pd.DataFrame({'x': [-5], 'y': [-5], 'h': [20], 'w': [20]})
+        _, bboxes = crop_and_resize_frames(frames, bbox_rows, [32, 32])
+        # x1 = max(0, -5) = 0; x2 = max(1, min(50, -5+20)) = 15 -> returned w = 15 - 0 = 15
+        assert bboxes[0, 0] == 0.0
+        assert bboxes[0, 1] == 0.0
+        assert bboxes[0, 2] == 15.0
+        assert bboxes[0, 3] == 15.0
+
+    def test_bbox_exceeds_frame_bounds_clamped(self):
+        """A bbox extending past the frame's far edge is clamped to the frame size."""
+        frames = torch.rand(1, 3, 50, 50)
+        bbox_rows = pd.DataFrame({'x': [40], 'y': [40], 'h': [30], 'w': [30]})
+        _, bboxes = crop_and_resize_frames(frames, bbox_rows, [32, 32])
+        # x2 = max(41, min(50, 40+30)) = 50 -> returned w = 50 - 40 = 10
+        assert bboxes[0, 0] == 40.0
+        assert bboxes[0, 1] == 40.0
+        assert bboxes[0, 2] == 10.0
+        assert bboxes[0, 3] == 10.0
+
+    def test_per_frame_bbox_rows_used_independently(self):
+        """Each frame in the sequence is cropped with its own bbox row, not a shared one."""
+        seq_len = 3
+        frames = torch.rand(seq_len, 3, 50, 50)
+        bbox_rows = pd.DataFrame({
+            'x': [0, 10, 20], 'y': [0, 10, 20], 'h': [10, 10, 10], 'w': [10, 10, 10],
+        })
+        _, bboxes = crop_and_resize_frames(frames, bbox_rows, [16, 16])
+        assert torch.equal(bboxes[0], torch.tensor([0., 0., 10., 10.]))
+        assert torch.equal(bboxes[1], torch.tensor([10., 10., 10., 10.]))
+        assert torch.equal(bboxes[2], torch.tensor([20., 20., 10., 10.]))
+
+    def test_resize_normalizes_differently_sized_crops(self):
+        """Crops of different pixel sizes across frames still stack, because each is
+        resized to the same resize_dims before stacking."""
+        frames = torch.rand(2, 3, 50, 50)
+        bbox_rows = pd.DataFrame({
+            'x': [0, 0], 'y': [0, 0], 'h': [10, 40], 'w': [10, 40],
+        })
+        cropped, _ = crop_and_resize_frames(frames, bbox_rows, [24, 24])
+        assert cropped.shape == (2, 3, 24, 24)

--- a/tests/data/test_pynvvc.py
+++ b/tests/data/test_pynvvc.py
@@ -1,0 +1,396 @@
+"""Test pynvvc dataloading functionality."""
+import os
+import shutil
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+import torch
+
+from lightning_pose.data import _IMAGENET_MEAN, _IMAGENET_STD
+from lightning_pose.data import pynvvc as pynvvc_module
+from lightning_pose.data.pynvvc import LitPynvvcWrapper, PreparePynvvc, is_pynvvc_available
+
+
+class TestIsPynvvcAvailable:
+    """Test the is_pynvvc_available function.
+
+    All three tests mock at the sys.modules level rather than relying on whatever
+    PyNvVideoCodec happens to be installed in the test environment (it IS installed on
+    the T4 GPU studio but not necessarily elsewhere), so behavior is deterministic
+    regardless of where these run.
+    """
+
+    def test_returns_true_when_decoder_constructs(self):
+        mock_nvc = MagicMock()
+        mock_nvc.SimpleDecoder.return_value = MagicMock()
+        with patch.dict(sys.modules, {'PyNvVideoCodec': mock_nvc}):
+            assert is_pynvvc_available('/fake/video.mp4') is True
+
+    def test_returns_false_when_decoder_construction_raises(self):
+        """Closes the gap flagged in the docstring: the 'fails safely' path was untested."""
+        mock_nvc = MagicMock()
+        mock_nvc.SimpleDecoder.side_effect = RuntimeError('unsupported GPU generation')
+        with patch.dict(sys.modules, {'PyNvVideoCodec': mock_nvc}):
+            assert is_pynvvc_available('/fake/video.mp4') is False
+
+    def test_returns_false_when_package_not_installed(self):
+        """sys.modules[name] = None forces the same ImportError a real missing install would."""
+        with patch.dict(sys.modules, {'PyNvVideoCodec': None}):
+            assert is_pynvvc_available('/fake/video.mp4') is False
+
+
+class TestPreparePynvvc:
+    """Test the PreparePynvvc class."""
+
+    def test_single_view_raises_on_nonexistent_file(self, cfg, video_list):
+        with pytest.raises(FileNotFoundError):
+            PreparePynvvc(
+                model_type='base',
+                filenames=[video_list[0] + '_bad-id.mp4'],
+                resize_dims=[256, 256],
+                dali_config=cfg.dali,
+            )
+
+    def test_single_view_raises_when_path_is_directory(self, cfg, video_list):
+        with pytest.raises(FileNotFoundError):
+            PreparePynvvc(
+                model_type='base',
+                filenames=[os.path.dirname(video_list[0])],
+                resize_dims=[256, 256],
+                dali_config=cfg.dali,
+            )
+
+    def test_raises_on_more_than_one_video_per_view(self, cfg, video_list):
+        """pynvvc has no multi-session-batching concept, unlike DALI's train pipeline."""
+        vid = video_list[0]
+        with pytest.raises(NotImplementedError, match='exactly one video per view'):
+            PreparePynvvc(
+                model_type='base',
+                filenames=[[vid, vid]],
+                resize_dims=[256, 256],
+                dali_config=cfg.dali,
+            )
+
+    def test_multiview_raises_on_unequal_frame_counts(
+        self, cfg_multiview, video_list, tmp_path, monkeypatch,
+    ):
+        vid = video_list[0]
+        vid_copy = str(tmp_path / 'view1.mp4')
+        shutil.copy(vid, vid_copy)
+        monkeypatch.setattr(
+            pynvvc_module, 'count_frames', lambda p: {vid: 100, vid_copy: 90}[p],
+        )
+        with pytest.raises(ValueError, match='frame counts across views'):
+            PreparePynvvc(
+                model_type='base',
+                filenames=[[vid], [vid_copy]],
+                resize_dims=[256, 256],
+                dali_config=cfg_multiview.dali,
+            )
+
+    def test_unknown_model_type_raises(self, cfg, video_list):
+        with pytest.raises(ValueError, match='unknown model_type'):
+            PreparePynvvc(
+                model_type='bogus',  # type: ignore[arg-type]
+                filenames=video_list,
+                resize_dims=[256, 256],
+                dali_config=cfg.dali,
+            )
+
+    def test_num_iters_base(self, cfg, video_list, monkeypatch):
+        monkeypatch.setattr(pynvvc_module, 'count_frames', lambda p: 100)
+        cfg.dali.base.predict.sequence_length = 16
+        prep = PreparePynvvc(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        assert prep.num_iters == 7  # ceil(100 / 16) = 7
+
+    def test_num_iters_context(self, cfg, video_list, monkeypatch):
+        monkeypatch.setattr(pynvvc_module, 'count_frames', lambda p: 100)
+        cfg.dali.context.predict.sequence_length = 9
+        prep = PreparePynvvc(
+            model_type='context',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        # step = 9 - 4 = 5; ceil((100 - 9) / 5) + 1 = ceil(91 / 5) + 1 = 19 + 1 = 20
+        assert prep.num_iters == 20
+
+    def test_context_num_iters_raises_on_invalid_step(self, cfg, video_list, monkeypatch):
+        monkeypatch.setattr(pynvvc_module, 'count_frames', lambda p: 100)
+        cfg.dali.context.predict.sequence_length = 4  # step = 4 - 4 = 0
+        prep = PreparePynvvc(
+            model_type='context',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        with pytest.raises(ValueError, match='step cannot be 0'):
+            _ = prep.num_iters
+
+    def test_bbox_df_sets_decode_resize_dims_none(self, cfg, video_list):
+        bbox_df = pd.DataFrame({'x': [0], 'y': [0], 'h': [10], 'w': [10]})
+        prep = PreparePynvvc(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+            bbox_df=bbox_df,
+        )
+        assert prep._decode_resize_dims is None
+
+    def test_no_bbox_df_sets_decode_resize_dims_to_resize_dims(self, cfg, video_list):
+        prep = PreparePynvvc(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        assert prep._decode_resize_dims == [256, 256]
+
+    def test_call_builds_wrapper_with_correct_params(self, cfg, video_list, monkeypatch):
+        """Integration check: PreparePynvvc() actually produces a correctly-configured
+        LitPynvvcWrapper, with the real PyNvVideoCodec import mocked out."""
+        monkeypatch.setattr(pynvvc_module, 'count_frames', lambda p: 100)
+        prep = PreparePynvvc(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        mock_nvc = MagicMock()
+        fake_decoder = MagicMock()
+        fake_decoder.__len__.return_value = 100
+        mock_nvc.SimpleDecoder.return_value = fake_decoder
+        with patch.dict(sys.modules, {'PyNvVideoCodec': mock_nvc}):
+            wrapper = prep()
+        assert isinstance(wrapper, LitPynvvcWrapper)
+        assert wrapper.resize_dims == [256, 256]
+        assert wrapper.sequence_length == prep.sequence_length
+        assert wrapper.multiview is False
+        assert wrapper.num_iters == prep.num_iters
+
+
+def _make_fake_decoder(total_frames: int, h: int = 100, w: int = 120) -> list[torch.Tensor]:
+    """Fake decoder: a plain list of CHW CPU tensors, slice-indexable like SimpleDecoder.
+
+    torch.from_dlpack() accepts anything implementing __dlpack__, which torch.Tensor
+    already does (including CPU tensors) -- so _read_window's real
+    `torch.from_dlpack(f)` call works unmodified against this fake, no mocking needed
+    for that part.
+    """
+    return [torch.rand(3, h, w) for _ in range(total_frames)]
+
+
+class TestLitPynvvcWrapper:
+    """Test the LitPynvvcWrapper class.
+
+    All tests bypass __init__ (which needs a real/mocked PyNvVideoCodec import) via
+    object.__new__, same discipline as test_dali.py's TestLitDaliWrapper. The one
+    piece of real hardware LitPynvvcWrapper touches outside decoding itself --
+    torch.cuda.current_stream().synchronize() inside __next__ -- is mocked out so
+    these run on CPU-only machines too.
+    """
+
+    @pytest.fixture
+    def bbox_df(self):
+        """Sample bbox DataFrame with 10 rows (same values as test_dali.py's fixture)."""
+        return pd.DataFrame({
+            'x': [10] * 10,
+            'y': [20] * 10,
+            'h': [50] * 10,
+            'w': [60] * 10,
+        })
+
+    def _make_wrapper(
+        self,
+        total_frames: int,
+        resize_dims: list[int] | None = None,
+        decode_resize_dims: list[int] | None = None,
+        sequence_length: int = 4,
+        do_context: bool = False,
+        multiview: bool = False,
+        bbox_df: pd.DataFrame | None = None,
+        frame_idx: int = 0,
+        num_views: int = 1,
+        frame_h: int = 100,
+        frame_w: int = 120,
+    ) -> LitPynvvcWrapper:
+        """Create a LitPynvvcWrapper without a real PyNvVideoCodec decoder."""
+        wrapper = object.__new__(LitPynvvcWrapper)
+        wrapper._decoders = [  # type: ignore[assignment]
+            _make_fake_decoder(total_frames, frame_h, frame_w) for _ in range(num_views)
+        ]
+        wrapper._total_frames = total_frames
+        # resize_dims is always a concrete list on the real class (unlike
+        # decode_resize_dims, which is the actually-optional one) -- default to a
+        # harmless placeholder when a test doesn't care about its value.
+        wrapper.resize_dims = resize_dims if resize_dims is not None else [64, 64]
+        wrapper.decode_resize_dims = decode_resize_dims
+        wrapper.sequence_length = sequence_length
+        wrapper.step = sequence_length - 4 if do_context else sequence_length
+        wrapper.do_context = do_context
+        wrapper.num_iters = 1000  # overridden per-test where StopIteration timing matters
+        wrapper.multiview = multiview
+        wrapper.bbox_df = bbox_df
+        wrapper._cursor = 0
+        wrapper._iters_done = 0
+        wrapper._frame_idx = frame_idx
+        return wrapper
+
+    # -- _read_window --
+
+    def test_read_window_full_batch_no_padding(self):
+        wrapper = self._make_wrapper(total_frames=10, sequence_length=4)
+        window = wrapper._read_window(wrapper._decoders[0])
+        assert window.shape == (4, 3, 100, 120)
+
+    def test_read_window_pads_last_partial_batch(self):
+        wrapper = self._make_wrapper(total_frames=10, sequence_length=4)
+        wrapper._cursor = 8  # only frames 8, 9 are real; need 2 padding frames
+        window = wrapper._read_window(wrapper._decoders[0])
+        assert window.shape == (4, 3, 100, 120)
+        assert torch.equal(window[1], window[2])
+        assert torch.equal(window[2], window[3])
+        assert not torch.equal(window[0], window[1])
+
+    def test_read_window_fully_out_of_bounds(self):
+        """Closes the gap flagged in _read_window's docstring: cursor already past the
+        end of the video (untested against the real SimpleDecoder API before this)."""
+        wrapper = self._make_wrapper(total_frames=10, sequence_length=4)
+        wrapper._cursor = 10  # nothing left to read
+        window = wrapper._read_window(wrapper._decoders[0])
+        assert window.shape == (4, 3, 100, 120)
+        # every frame should be the single last real frame (index 9), repeated
+        for i in range(1, 4):
+            assert torch.equal(window[0], window[i])
+
+    # -- _resize_normalize --
+
+    def test_resize_normalize_no_resize_when_decode_resize_dims_none(self):
+        wrapper = self._make_wrapper(total_frames=5, decode_resize_dims=None)
+        frames = torch.randint(0, 256, (4, 3, 50, 60), dtype=torch.uint8).float()
+        out = wrapper._resize_normalize(frames)
+        assert out.shape == (4, 3, 50, 60)
+
+    def test_resize_normalize_resizes_when_decode_resize_dims_set(self):
+        wrapper = self._make_wrapper(total_frames=5, decode_resize_dims=[32, 32])
+        frames = torch.rand(4, 3, 50, 60) * 255
+        out = wrapper._resize_normalize(frames)
+        assert out.shape == (4, 3, 32, 32)
+
+    def test_resize_normalize_applies_imagenet_normalization(self):
+        """Exact-value check against the same formula/order of operations the method
+        itself uses, so this fails if the scale-then-normalize order ever changes."""
+        wrapper = self._make_wrapper(total_frames=5, decode_resize_dims=None)
+        frames = torch.full((1, 3, 4, 4), 127.5)
+        out = wrapper._resize_normalize(frames)
+        mean = torch.tensor(_IMAGENET_MEAN).view(1, 3, 1, 1)
+        std = torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1)
+        expected = (127.5 / 255.0 - mean) / std
+        assert torch.allclose(out, expected.expand_as(out), atol=1e-5)
+
+    # -- __next__ --
+
+    def test_next_output_frames_shape_no_bbox(self):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, decode_resize_dims=[64, 64],
+        )
+        wrapper.num_iters = 1
+        with patch('torch.cuda.current_stream'):
+            batch = next(wrapper)
+        assert batch['frames'].shape == (4, 3, 64, 64)
+        assert batch['is_multiview'] is False
+        assert batch['bbox'].shape == (4, 4)
+
+    def test_next_bbox_crop_output_shape(self, bbox_df):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, resize_dims=[64, 64],
+            decode_resize_dims=None, bbox_df=bbox_df,
+        )
+        wrapper.num_iters = 1
+        with patch('torch.cuda.current_stream'):
+            batch = next(wrapper)
+        assert batch['frames'].shape == (4, 3, 64, 64)
+        assert batch['is_multiview'] is False
+
+    def test_next_advances_frame_idx_base(self, bbox_df):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, resize_dims=[64, 64],
+            decode_resize_dims=None, bbox_df=bbox_df, do_context=False,
+        )
+        wrapper.num_iters = 1
+        with patch('torch.cuda.current_stream'):
+            next(wrapper)
+        assert wrapper._frame_idx == 4
+
+    def test_next_advances_frame_idx_context(self, bbox_df):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=5, resize_dims=[64, 64],
+            decode_resize_dims=None, bbox_df=bbox_df, do_context=True,
+        )
+        wrapper.num_iters = 1
+        with patch('torch.cuda.current_stream'):
+            next(wrapper)
+        assert wrapper._frame_idx == 1  # step = seq_len - 4 = 1
+
+    def test_next_pads_bbox_rows_on_last_batch(self):
+        """Mirrors test_dali.py's TestLitDaliWrapper.test_pads_last_partial_batch --
+        same padding logic, ported to the pynvvc backend."""
+        two_row_df = pd.DataFrame({
+            'x': [10, 20], 'y': [10, 20], 'h': [50, 60], 'w': [50, 60],
+        })
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, resize_dims=[64, 64],
+            decode_resize_dims=None, bbox_df=two_row_df, frame_idx=1,
+        )
+        wrapper.num_iters = 1
+        with patch('torch.cuda.current_stream'):
+            batch = next(wrapper)
+        assert batch['bbox'].shape == (4, 4)
+        expected_last = torch.tensor([20, 20, 60, 60], dtype=torch.float32)
+        for i in range(4):
+            assert torch.allclose(batch['bbox'][i], expected_last)
+
+    def test_next_stops_iteration_after_num_iters(self):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, decode_resize_dims=[32, 32],
+        )
+        wrapper.num_iters = 2
+        with patch('torch.cuda.current_stream'):
+            next(wrapper)
+            next(wrapper)
+            with pytest.raises(StopIteration):
+                next(wrapper)
+
+    def test_next_multiview_output_shape(self):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, decode_resize_dims=[64, 64],
+            multiview=True, num_views=2,
+        )
+        wrapper.num_iters = 1
+        with patch('torch.cuda.current_stream'):
+            batch = next(wrapper)
+        assert batch['frames'].shape == (4, 2, 3, 64, 64)
+        assert batch['is_multiview'] is True
+        assert batch['bbox'].shape == (4, 2 * 4)
+        assert batch['transforms'].shape == (2, 1, 1)
+
+    def test_next_calls_cuda_stream_synchronize(self):
+        """Regression guard for the documented 'safe but not optimal' CUDA sync fix
+        (see module docstring) -- fails loudly if this guard is ever accidentally
+        removed, since that would silently corrupt predictions rather than error."""
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, decode_resize_dims=[32, 32],
+        )
+        wrapper.num_iters = 1
+        with patch('torch.cuda.current_stream') as mock_stream:
+            next(wrapper)
+        mock_stream.assert_called_once()
+        mock_stream.return_value.synchronize.assert_called_once()

--- a/tests/data/test_pynvvc.py
+++ b/tests/data/test_pynvvc.py
@@ -176,6 +176,54 @@ class TestPreparePynvvc:
         assert wrapper.multiview is False
         assert wrapper.num_iters == prep.num_iters
 
+    def test_multiview_synchronized_frames(self, cfg_multiview, video_list, monkeypatch):
+        """Every view's decoder is read from the same shared cursor each iteration
+        (see LitPynvvcWrapper.__next__), so per-view frame content stays
+        synchronized across the whole video -- the pynvvc analogue of
+        test_dali.py's TestPrepareDALI.test_multiview_synchronized_frames.
+
+        Unlike DALI (independent per-view readers kept in lockstep only via a
+        shared reader seed under random shuffle), pynvvc uses a single shared
+        self._cursor for every decoder, so synchronization holds by construction
+        today -- this test is a regression guard in case a future change ever
+        gives each view its own cursor.
+
+        Each mocked SimpleDecoder returns frames whose content encodes the frame
+        index (not real decoded pixels), so cross-view content equality actually
+        proves matching windows, not just matching shape.
+        """
+        monkeypatch.setattr(pynvvc_module, 'count_frames', lambda p: 100)
+        num_views = 3
+        vid = video_list[0]
+        filenames = [[vid]] * num_views
+        total_frames = 100
+        cfg_multiview.dali.base.predict.sequence_length = 4
+
+        def make_fake_decoder(*args, **kwargs):
+            return [torch.full((3, 8, 8), float(k)) for k in range(total_frames)]
+
+        mock_nvc = MagicMock()
+        mock_nvc.SimpleDecoder.side_effect = make_fake_decoder
+
+        prep = PreparePynvvc(
+            model_type='base',
+            filenames=filenames,
+            resize_dims=[8, 8],
+            dali_config=cfg_multiview.dali,
+        )
+        with patch.dict(sys.modules, {'PyNvVideoCodec': mock_nvc}):
+            wrapper = prep()
+
+        with patch('torch.cuda.current_stream'):
+            for _ in range(4):
+                batch = next(wrapper)
+                frames = batch['frames']  # (seq_len, num_views, C, H, W)
+                for view in range(1, num_views):
+                    assert torch.equal(frames[:, 0], frames[:, view])
+                # sanity: frames within a window are still distinct, not a
+                # degenerate constant-value fake that would pass trivially
+                assert not torch.equal(frames[0, 0], frames[-1, 0])
+
 
 def _make_fake_decoder(total_frames: int, h: int = 100, w: int = 120) -> list[torch.Tensor]:
     """Fake decoder: a plain list of CHW CPU tensors, slice-indexable like SimpleDecoder.


### PR DESCRIPTION
Closes #476.

Adds a `--decoder` option (`dali` / `pynvvc`) for video prediction, mirroring the
structure of #470/#471 (ONNX export/runtime). Follows up on the decode-speed
benchmark confirming PyNvVideoCodec (direct NVIDIA Video Codec SDK / NVDEC bindings)
decodes **8.76x faster** than DALI's GPU video reader on a T4 (3735.7 vs 426.5 fps,
7 timed runs) -- this PR turns that into a selectable inference-time backend.

## API / CLI

- `Model.predict_on_video_file(decoder="pynvvc")` / `predict_on_video_file_multiview(decoder=...)`
  accept `"dali"`, `"pynvvc"`, or `None`.
- `litpose predict ... --decoder pynvvc` / `--decoder dali` on the CLI.
- `decoder=None` (the default) auto-selects `pynvvc` when it's actually usable on the
  current machine for the given video (checked via `is_pynvvc_available()`, which
  probes with a real decoder construction rather than trusting a bare `import`
  succeeding), falling back to `dali` otherwise. Explicitly requesting
  `decoder="pynvvc"` on a machine where it isn't usable raises a clear `RuntimeError`
  instead of silently falling back.
- `--decoder` is fully independent of `--runtime`/`--compile` -- it only controls
  video ingestion, not model execution.
- Shared the bbox-crop math (`LitDaliWrapper._apply_bbox_crop`'s core logic) out into
  `lightning_pose/data/bboxes.py::crop_and_resize_frames()`, used by both `dali.py`
  and the new `pynvvc.py`, rather than forking ~65 lines into a second class.

## New file: `lightning_pose/data/pynvvc.py`

`PreparePynvvc`/`LitPynvvcWrapper`, mirroring `dali.py`'s `PrepareDALI`/`LitDaliWrapper`
two-phase construction, but predict-only (no shuffle, no imgaug -- `litpose predict`
never uses either). Handles single-view + multiview (lockstep sequential reads), base
and context (5-frame overlapping window) model types, bbox-crop mode, and last-batch
padding (repeats the final frame so shape stays static for torch.compile).

## Design note flagged for review (not resolved)

`PreparePynvvc` reuses `cfg.dali.base/context.predict.sequence_length` rather than
introducing a parallel `cfg.pynvvc` config section, since the windowing semantics are
decoder-agnostic. Open question whether a separate config section is actually wanted.

## CUDA stream synchronization

`PyNvVideoCodec.SimpleDecoder` writes frames asynchronously on its own CUDA stream;
`LitPynvvcWrapper.__next__` guards against reading not-yet-finished decodes with a
blanket `torch.cuda.current_stream().synchronize()` per batch. Safe, but possibly not
optimal -- passing an explicit stream handle into the decoder constructor (if
supported) would avoid the sync cost. Flagged as a follow-up, not done here.

## Testing

- `tests/data/test_pynvvc.py` (28 tests, all GPU-free): `is_pynvvc_available()`
  (including the "PyNvVideoCodec not installed" and "decoder construction fails"
  paths, both previously untested per the code's own docstring), `PreparePynvvc`
  validation/`num_iters` math, and `LitPynvvcWrapper`'s `_read_window`/
  `_resize_normalize`/`__next__` -- built via `object.__new__` + a fake list-based
  decoder (works because `torch.from_dlpack()` accepts anything implementing
  `__dlpack__`, including CPU tensors) + a mocked `torch.cuda.current_stream()`.
  Also closes a previously-untested edge case: `_read_window`'s fully-out-of-bounds
  branch.
- `tests/cli/test_predict.py`: 4 new tests for the `--decoder` argparse flag
  (default/pynvvc/dali/rejects-unknown), plus existing hand-built `Namespace` test
  fixtures updated for the new `decoder` field.
- GPU (T4, `tests/api/test_model.py -q`, no marker filter): 61/61 passed, including
  all three `TestPredictOnVideoFile` tests -- confirms the auto-select/fallback
  wiring works end-to-end on real hardware, not just at the unit level.
- `pyright`: 0 errors. `ruff check`: clean. `pre-commit run`: clean.
- Docs: `sphinx-build` clean, new section's cross-reference link verified resolving
  correctly in the built HTML.

## Docs

New "PyNvVideoCodec (Video Decoding)" section in `increasing_inference_speed.rst`
(install/usage, GPU/driver requirements, the 8.76x decode-throughput number with an
explicit caveat that it's decode-only, not end-to-end), cross-referenced from the
page's existing "isolated forward-pass, not end-to-end" caveat.

## Not done / follow-ups

- `is_pynvvc_available()`'s "returns False safely" path is unit-tested via mocking,
  but not verified against a real unsupported GPU/driver combination.
- The CUDA stream synchronization approach (see above) hasn't been checked against
  an explicit-stream-handle alternative.
