### PR TITLE
make inference backwards compatible with non-hflip configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,9 +289,16 @@ duplicated in both branches.
    flag that is not cleared here will remain active during prediction, causing randomly-augmented
    inference on labeled frames and silently wrong evaluation metrics. The fix pattern is:
    ```python
-   cfg_pred.training.imgaug = "default"
-   cfg_pred.training.<your_flag> = False   # ← must be explicit
+   with open_dict(cfg_pred.training):
+       cfg_pred.training.imgaug = "default"
+       cfg_pred.training.<your_flag> = False   # ← must be explicit
    ```
+   The `open_dict` wrapper is required, not optional: `cfg` may be struct-mode (e.g. composed via
+   `Model.from_dir2`'s `hydra_overrides`), and configs saved by older LP versions won't have your
+   new flag as a key at all, so a plain assignment raises `ConfigAttributeError`. The same applies
+   anywhere else a new/renamed config key is merged or assigned onto a loaded model's `cfg` (see
+   `predict_on_label_csv` and `predict_on_label_csv_multiview`, which wrap their
+   `OmegaConf.merge(self.cfg, cfg_overrides)` calls the same way).
 
 ### Data module split logic (`lightning_pose/data/datamodules.py` → `BaseDataModule._setup`)
 

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -13,7 +13,7 @@ import cv2
 import numpy as np
 import pandas as pd
 import torch
-from omegaconf import DictConfig, ListConfig, OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf, open_dict
 
 from lightning_pose.api.model_config import ModelConfig
 from lightning_pose.data import (
@@ -1319,7 +1319,12 @@ class Model:
         if not add_train_val_test_set:
             cfg_overrides.update({"train_prob": 1, "val_prob": 0, "train_frames": 1})
 
-        cfg_pred = OmegaConf.merge(self.cfg, cfg_overrides)
+        # open_dict: cfg_overrides may introduce keys (e.g. data.bbox_file) that are
+        # absent from configs saved by older LP versions -- merging those into a
+        # struct-mode cfg (e.g. one composed via Model.from_dir2's hydra_overrides)
+        # would otherwise raise ConfigAttributeError.
+        with open_dict(self.cfg):
+            cfg_pred = OmegaConf.merge(self.cfg, cfg_overrides)
 
         # HACK: For true multi-view model, trick predict_dataset and compute_metrics
         # into thinking this is a single-view model.
@@ -1405,7 +1410,10 @@ class Model:
         if not add_train_val_test_set:
             cfg_overrides.update({"train_prob": 1, "val_prob": 0, "train_frames": 1})
 
-        cfg_pred = OmegaConf.merge(self.cfg, cfg_overrides)
+        # open_dict: see predict_on_label_csv for why this guards against struct-mode
+        # ConfigAttributeError on configs saved by older LP versions.
+        with open_dict(self.cfg):
+            cfg_pred = OmegaConf.merge(self.cfg, cfg_overrides)
 
         data_module_pred = _build_datamodule_pred(cfg_pred)
 
@@ -1641,8 +1649,12 @@ def _build_datamodule_pred(cfg: DictConfig | ListConfig) -> BaseDataModule | Unl
         data module ready for use with `predict_dataset`.
     """
     cfg_pred = copy.deepcopy(cfg)
-    cfg_pred.training.imgaug = "default"
-    cfg_pred.training.imgaug_hflip = False
+    # open_dict: imgaug_hflip (and any future prediction-only flag added here) may be
+    # absent from configs saved by older LP versions; plain assignment would raise
+    # ConfigAttributeError if cfg is struct-mode (e.g. composed via hydra_overrides).
+    with open_dict(cfg_pred.training):
+        cfg_pred.training.imgaug = "default"
+        cfg_pred.training.imgaug_hflip = False
     imgaug_transform_pred = get_imgaug_transform(cfg=cfg_pred)
     dataset_pred = get_dataset(
         cfg=cfg_pred,

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+from omegaconf import OmegaConf
 
 from lightning_pose.api import Model
 from lightning_pose.api.model import _build_datamodule_pred, _Precision
@@ -91,6 +92,29 @@ class TestPredictOnLabelCsv:
         assert (model.image_preds_dir() / "top.csv" / "predictions_pixel_error.csv").is_file()
         assert (model.image_preds_dir() / "bot.csv" / "predictions.csv").is_file()
         assert (model.image_preds_dir() / "bot.csv" / "predictions_pixel_error.csv").is_file()
+
+    def test_predict_on_label_csv_struct_mode_missing_bbox_file(
+        self, tmp_path, request, toy_data_dir
+    ):
+        """Reproduces a real crash report: the test fixture's config.yaml predates the
+        data.bbox_file key (added for the bbox/cropzoom feature). Model.from_dir2 with
+        hydra_overrides set (even an empty list, as `litpose predict --overrides` with no
+        values produces) puts the loaded cfg in struct mode via hydra.compose. Merging in
+        cfg_overrides, which always sets data.bbox_file, then raised ConfigAttributeError
+        before predict_on_label_csv's OmegaConf.merge was wrapped in open_dict.
+        """
+        dataset_name = "test_model_mirror_mouse"
+        fetch_test_data_if_needed(request.path.parent, dataset_name)
+        tmp_model_dir = tmp_path / dataset_name
+        shutil.copytree(request.path.parent / dataset_name, tmp_model_dir)
+        assert "bbox_file" not in Model.from_dir(tmp_model_dir).cfg.data
+
+        model = Model.from_dir2(tmp_model_dir, hydra_overrides=[])
+        assert OmegaConf.is_struct(model.cfg)
+
+        model.predict_on_label_csv(Path(toy_data_dir) / "CollectedData.csv")
+
+        assert (model.image_preds_dir() / "CollectedData.csv" / "predictions.csv").is_file()
 
 
 class TestPredictOnVideoFile:
@@ -383,6 +407,19 @@ class TestBuildDatamodulePred:
         _build_datamodule_pred(cfg_copy)
         assert cfg_copy.training.imgaug == 'dlc'
         assert cfg_copy.training.imgaug_hflip is True
+
+    def test_build_datamodule_pred_struct_mode_missing_imgaug_hflip(self, cfg):
+        """Reproduces a real crash: an older model's config.yaml predates the
+        training.imgaug_hflip key (config_mirror-mouse-example.yaml, loaded by the `cfg`
+        fixture, is one such config), and the loaded cfg is struct-mode (e.g. because it
+        was composed via Model.from_dir2's hydra_overrides). Without open_dict, setting
+        cfg_pred.training.imgaug_hflip raised ConfigAttributeError.
+        """
+        cfg_copy = copy.deepcopy(cfg)
+        assert 'imgaug_hflip' not in cfg_copy.training
+        OmegaConf.set_struct(cfg_copy, True)
+        data_module = _build_datamodule_pred(cfg_copy)
+        assert data_module.dataset.imgaug_hflip is False
 
 
 def _torch_compile_supported() -> bool:


### PR DESCRIPTION
Inference with `lightning-pose>=2.30` will fail on models trained with `lightning-pose<2.3.0` due to the addition of `training.imgaug_hflip` entry in the config - the code will load the old config file (without the hflip entry) then set that non-existent entry to `False` for inference (in OmageConf's struct mode), raising an error.
 
This PR makes inference backwards compatible.

closes #474 