### PR TITLE
Fix PyNvVideoCodec batch frame reads

### DIFF
--- a/lightning_pose/data/pynvvc.py
+++ b/lightning_pose/data/pynvvc.py
@@ -208,22 +208,20 @@ class LitPynvvcWrapper:
         behavior) -- this matters for torch.compile, which would otherwise eat a
         recompilation stall on the last, oddly-shaped batch of every video.
 
-        NOTE: the fully-out-of-bounds branch (cursor already >= total_frames) is
-        untested against the real SimpleDecoder API -- verify with a short test video
-        before trusting this on an edge case video whose frame count doesn't divide
-        evenly by (sequence_length, step).
+        Uses ``get_batch_frames_by_index`` rather than slice indexing because
+        PyNvVideoCodec 2.1.0's ``SimpleDecoder.__getitem__`` does not support
+        ordinary Python slices whose step is omitted.
         """
-        end = self._cursor + self.sequence_length
-        if end <= self._total_frames:
-            frames = list(decoder[self._cursor:end])
-        else:
-            frames = list(decoder[self._cursor:self._total_frames])
-            n_missing = end - self._total_frames
-            if len(frames) == 0:
-                frames = [decoder[self._total_frames - 1]]
-                n_missing -= 1
-            if n_missing > 0:
-                frames = frames + [frames[-1]] * n_missing
+        end = min(self._cursor + self.sequence_length, self._total_frames)
+        indices = list(range(self._cursor, end))
+        frames = list(decoder.get_batch_frames_by_index(indices)) if indices else []
+
+        n_missing = self.sequence_length - len(frames)
+        if len(frames) == 0:
+            frames = [decoder[self._total_frames - 1]]
+            n_missing -= 1
+        if n_missing > 0:
+            frames = frames + [frames[-1]] * n_missing
         return torch.stack([torch.from_dlpack(f) for f in frames])  # (seq_len, C, H, W)
 
     def _resize_normalize(self, frames: torch.Tensor) -> torch.Tensor:

--- a/tests/data/test_pynvvc.py
+++ b/tests/data/test_pynvvc.py
@@ -200,7 +200,9 @@ class TestPreparePynvvc:
         cfg_multiview.dali.base.predict.sequence_length = 4
 
         def make_fake_decoder(*args, **kwargs):
-            return [torch.full((3, 8, 8), float(k)) for k in range(total_frames)]
+            return _FakeSimpleDecoder(
+                [torch.full((3, 8, 8), float(k)) for k in range(total_frames)]
+            )
 
         mock_nvc = MagicMock()
         mock_nvc.SimpleDecoder.side_effect = make_fake_decoder
@@ -225,15 +227,39 @@ class TestPreparePynvvc:
                 assert not torch.equal(frames[0, 0], frames[-1, 0])
 
 
-def _make_fake_decoder(total_frames: int, h: int = 100, w: int = 120) -> list[torch.Tensor]:
-    """Fake decoder: a plain list of CHW CPU tensors, slice-indexable like SimpleDecoder.
+class _FakeSimpleDecoder:
+    """Minimal fake matching the PyNvVideoCodec 2.1.0 access API."""
+
+    def __init__(self, frames: list[torch.Tensor]) -> None:
+        self.frames = frames
+
+    def __len__(self) -> int:
+        return len(self.frames)
+
+    def __getitem__(self, index: int) -> torch.Tensor:
+        if not isinstance(index, int):
+            raise TypeError("SimpleDecoder batch reads require get_batch_frames_by_index()")
+        return self.frames[index]
+
+    def get_batch_frames_by_index(self, indices: list[int]) -> list[torch.Tensor]:
+        return [self.frames[index] for index in indices]
+
+
+def _make_fake_decoder(
+    total_frames: int,
+    h: int = 100,
+    w: int = 120,
+) -> _FakeSimpleDecoder:
+    """Build a decoder with CHW CPU tensors that support DLPack conversion.
 
     torch.from_dlpack() accepts anything implementing __dlpack__, which torch.Tensor
     already does (including CPU tensors) -- so _read_window's real
     `torch.from_dlpack(f)` call works unmodified against this fake, no mocking needed
     for that part.
     """
-    return [torch.rand(3, h, w) for _ in range(total_frames)]
+    return _FakeSimpleDecoder(
+        [torch.rand(3, h, w) for _ in range(total_frames)]
+    )
 
 
 class TestLitPynvvcWrapper:


### PR DESCRIPTION
## Summary

- replace `SimpleDecoder` slice access with its public `get_batch_frames_by_index()` API
- preserve static-shape padding for partial and fully exhausted windows
- make the test decoder mirror the PyNvVideoCodec 2.1.0 access API so unsupported slicing is caught

## Problem

With PyNvVideoCodec 2.1.0, `decoder[start:end]` reaches `range(key.start, key.stop, key.step)` with `key.step=None` and raises:

```text
TypeError: 'NoneType' object cannot be interpreted as an integer\n```\n\nThe existing test double was a Python list, whose slicing behavior masked this incompatibility. The replacement uses ascending, unique frame indices, matching the public indexed-batch API.\n\n## Validation\n\n- `python -m pytest tests/data/test_pynvvc.py -q` — 29 passed\n- `ruff check lightning_pose/data/pynvvc.py tests/data/test_pynvvc.py`\n- real PyNvVideoCodec 2.1.0 decode: 96 RGBP CUDA frames returned with shape `(96, 3, 1080, 1440)`\n- real 200-frame H.264 Lightning Pose inference completed with both a base heatmap model and an overlapping-window `heatmap_mhcrnn` context model\n\nHardware/software used for the real-video checks: RTX 4090, CUDA 12.8, Python 3.12, PyTorch 2.9.1, PyNvVideoCodec 2.1.0.