### PR TITLE
add OpenCV video reader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,9 @@ This file contains project-specific guidelines for Claude Code when working on t
 - Use type hints for all function parameters and return values
 - Import types from typing module when needed
 - use X | Y, list[X], dict[K, V] syntax; avoid typing imports for these
+- `pandas-stubs` rejects a plain `list[str]` (or other bare list) passed as the `index=`
+  argument to `pd.DataFrame(...)`/`pd.Series(...)` under pyright — wrap it in `pd.Index(...)`.
+  See `lightning_pose/utils/cropzoom.py` for a precedent.
 
 ### Imports
 - Group imports: standard library, third-party, local

--- a/docs/modules/lightning_pose.data.rst
+++ b/docs/modules/lightning_pose.data.rst
@@ -12,6 +12,12 @@ lightning\_pose.data
 .. automodapi:: lightning_pose.data.video.dali
    :no-inheritance-diagram:
 
+.. automodapi:: lightning_pose.data.video.opencv
+   :no-inheritance-diagram:
+
+.. automodapi:: lightning_pose.data.video.pynvvc
+   :no-inheritance-diagram:
+
 .. automodapi:: lightning_pose.data.datamodules
    :no-inheritance-diagram:
 

--- a/docs/modules/lightning_pose.data.rst
+++ b/docs/modules/lightning_pose.data.rst
@@ -12,6 +12,9 @@ lightning\_pose.data
 .. automodapi:: lightning_pose.data.video.dali
    :no-inheritance-diagram:
 
+.. automodapi:: lightning_pose.data.video.factory
+   :no-inheritance-diagram:
+
 .. automodapi:: lightning_pose.data.video.opencv
    :no-inheritance-diagram:
 

--- a/docs/modules/lightning_pose.data.rst
+++ b/docs/modules/lightning_pose.data.rst
@@ -9,7 +9,7 @@ lightning\_pose.data
 .. automodapi:: lightning_pose.data.cameras
    :no-inheritance-diagram:
 
-.. automodapi:: lightning_pose.data.dali
+.. automodapi:: lightning_pose.data.video.dali
    :no-inheritance-diagram:
 
 .. automodapi:: lightning_pose.data.datamodules

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,14 +8,16 @@
 - [ ] read COCO-style JSON label files
 - [ ] export predictions in COCO-style JSON format
 - [ ] support training across multiple datasets; see [#284](https://github.com/paninski-lab/lightning-pose/pull/284)
+- [ ] training/inference support on macOS (no semi-supervised models that require DALI)
+- [ ] training/inference support on Windows (no semi-supervised models that require DALI)
 
 ## Inference enhancements
-- [x] inference with mixed precision [#458](https://github.com/paninski-lab/lightning-pose/pull/458)
-- [x] `torch.compile()` to improve inference speed [#469](https://github.com/paninski-lab/lightning-pose/pull/469)
-- [x] [ONNX runtime](https://onnxruntime.ai/) to improve inference speed [#471](https://github.com/paninski-lab/lightning-pose/pull/471)
-- [x] [TensorRT runtime](https://docs.nvidia.com/deeplearning/tensorrt/latest/index.html) to improve inference speed [#475](https://github.com/paninski-lab/lightning-pose/pull/475)
-- [x] [pynvvideocodec](https://developer.nvidia.com/pynvvideocodec) to improve inference speed [#477](https://github.com/paninski-lab/lightning-pose/pull/477)
-- [ ] add OpenCV video reader option for inference for native Windows compatability
+- [x] inference with mixed precision ([#458](https://github.com/paninski-lab/lightning-pose/pull/458))
+- [x] `torch.compile()` to improve inference speed ([#469](https://github.com/paninski-lab/lightning-pose/pull/469))
+- [x] [ONNX runtime](https://onnxruntime.ai/) to improve inference speed ([#471](https://github.com/paninski-lab/lightning-pose/pull/471))
+- [x] [TensorRT runtime](https://docs.nvidia.com/deeplearning/tensorrt/latest/index.html) to improve inference speed ([#475](https://github.com/paninski-lab/lightning-pose/pull/475))
+- [x] [pynvvideocodec](https://developer.nvidia.com/pynvvideocodec) to improve inference speed ([#477](https://github.com/paninski-lab/lightning-pose/pull/477))
+- [x] add OpenCV video reader option for inference ([#491](https://github.com/paninski-lab/lightning-pose/pull/491))
 
 ## Losses and backbones
 - [x] incorporate transformer backbones ([#84](https://github.com/paninski-lab/lightning-pose/pull/84), [#106](https://github.com/paninski-lab/lightning-pose/pull/106))

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -483,8 +483,9 @@ Installation
 Requires an NVIDIA GPU from the Turing generation or newer (Turing/Ampere/Ada/Hopper/Blackwell)
 and driver version 530.41.03 or newer on Linux. If PyNvVideoCodec can't decode a given video on
 the current machine (unsupported GPU generation, driver too old, package not installed, or an
-unsupported video format), ``litpose predict`` automatically falls back to DALI rather than
-erroring -- see below.
+unsupported video format), ``litpose predict`` automatically falls back to DALI (or, if DALI
+itself isn't installed -- e.g. on macOS/Windows, where ``nvidia-dali-cuda110`` isn't available --
+to OpenCV) rather than erroring -- see below.
 
 Usage
 ~~~~~
@@ -496,6 +497,7 @@ frames are read, not how the model runs on them. From the CLI:
 
     litpose predict /path/to/model_dir /path/to/video.mp4 --reader pynvvc
     litpose predict /path/to/model_dir /path/to/video.mp4 --reader dali
+    litpose predict /path/to/model_dir /path/to/video.mp4 --reader opencv
 
 Or from the API:
 
@@ -504,8 +506,11 @@ Or from the API:
     model = Model.from_dir("path/to/model_dir")
     result = model.predict_on_video_file("path/to/video.mp4", reader="pynvvc")
 
-Omitting ``--reader`` (or passing ``reader=None``) auto-selects PyNvVideoCodec when it's
-usable on the current machine for the given video, falling back to DALI otherwise -- no error,
-just a quieter/slower run. Explicitly requesting ``--reader pynvvc`` on a machine where it
-isn't usable raises a clear error instead of silently falling back, so you know your run isn't
-using the backend you asked for.
+Omitting ``--reader`` (or passing ``reader=None``) auto-selects the best backend usable on the
+current machine for the given video: PyNvVideoCodec if it's usable, else DALI if it's installed,
+else OpenCV -- no error, just a progressively slower/more-portable fallback. OpenCV decodes on
+CPU and needs no NVIDIA GPU or platform-specific package, so it's the one backend guaranteed to
+work everywhere (including macOS, Windows, and GPU-less machines), making it the last rung of the
+fallback chain rather than a speed option. Explicitly requesting a specific ``--reader`` on a
+machine where it isn't usable raises a clear error instead of silently falling back, so you know
+your run isn't using the backend you asked for.

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -720,10 +720,11 @@ class Model(_RuntimeMixin):  # pyright: ignore[reportGeneralTypeIssues]
                 Defaults to False.
             progress_file (Path, optional): Path to a file to save progress information for the
                 App. Defaults to None.
-            reader (optional): which video-reading backend to use, "dali" or "pynvvc".
-                None (default) auto-selects pynvvc if it's usable on this machine for this
-                video, else falls back to dali. Independent of the model's runtime
-                (eager/onnx) and torch.compile -- this only controls video ingestion.
+            reader (optional): which video-reading backend to use, "dali", "pynvvc", or
+                "opencv". None (default) auto-selects pynvvc if it's usable on this machine
+                for this video, else dali if it's installed, else opencv (the portable
+                fallback, always available). Independent of the model's runtime (eager/onnx)
+                and torch.compile -- this only controls video ingestion.
             bbox_file (str | Path, optional): Path to a per-frame bbox CSV (columns x, y, h, w;
                 one row per frame). When provided, each frame is cropped to its bounding box
                 before being passed to the model, and predictions are returned in the original
@@ -809,9 +810,10 @@ class Model(_RuntimeMixin):  # pyright: ignore[reportGeneralTypeIssues]
             compute_metrics: whether to compute pixel error and loss metrics on predictions.
             generate_labeled_video: whether to save a labeled video.
             progress_file: path to a file to save progress information for the App.
-            reader: which video-reading backend to use, "dali" or "pynvvc". None (default)
-                auto-selects pynvvc if it's usable on this machine for this video, else falls
-                back to dali.
+            reader: which video-reading backend to use, "dali", "pynvvc", or "opencv". None
+                (default) auto-selects pynvvc if it's usable on this machine for this video,
+                else dali if it's installed, else opencv (the portable fallback, always
+                available).
 
         Returns:
             object containing the predictions and metrics for each view.

--- a/lightning_pose/cli/commands/predict.py
+++ b/lightning_pose/cli/commands/predict.py
@@ -156,9 +156,10 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
         choices=sorted(_READER_CHOICES),
         default=None,
         help=(
-            "video-reading backend for video inputs. 'dali' or 'pynvvc'. If omitted "
-            "(default), auto-selects 'pynvvc' when it's usable on this machine for the "
-            "given video, else falls back to 'dali'. Independent of --runtime/--compile "
+            "video-reading backend for video inputs. 'dali', 'pynvvc', or 'opencv'. If "
+            "omitted (default), auto-selects 'pynvvc' when it's usable on this machine "
+            "for the given video, else 'dali' when it's installed, else 'opencv' (the "
+            "portable fallback, always available). Independent of --runtime/--compile "
             "-- this only controls video ingestion, not model execution. Ignored for "
             "CSV/image inputs."
         ),

--- a/lightning_pose/data/__init__.py
+++ b/lightning_pose/data/__init__.py
@@ -33,11 +33,11 @@ All three dispatch on ``cfg.model.model_type`` to select the right class.
 - ``utils.py`` — dataset-level utilities: train/val/test splits, frame counting,
   affine-transform undo.
 
-*Video infrastructure* — used only for semi-supervised training:
+*Video infrastructure*:
 
-- ``dali.py`` — GPU-accelerated video loading via NVIDIA DALI
-  (:class:`~lightning_pose.data.dali.PrepareDALI`,
-  :class:`~lightning_pose.data.dali.LitDaliWrapper`).
+- ``video/`` — video-reading backends for semi-supervised training and prediction (DALI,
+  PyNvVideoCodec, OpenCV); see that subpackage's docstring for the reader contract and how
+  to add a new backend.
 - ``extractor.py`` — frame extraction utilities.
 """
 

--- a/lightning_pose/data/bboxes.py
+++ b/lightning_pose/data/bboxes.py
@@ -298,10 +298,10 @@ def crop_and_resize_frames(
 ]:
     """Crop each frame to its per-frame bounding box and resize to a common size.
 
-    Shared by the DALI and pynvvc video-decoding backends: both hand this function a
-    full-resolution ``frames`` tensor plus one already-sliced-and-padded bbox row per
-    frame (cursor/step bookkeeping to select those rows lives in each backend's own
-    wrapper, not here — see ``LitDaliWrapper._apply_bbox_crop``).
+    Shared by all video-decoding backends: each hands this function a full-resolution ``frames``
+    tensor plus one already-sliced-and-padded bbox row per frame (cursor/step bookkeeping to select
+    those rows lives in each backend's own wrapper, not here —
+    see ``LitDaliWrapper._apply_bbox_crop``).
 
     Args:
         frames: full-resolution frames, shape (seq_len, 3, H, W).

--- a/lightning_pose/data/datamodules.py
+++ b/lightning_pose/data/datamodules.py
@@ -319,7 +319,7 @@ class UnlabeledDataModule(BaseDataModule):
 
     def setup_unlabeled(self) -> None:
         """Sets up the unlabeled data loader."""
-        from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
+        from lightning_pose.data.video.dali import PrepareDALI  # avoids cpu-only ImportError
         dali_prep = PrepareDALI(
             train_stage="train",
             model_type="context" if self.dataset.do_context else "base",

--- a/lightning_pose/data/video/__init__.py
+++ b/lightning_pose/data/video/__init__.py
@@ -1,11 +1,14 @@
 """Video-reading backends for training and prediction.
 
-Three backends currently implement the same reader contract (see below): ``dali.py`` (GPU video
-loading via NVIDIA DALI, training + prediction), ``pynvvc.py`` (direct NVDEC access via
-PyNvVideoCodec, prediction only), and ``opencv.py`` (CPU decode via OpenCV, prediction only). All
-three plug into the same call sites -- ``lightning_pose.data.datamodules.UnlabeledDataModule``
-for training, ``lightning_pose.utils.predictions.predict_video`` for prediction -- which select a
-backend by name (``--reader``/``reader=`` in the API) or by auto-probing hardware availability.
+Three backends implement the same reader contract:
+
+- ``dali.py`` (GPU video loading via NVIDIA DALI, training + prediction)
+- ``pynvvc.py`` (direct NVDEC access via PyNvVideoCodec, prediction only)
+- ``opencv.py`` (CPU decode via OpenCV, prediction only)
+
+:func:`~lightning_pose.data.video.factory.build_video_reader` selects among them
+by name (``--reader``/``reader=`` in the API) or by auto-probing hardware availability;
+see ``factory.py`` for the dispatch logic and the "Adding a new video reader" recipe.
 
 Backends
 --------
@@ -23,47 +26,9 @@ Backends
   ``opencv-python-headless``, an unconditional cross-platform dependency -- works on any
   platform/hardware, including macOS, Windows, and GPU-less machines. Slower than DALI/pynvvc on
   a supported NVIDIA box; the guaranteed fallback everywhere else. Prediction only.
-
-Adding a new video reader
---------------------------
-
-Every backend module implements the same contract. To add one:
-
-1. **Two-phase prepare class**: ``Prepare<Name>.__init__(model_type, filenames, resize_dims,
-   dali_config, bbox_df=None, ...)`` validates inputs and precomputes windowing parameters
-   (raise early, before any GPU/decoder allocation); ``__call__()`` builds and returns a
-   ``Lit<Name>Wrapper``. (The ``dali_config`` parameter name is a pre-existing wart --
-   ``PreparePynvvc`` already reuses ``cfg.dali``'s windowing section rather than inventing a
-   per-backend config block, since the windowing semantics are decoder-agnostic; new backends
-   should follow the same precedent rather than fixing it in isolation.)
-2. **Iterator wrapper class**: ``Lit<Name>Wrapper`` is iterable, defines ``__len__``, and yields
-   :class:`~lightning_pose.data.datatypes.UnlabeledBatchDict` /
-   :class:`~lightning_pose.data.datatypes.MultiviewUnlabeledBatchDict` -- FCHW float frames,
-   ImageNet-normalized, plus ``transforms`` and ``bbox``. Match ``LitDaliWrapper`` /
-   ``LitPynvvcWrapper``'s shape exactly so downstream code (``PredictionHandler``,
-   ``trainer.predict``) doesn't need to know which backend produced a batch.
-3. **Availability probe (optional)**: ``is_<name>_available(video_path, ...) -> bool``, only
-   needed if the backend can be installed but still unusable for a given machine/video (wrong
-   hardware/driver generation, as with pynvvc). Skip it for a backend that's simply present or
-   absent as a plain package dependency.
-4. **Import discipline**: if the backend's package is platform-gated or proprietary (not a
-   guaranteed cross-platform install), every import of it must be lazy -- inside the function or
-   method body that uses it, never at module top level (see the ``# lazy: avoids ImportError on
-   cpu-only installs`` convention in ``dali.py``/``pynvvc.py``). A top-level import of such a
-   package anywhere in the package or tests will break ``import lightning_pose`` on machines that
-   don't have it. If the package is an unconditional, cross-platform dependency already declared
-   in ``pyproject.toml`` (like ``opencv-python-headless``), top-level imports are fine.
-5. **Wire it in**:
-
-   - add the name to ``_Reader`` in ``lightning_pose/utils/inference_types.py`` (the single
-     source for the CLI's ``--reader`` choices and API type hints);
-   - add a dispatch branch -- and, if step 3 applies, a fallback rung -- in ``predict_video()``
-     (``lightning_pose/utils/predictions.py``);
-   - update the ``--reader`` help text in ``lightning_pose/cli/commands/predict.py``;
-   - add this module to the package map above.
-6. **Tests**: add ``tests/data/video/test_<name>.py`` mirroring a sibling reader's test module
-   one-for-one; mark any test that needs real hardware with ``@pytest.mark.gpu`` so the CPU CI
-   workflow (``pytest -m "not gpu"``) still exercises everything else.
+- ``factory.py`` -- :func:`~lightning_pose.data.video.factory.build_video_reader`, the reader-
+  selection dispatch used by ``predict_video``. See its docstring for the fallback chain and
+  the recipe for adding a new backend.
 """
 
 __all__: list[str] = []

--- a/lightning_pose/data/video/__init__.py
+++ b/lightning_pose/data/video/__init__.py
@@ -1,0 +1,6 @@
+"""Video-reading backends for training and prediction.
+
+TODO(Part 2): package map + "adding a new video reader" contract.
+"""
+
+__all__: list[str] = []

--- a/lightning_pose/data/video/__init__.py
+++ b/lightning_pose/data/video/__init__.py
@@ -1,6 +1,69 @@
 """Video-reading backends for training and prediction.
 
-TODO(Part 2): package map + "adding a new video reader" contract.
+Three backends currently implement the same reader contract (see below): ``dali.py`` (GPU video
+loading via NVIDIA DALI, training + prediction), ``pynvvc.py`` (direct NVDEC access via
+PyNvVideoCodec, prediction only), and ``opencv.py`` (CPU decode via OpenCV, prediction only). All
+three plug into the same call sites -- ``lightning_pose.data.datamodules.UnlabeledDataModule``
+for training, ``lightning_pose.utils.predictions.predict_video`` for prediction -- which select a
+backend by name (``--reader``/``reader=`` in the API) or by auto-probing hardware availability.
+
+Backends
+--------
+
+- ``dali.py`` -- :class:`~lightning_pose.data.video.dali.PrepareDALI` /
+  :class:`~lightning_pose.data.video.dali.LitDaliWrapper`. GPU-accelerated, NVIDIA + Linux
+  x86_64 only (``nvidia-dali-cuda110`` is platform-gated in ``pyproject.toml``). The only
+  backend used for training; also used for prediction.
+- ``pynvvc.py`` -- :class:`~lightning_pose.data.video.pynvvc.PreparePynvvc` /
+  :class:`~lightning_pose.data.video.pynvvc.LitPynvvcWrapper`. Direct NVDEC access via
+  PyNvVideoCodec, Linux x86_64 plus a supported NVIDIA GPU/driver generation only. Prediction
+  only.
+- ``opencv.py`` -- :class:`~lightning_pose.data.video.opencv.PrepareOpenCV` /
+  :class:`~lightning_pose.data.video.opencv.LitOpenCVWrapper`. CPU decode via
+  ``opencv-python-headless``, an unconditional cross-platform dependency -- works on any
+  platform/hardware, including macOS, Windows, and GPU-less machines. Slower than DALI/pynvvc on
+  a supported NVIDIA box; the guaranteed fallback everywhere else. Prediction only.
+
+Adding a new video reader
+--------------------------
+
+Every backend module implements the same contract. To add one:
+
+1. **Two-phase prepare class**: ``Prepare<Name>.__init__(model_type, filenames, resize_dims,
+   dali_config, bbox_df=None, ...)`` validates inputs and precomputes windowing parameters
+   (raise early, before any GPU/decoder allocation); ``__call__()`` builds and returns a
+   ``Lit<Name>Wrapper``. (The ``dali_config`` parameter name is a pre-existing wart --
+   ``PreparePynvvc`` already reuses ``cfg.dali``'s windowing section rather than inventing a
+   per-backend config block, since the windowing semantics are decoder-agnostic; new backends
+   should follow the same precedent rather than fixing it in isolation.)
+2. **Iterator wrapper class**: ``Lit<Name>Wrapper`` is iterable, defines ``__len__``, and yields
+   :class:`~lightning_pose.data.datatypes.UnlabeledBatchDict` /
+   :class:`~lightning_pose.data.datatypes.MultiviewUnlabeledBatchDict` -- FCHW float frames,
+   ImageNet-normalized, plus ``transforms`` and ``bbox``. Match ``LitDaliWrapper`` /
+   ``LitPynvvcWrapper``'s shape exactly so downstream code (``PredictionHandler``,
+   ``trainer.predict``) doesn't need to know which backend produced a batch.
+3. **Availability probe (optional)**: ``is_<name>_available(video_path, ...) -> bool``, only
+   needed if the backend can be installed but still unusable for a given machine/video (wrong
+   hardware/driver generation, as with pynvvc). Skip it for a backend that's simply present or
+   absent as a plain package dependency.
+4. **Import discipline**: if the backend's package is platform-gated or proprietary (not a
+   guaranteed cross-platform install), every import of it must be lazy -- inside the function or
+   method body that uses it, never at module top level (see the ``# lazy: avoids ImportError on
+   cpu-only installs`` convention in ``dali.py``/``pynvvc.py``). A top-level import of such a
+   package anywhere in the package or tests will break ``import lightning_pose`` on machines that
+   don't have it. If the package is an unconditional, cross-platform dependency already declared
+   in ``pyproject.toml`` (like ``opencv-python-headless``), top-level imports are fine.
+5. **Wire it in**:
+
+   - add the name to ``_Reader`` in ``lightning_pose/utils/inference_types.py`` (the single
+     source for the CLI's ``--reader`` choices and API type hints);
+   - add a dispatch branch -- and, if step 3 applies, a fallback rung -- in ``predict_video()``
+     (``lightning_pose/utils/predictions.py``);
+   - update the ``--reader`` help text in ``lightning_pose/cli/commands/predict.py``;
+   - add this module to the package map above.
+6. **Tests**: add ``tests/data/video/test_<name>.py`` mirroring a sibling reader's test module
+   one-for-one; mark any test that needs real hardware with ``@pytest.mark.gpu`` so the CPU CI
+   workflow (``pytest -m "not gpu"``) still exercises everything else.
 """
 
 __all__: list[str] = []

--- a/lightning_pose/data/video/dali.py
+++ b/lightning_pose/data/video/dali.py
@@ -8,7 +8,7 @@ platforms and break ``import lightning_pose`` entirely. Always import from this 
 inside the function or method body that uses it::
 
     def my_function(...):
-        from lightning_pose.data.dali import PrepareDALI  # lazy: avoids ImportError on cpu-only
+        from lightning_pose.data.video.dali import PrepareDALI  # lazy: avoids cpu-only ImportError
         ...
 
 Architecture overview

--- a/lightning_pose/data/video/factory.py
+++ b/lightning_pose/data/video/factory.py
@@ -1,0 +1,190 @@
+"""Reader-selection dispatch: turns a backend name (or ``None``) into a built dataloader.
+
+Single entry point: :func:`build_video_reader`. Resolves which backend to use --
+either the caller's explicit choice, validated against this machine/video, or an
+auto-select fallback chain (pynvvc -> dali -> opencv, richest/fastest first, most
+portable last) -- then constructs and returns that backend's ready-to-iterate loader.
+
+Adding a new video reader
+-------------------------
+
+Every backend module (``dali.py``, ``pynvvc.py``, ``opencv.py``, ...) implements the
+same contract. To add one:
+
+1. **Two-phase prepare class**: ``Prepare<Name>.__init__(model_type, filenames,
+   resize_dims, dali_config, bbox_df=None, ...)`` validates inputs and precomputes
+   windowing parameters (raise early, before any GPU/decoder allocation);
+   ``__call__()`` builds and returns a ``Lit<Name>Wrapper``. (The ``dali_config``
+   parameter name is a pre-existing wart -- ``PreparePynvvc`` already reuses
+   ``cfg.dali``'s windowing section rather than inventing a per-backend config block,
+   since the windowing semantics are decoder-agnostic; new backends should follow the
+   same precedent rather than fixing it in isolation.)
+2. **Iterator wrapper class**: ``Lit<Name>Wrapper`` is iterable, defines ``__len__``,
+   and yields :class:`~lightning_pose.data.datatypes.UnlabeledBatchDict` /
+   :class:`~lightning_pose.data.datatypes.MultiviewUnlabeledBatchDict` -- FCHW float
+   frames, ImageNet-normalized, plus ``transforms`` and ``bbox``. Match
+   ``LitDaliWrapper``/``LitPynvvcWrapper``'s shape exactly so downstream code
+   (``PredictionHandler``, ``trainer.predict``) doesn't need to know which backend
+   produced a batch.
+3. **Availability probe (optional)**: ``is_<name>_available(video_path, ...) -> bool``,
+   only needed if the backend can be installed but still unusable for a given
+   machine/video (wrong hardware/driver generation, as with pynvvc). Skip it for a
+   backend that's simply present or absent as a plain package dependency.
+4. **Import discipline**: if the backend's package is platform-gated or proprietary
+   (not a guaranteed cross-platform install), every import of it must be lazy --
+   inside the function or method body that uses it, never at module top level (see
+   the ``# lazy: avoids ImportError on cpu-only installs`` convention in
+   ``dali.py``/``pynvvc.py``). A top-level import of such a package anywhere in the
+   package or tests will break ``import lightning_pose`` on machines that don't have
+   it. If the package is an unconditional, cross-platform dependency already declared
+   in ``pyproject.toml`` (like ``opencv-python-headless``), top-level imports are
+   fine.
+5. **Wire it in**:
+
+   - add the name to ``_Reader`` in ``lightning_pose/utils/inference_types.py`` (the
+     single source for the CLI's ``--reader`` choices and API type hints);
+   - add a branch -- and, if step 3 applies, a fallback rung -- in
+     :func:`build_video_reader` (this file);
+   - update the ``--reader`` help text in ``lightning_pose/cli/commands/predict.py``;
+   - add this module to the package map in ``lightning_pose.data.video``'s docstring.
+6. **Tests**: add ``tests/data/video/test_<name>.py`` mirroring a sibling reader's
+   test module one-for-one, plus a case in ``tests/data/video/test_factory.py``
+   covering its fallback/validation branch; mark any test that needs real hardware
+   with ``@pytest.mark.gpu`` so the CPU CI workflow (``pytest -m "not gpu"``) still
+   exercises everything else.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+import pandas as pd
+from omegaconf import DictConfig, ListConfig
+
+from lightning_pose.utils.inference_types import _Reader
+
+if TYPE_CHECKING:
+    from lightning_pose.data.video.dali import LitDaliWrapper
+    from lightning_pose.data.video.opencv import LitOpenCVWrapper
+    from lightning_pose.data.video.pynvvc import LitPynvvcWrapper
+
+logger = logging.getLogger(__name__)
+
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
+
+
+def build_video_reader(
+    reader: _Reader | None,
+    probe_video: str,
+    model_type: Literal["base", "context"],
+    dali_config: dict | DictConfig | ListConfig,
+    filenames: list[str] | list[list[str]],
+    resize_dims: list[int],
+    bbox_df: pd.DataFrame | None,
+) -> LitDaliWrapper | LitPynvvcWrapper | LitOpenCVWrapper:
+    """Resolve which video-reading backend to use and build its dataloader.
+
+    ``reader=None`` auto-selects the best backend usable on this machine for this
+    video -- pynvvc if it's actually usable (installed + this GPU/driver + this video
+    decode successfully), else dali if it's installed (``nvidia-dali-cuda110`` is
+    platform-gated to Linux x86_64, so it's simply absent on macOS/Windows/other
+    architectures), else opencv, an unconditional cross-platform dependency and thus
+    the guaranteed final rung. An explicit ``reader`` is validated the same way and
+    raises a clear error instead of a deep traceback if it isn't usable.
+
+    Args:
+        reader: explicit backend choice, or ``None`` to auto-select.
+        probe_video: a real video file path used to probe hardware/file-specific
+            availability (pynvvc's GPU/driver check, opencv's file-readability
+            check). For multiview callers, pass the first view's video.
+        model_type: ``"base"`` or ``"context"`` -- selects windowing parameters.
+        dali_config: ``cfg.dali`` dict/section; only ``predict.sequence_length``
+            (base and context) is used, by every backend (see
+            ``lightning_pose.data.video``'s package docstring for why this
+            parameter name is kept even for non-DALI backends).
+        filenames: for single-view, a flat list containing one video path; for
+            multiview, one single-element list per view (see each backend's
+            ``Prepare<Name>`` class for the exact shape).
+        resize_dims: ``[height, width]`` the model expects as input.
+        bbox_df: optional per-frame bbox DataFrame; single-view only.
+
+    Returns:
+        A ready-to-iterate loader (``LitDaliWrapper``, ``LitPynvvcWrapper``, or
+        ``LitOpenCVWrapper``).
+
+    Raises:
+        RuntimeError: if an explicit ``reader`` is requested but isn't usable on this
+            machine/video.
+    """
+    if reader is None:
+        from lightning_pose.data.video.pynvvc import is_pynvvc_available
+        if is_pynvvc_available(probe_video):
+            reader = "pynvvc"
+        else:
+            try:
+                import lightning_pose.data.video.dali  # noqa: F401  probe importability
+                reader = "dali"
+            except ImportError:
+                reader = "opencv"
+    elif reader == "dali":
+        try:
+            import lightning_pose.data.video.dali  # noqa: F401  probe importability
+        except ImportError as e:
+            raise RuntimeError(
+                "reader='dali' was requested but nvidia-dali isn't installed on this "
+                "machine (it's platform-gated to Linux x86_64, so it's simply absent on "
+                "macOS/Windows/other architectures). Pass reader='pynvvc'/'opencv' or "
+                "omit reader to auto-select."
+            ) from e
+    elif reader == "pynvvc":
+        from lightning_pose.data.video.pynvvc import is_pynvvc_available
+        if not is_pynvvc_available(probe_video):
+            raise RuntimeError(
+                "reader='pynvvc' was requested but PyNvVideoCodec can't decode "
+                f"{probe_video!r} on this machine (unsupported GPU generation, driver "
+                "too old, pynvvideocodec not installed, or an unsupported video "
+                "format). Pass reader='dali'/'opencv' or omit reader to auto-select."
+            )
+    elif reader == "opencv":
+        from lightning_pose.data.video.opencv import is_opencv_available
+        if not is_opencv_available(probe_video):
+            raise RuntimeError(
+                f"reader='opencv' was requested but OpenCV can't open {probe_video!r} "
+                "(corrupt file or unsupported codec/container). Pass a different "
+                "reader or omit reader to auto-select."
+            )
+    logger.info(f"build_video_reader: using '{reader}' reader backend")
+
+    if reader == "dali":
+        from lightning_pose.data.video.dali import PrepareDALI  # avoids cpu-only ImportError
+        vid_pred_class = PrepareDALI(
+            train_stage="predict",
+            model_type=model_type,
+            dali_config=dali_config,
+            # Important: This will be a list of lists for multiview.
+            # This will trigger dali to return multiview batches to predict_step.
+            filenames=filenames,
+            resize_dims=resize_dims,
+            bbox_df=bbox_df,
+        )
+    elif reader == "pynvvc":
+        from lightning_pose.data.video.pynvvc import PreparePynvvc  # avoids cpu-only ImportError
+        vid_pred_class = PreparePynvvc(
+            model_type=model_type,
+            dali_config=dali_config,
+            filenames=filenames,
+            resize_dims=resize_dims,
+            bbox_df=bbox_df,
+        )
+    else:  # opencv
+        from lightning_pose.data.video.opencv import PrepareOpenCV
+        vid_pred_class = PrepareOpenCV(
+            model_type=model_type,
+            dali_config=dali_config,
+            filenames=filenames,
+            resize_dims=resize_dims,
+            bbox_df=bbox_df,
+        )
+    return vid_pred_class()

--- a/lightning_pose/data/video/opencv.py
+++ b/lightning_pose/data/video/opencv.py
@@ -301,8 +301,8 @@ class PrepareOpenCV:
         Args:
             model_type: ``"base"`` for standard single-frame models, ``"context"``
                 for MHCRNN models that consume a temporal window.
-            filenames: for single-view, a single video path (as a length-1 list or
-                bare string); for multi-view, one video path per view.
+            filenames: for single-view, a flat list containing one video path; for
+                multi-view, one single-element list per view.
             resize_dims: ``[height, width]`` to resize frames to before feeding the
                 model. Also used as the post-crop resize target when ``bbox_df`` is
                 provided.

--- a/lightning_pose/data/video/opencv.py
+++ b/lightning_pose/data/video/opencv.py
@@ -1,0 +1,413 @@
+"""Data pipeline for video prediction based on OpenCV (``cv2.VideoCapture``).
+
+Import discipline
+------------------
+Unlike ``dali.py``/``pynvvc.py``, ``cv2`` (``opencv-python-headless``) is an unconditional,
+cross-platform dependency already declared in ``pyproject.toml`` and already imported at module
+top level elsewhere in this package (e.g. ``lightning_pose.data.cameras``,
+``lightning_pose.utils.predictions``). So, unlike those two backends, this module imports ``cv2``
+eagerly; no lazy-import discipline is needed here (see ``lightning_pose.data.video``'s package
+docstring for when lazy imports are required).
+
+Architecture overview
+----------------------
+Mirrors ``lightning_pose.data.video.pynvvc``'s two-phase construction: ``PrepareOpenCV.__init__``
+validates inputs and precomputes windowing parameters; calling the instance (``__call__``) builds
+and returns a ready-to-iterate ``LitOpenCVWrapper``.
+
+Predict-only, like pynvvc: this backend never runs ``random_shuffle`` or the ``imgaug``
+augmentation pipeline, since ``litpose predict`` already runs with both off. Training continues
+to go through DALI exclusively (``lightning_pose.data.video.dali``).
+
+Sequential decode, not seek-based
+-----------------------------------
+Context (MHCRNN) models read overlapping windows: consecutive ``sequence_length``-frame windows
+advance by ``step = sequence_length - 4``, so the last 4 frames of window *i* are the same
+physical frames as the first 4 of window *i+1*. ``cv2.VideoCapture``'s ``CAP_PROP_POS_FRAMES``
+seeking is not reliably frame-exact on containers with B-frames or a variable/estimated frame
+rate -- a seek-per-window implementation risks silently misaligning that overlap: no crash, no
+shape change, just a temporally-shifted context stack feeding a plausible-but-wrong prediction.
+
+To avoid that, ``LitOpenCVWrapper`` never seeks: it opens each view's ``cv2.VideoCapture`` once
+and reads strictly forward via ``cap.read()``, caching the trailing 4 frames of each window in
+``self._tail`` to prepend to the next one. Every physical frame is decoded exactly once (aside
+from the cached tail).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+import cv2
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn.functional as F
+from omegaconf import DictConfig, ListConfig
+
+from lightning_pose.data import _IMAGENET_MEAN, _IMAGENET_STD
+from lightning_pose.data.bboxes import crop_and_resize_frames
+from lightning_pose.data.datatypes import (
+    MultiviewUnlabeledBatchDict,
+    UnlabeledBatchDict,
+)
+from lightning_pose.data.utils import count_frames
+
+# to ignore imports for sphinx-autoapidoc
+__all__: list[str] = []
+
+
+def is_opencv_available(video_path: str) -> bool:
+    """Best-effort check whether OpenCV can open ``video_path`` for reading.
+
+    Cheap relative to ``is_pynvvc_available`` -- no real decoder construction, no
+    CUDA -- since ``opencv-python-headless`` is an unconditional dependency, this only
+    needs to catch a bad/corrupt/unsupported file, not an availability question about
+    the package itself. Used to give a clear error when a user explicitly requests
+    ``--reader opencv`` against an unreadable file; not used to gate the auto-select
+    fallback chain, where opencv is the unconditional final rung (see
+    ``lightning_pose.utils.predictions.predict_video``).
+
+    Args:
+        video_path: path to a real, existing video file to probe.
+
+    Returns:
+        True if ``cv2.VideoCapture`` can open the file, False otherwise.
+    """
+    cap = cv2.VideoCapture(video_path)
+    try:
+        return cap.isOpened()
+    finally:
+        cap.release()
+
+
+class LitOpenCVWrapper:
+    """OpenCV-backed iterator for Lightning Pose video prediction.
+
+    Mirrors ``LitPynvvcWrapper``'s public shape (iterable, ``__len__``, yields typed
+    batch dicts consumable by ``trainer.predict()``) but reads sequentially from
+    ``cv2.VideoCapture`` instead of indexed random access -- see module docstring for
+    why.
+
+    Predict-only: no ``random_shuffle``, no ``imgaug``. See
+    ``lightning_pose.data.video.dali.LitDaliWrapper`` for the train-time DALI path,
+    which this class does not replicate.
+    """
+
+    def __init__(
+        self,
+        filenames: list[list[str]],
+        resize_dims: list[int],
+        decode_resize_dims: list[int] | None,
+        sequence_length: int,
+        step: int,
+        do_context: bool,
+        num_iters: int,
+        multiview: bool,
+        bbox_df: pd.DataFrame | None = None,
+    ) -> None:
+        """
+        Args:
+            filenames: one single-element list per view, e.g. ``[["v0.mp4"]]`` for
+                single-view or ``[["v0.mp4"], ["v1.mp4"]]`` for multiview -- always
+                exactly one video per view (no multi-session batching in predict).
+            resize_dims: ``[height, width]`` the model expects as input. Used as the
+                post-crop resize target when ``bbox_df`` is set.
+            decode_resize_dims: ``[height, width]`` to resize decoded frames to
+                immediately after decode. ``None`` in bbox-crop mode (full-resolution
+                frames are needed for cropping); equal to ``resize_dims`` otherwise.
+            sequence_length: number of frames per batch/window.
+            step: frames to advance the read cursor between windows. Equals
+                ``sequence_length`` for non-overlapping ("base") windows, or
+                ``sequence_length - 4`` for context models' overlapping windows.
+            do_context: whether this is a 5-frame-context (MHCRNN-style) model.
+            num_iters: total number of batches this video will produce; precomputed
+                by ``PrepareOpenCV.num_iters`` so Lightning can report progress.
+            multiview: whether this is a multiview prediction (one capture per view,
+                read in lockstep since predict never shuffles).
+            bbox_df: optional per-frame bbox DataFrame (columns x, y, h, w); single-
+                view only (enforced upstream in ``predict_video``).
+        """
+        self.resize_dims = resize_dims
+        self.decode_resize_dims = decode_resize_dims
+        self.sequence_length = sequence_length
+        self.step = step
+        self.do_context = do_context
+        self.num_iters = num_iters
+        self.multiview = multiview
+        self.bbox_df = bbox_df
+
+        self._caps = [cv2.VideoCapture(view_list[0]) for view_list in filenames]
+        # up to 4 frames carried over from the previous window's tail, per view --
+        # see module docstring for why this replaces seeking
+        self._tail: list[list[np.ndarray]] = [[] for _ in self._caps]
+
+        self._iters_done = 0
+        # cursor into bbox_df; advances by the context-adjusted step per batch, same
+        # convention as LitDaliWrapper._frame_idx / LitPynvvcWrapper._frame_idx
+        self._frame_idx = 0
+
+    def __len__(self) -> int:
+        """Return the number of iterations (batches) in this dataloader."""
+        return self.num_iters
+
+    def __iter__(self) -> LitOpenCVWrapper:
+        return self
+
+    def _read_new_frames(self, cap: cv2.VideoCapture, n: int) -> list[np.ndarray]:
+        """Read up to ``n`` frames sequentially from ``cap``; returns fewer at EOF."""
+        frames: list[np.ndarray] = []
+        for _ in range(n):
+            ret, frame = cap.read()
+            if not ret:
+                break
+            frames.append(frame)  # HWC, BGR, uint8
+        return frames
+
+    def _next_window(self, cap_idx: int) -> torch.Tensor:
+        """Read the next ``sequence_length``-frame window for one view.
+
+        Prepends any tail carried over from the previous window (context models
+        only), reads just the new frames needed to fill out ``sequence_length``, pads
+        by repeating the last frame at end-of-video (matches DALI's
+        ``pad_sequences=True`` / ``LastBatchPolicy.FILL`` and ``LitPynvvcWrapper``'s
+        equivalent padding -- needed so every batch has a static shape, which matters
+        for torch.compile), and -- for context models -- caches the window's last 4
+        frames as the tail for next time.
+        """
+        tail = self._tail[cap_idx]
+        n_new = self.sequence_length - len(tail)
+        new_frames = self._read_new_frames(self._caps[cap_idx], n_new)
+        window = tail + new_frames
+
+        n_missing = self.sequence_length - len(window)
+        if n_missing > 0:
+            if not window:
+                raise RuntimeError(
+                    f"opencv reader exhausted view {cap_idx} with no frames decoded for this "
+                    "window; this indicates a mismatch between count_frames() and the actual "
+                    "decodable frame count."
+                )
+            window = window + [window[-1]] * n_missing
+
+        self._tail[cap_idx] = window[-4:] if self.do_context else []
+
+        # HWC BGR uint8 -> (seq_len, C, H, W) RGB, matching the other backends' output layout
+        frames_np = np.stack(window)  # (seq_len, H, W, C)
+        frames_bgr = torch.from_numpy(frames_np).permute(0, 3, 1, 2)  # (seq_len, C, H, W)
+        return frames_bgr[:, [2, 1, 0], :, :]  # BGR -> RGB
+
+    def _resize_normalize(self, frames: torch.Tensor) -> torch.Tensor:
+        """frames: (seq_len, C, H, W), uint8, RGB.
+
+        Returns float, optionally resized to ``decode_resize_dims``, [0,1]-scaled,
+        then ImageNet-normalized -- same order of operations as DALI's
+        ``fn.resize`` -> ``fn.crop_mirror_normalize`` in ``dali.py:video_pipe``.
+        """
+        frames = frames.float() / 255.0
+        if self.decode_resize_dims is not None:
+            frames = F.interpolate(
+                frames, size=self.decode_resize_dims, mode='bilinear', align_corners=False,
+            )
+        mean = torch.tensor(_IMAGENET_MEAN, device=frames.device).view(1, 3, 1, 1)
+        std = torch.tensor(_IMAGENET_STD, device=frames.device).view(1, 3, 1, 1)
+        return (frames - mean) / std
+
+    def __next__(self) -> UnlabeledBatchDict | MultiviewUnlabeledBatchDict:
+        """Fetch the next batch, applying per-frame bbox crop+resize when configured."""
+        if self._iters_done >= self.num_iters:
+            raise StopIteration
+        self._iters_done += 1
+
+        per_view_frames = [self._next_window(i) for i in range(len(self._caps))]
+        processed = [self._resize_normalize(f) for f in per_view_frames]
+
+        if not self.multiview:
+            frames = processed[0]
+            height, width = frames.shape[-2], frames.shape[-1]
+
+            if self.bbox_df is not None:
+                assert self.resize_dims is not None  # required whenever bbox_df is set
+                step = self.sequence_length - 4 if self.do_context else self.sequence_length
+                rows = self.bbox_df.iloc[self._frame_idx:self._frame_idx + self.sequence_length]
+                if len(rows) < self.sequence_length:
+                    last_row = self.bbox_df.iloc[[-1]]
+                    rows = pd.concat(
+                        [rows] + [last_row] * (self.sequence_length - len(rows)),
+                        ignore_index=True,
+                    )
+                cropped_frames, bboxes = crop_and_resize_frames(frames, rows, self.resize_dims)
+                self._frame_idx += step
+                return UnlabeledBatchDict(
+                    frames=cropped_frames,
+                    transforms=torch.tensor([-1.0]),
+                    bbox=bboxes,
+                    is_multiview=False,
+                )
+
+            bbox = torch.tensor(
+                [0, 0, height, width], device=frames.device, dtype=torch.float32,
+            ).repeat(frames.shape[0], 1)
+            return UnlabeledBatchDict(
+                frames=frames,
+                transforms=torch.tensor([-1.0]),
+                bbox=bbox,
+                is_multiview=False,
+            )
+
+        else:
+            frames = torch.stack(processed, dim=1)  # (seq_len, num_views, C, H, W)
+            height, width = frames.shape[-2], frames.shape[-1]
+            num_views = len(self._caps)
+            bbox_per_view = torch.tensor(
+                [0, 0, height, width], device=frames.device, dtype=torch.float32,
+            )
+            bbox = bbox_per_view.repeat(num_views).unsqueeze(0).repeat(frames.shape[0], 1)
+            transforms = torch.tensor([-1.0]).repeat(num_views, 1, 1)
+            return MultiviewUnlabeledBatchDict(
+                frames=frames,
+                transforms=transforms,
+                bbox=bbox,
+                is_multiview=True,
+            )
+
+
+class PrepareOpenCV:
+    """Factory for OpenCV-backed inference dataloaders.
+
+    Predict-only counterpart to ``lightning_pose.data.video.dali.PrepareDALI`` -- only
+    needs the "predict" x {"base", "context"} combinations, since this backend never
+    shuffles or augments. Construction is split the same way as ``PrepareDALI``/
+    ``PreparePynvvc``: ``__init__`` validates inputs and precomputes windowing
+    parameters; ``__call__`` builds and returns a ready-to-iterate ``LitOpenCVWrapper``.
+
+    Sequence-length source: reuses ``dali_config["base"]["predict"]["sequence_length"]``
+    / ``dali_config["context"]["predict"]["sequence_length"]`` (i.e. the existing
+    ``cfg.dali`` section), same precedent as ``PreparePynvvc`` -- see
+    ``lightning_pose.data.video``'s package docstring for why this parameter name is
+    kept even though it isn't DALI-specific.
+    """
+
+    def __init__(
+        self,
+        model_type: Literal["base", "context"],
+        filenames: list[str] | list[list[str]],
+        resize_dims: list[int],
+        dali_config: dict | DictConfig | ListConfig,
+        bbox_df: pd.DataFrame | None = None,
+    ) -> None:
+        """
+        Args:
+            model_type: ``"base"`` for standard single-frame models, ``"context"``
+                for MHCRNN models that consume a temporal window.
+            filenames: for single-view, a single video path (as a length-1 list or
+                bare string); for multi-view, one video path per view.
+            resize_dims: ``[height, width]`` to resize frames to before feeding the
+                model. Also used as the post-crop resize target when ``bbox_df`` is
+                provided.
+            dali_config: same ``cfg.dali`` dict ``PrepareDALI``/``PreparePynvvc`` read
+                from -- only the ``predict.sequence_length`` values (base and context)
+                are used.
+            bbox_df: optional DataFrame with columns ``["x", "y", "h", "w"]``, one
+                row per frame. When provided, frames are decoded at full resolution
+                and ``LitOpenCVWrapper`` crops each to its bbox before resizing.
+
+        Raises:
+            FileNotFoundError: if any path in ``filenames`` does not exist or is not
+                a file.
+            NotImplementedError: if any view supplies more than one video (multi-
+                session batching is a DALI-train-only concept, not needed here).
+            ValueError: for multiview inputs, if views have differing frame counts
+                (which would desynchronize the per-view sequential reads), or for an
+                unknown ``model_type``.
+        """
+        if isinstance(filenames, list) and isinstance(filenames[0], list):
+            self.multiview = True
+        else:
+            self.multiview = False
+
+        filenames_2d: list[list[str]]
+        if isinstance(filenames[0], str):
+            filenames_2d = [filenames]  # type: ignore[list-item]
+        else:
+            filenames_2d = filenames  # type: ignore[assignment]
+
+        for view_list in filenames_2d:
+            if len(view_list) != 1:
+                raise NotImplementedError(
+                    "opencv predict backend supports exactly one video per view "
+                    f"(no multi-session batching); got {len(view_list)} videos for one view."
+                )
+            vid = view_list[0]
+            if not os.path.exists(vid) or not os.path.isfile(vid):
+                raise FileNotFoundError(f"{vid} is not a video file!")
+
+        view0_frame_count = count_frames(filenames_2d[0][0])
+        if self.multiview:
+            for view_idx, view_list in enumerate(filenames_2d[1:], start=1):
+                frame_count = count_frames(view_list[0])
+                if frame_count != view0_frame_count:
+                    raise ValueError(
+                        "Mismatched frame counts across views; multiview opencv reading "
+                        f"would desynchronize. view 0={view0_frame_count}, "
+                        f"view {view_idx}={frame_count}"
+                    )
+
+        self.model_type = model_type
+        self.filenames = filenames_2d
+        self.resize_dims = resize_dims
+        self.bbox_df = bbox_df
+        self.frame_count = view0_frame_count
+
+        if model_type == "base":
+            predict_cfg = dali_config["base"]["predict"]  # type: ignore[index]
+            self.sequence_length = predict_cfg["sequence_length"]
+            self.step = self.sequence_length
+            self.do_context = False
+        elif model_type == "context":
+            predict_cfg = dali_config["context"]["predict"]  # type: ignore[index]
+            self.sequence_length = predict_cfg["sequence_length"]
+            self.step = self.sequence_length - 4
+            self.do_context = True
+        else:
+            raise ValueError(f"unknown model_type: {model_type}")
+
+        # bbox-crop mode needs full-resolution decoded frames to crop from; the
+        # post-crop resize to resize_dims happens in crop_and_resize_frames instead.
+        self._decode_resize_dims: list[int] | None = (
+            None if self.bbox_df is not None else resize_dims
+        )
+
+    @property
+    def num_iters(self) -> int:
+        """Number of dataloader iterations required to process all frames.
+
+        Identical formula to ``PreparePynvvc.num_iters`` (single sequence at a time,
+        batch_size=1): for context models this is the "step == sequence_length - 4"
+        case.
+        """
+        if self.model_type == "base":
+            return int(np.ceil(self.frame_count / self.sequence_length))
+        else:  # context
+            if self.step <= 0:
+                raise ValueError(
+                    "step cannot be 0, please modify "
+                    "cfg.dali.context.predict.sequence_length to be > 4"
+                )
+            data_except_first_batch = self.frame_count - self.sequence_length
+            return int(np.ceil(data_except_first_batch / self.step)) + 1
+
+    def __call__(self) -> LitOpenCVWrapper:
+        """Build and return a ready-to-iterate ``LitOpenCVWrapper``."""
+        return LitOpenCVWrapper(
+            filenames=self.filenames,
+            resize_dims=self.resize_dims,
+            decode_resize_dims=self._decode_resize_dims,
+            sequence_length=self.sequence_length,
+            step=self.step,
+            do_context=self.do_context,
+            num_iters=self.num_iters,
+            multiview=self.multiview,
+            bbox_df=self.bbox_df,
+        )

--- a/lightning_pose/data/video/pynvvc.py
+++ b/lightning_pose/data/video/pynvvc.py
@@ -339,8 +339,8 @@ class PreparePynvvc:
         Args:
             model_type: ``"base"`` for standard single-frame models, ``"context"``
                 for MHCRNN models that consume a temporal window.
-            filenames: for single-view, a single video path (as a length-1 list or
-                bare string); for multi-view, one video path per view.
+            filenames: for single-view, a flat list containing one video path; for
+                multi-view, one single-element list per view.
             resize_dims: ``[height, width]`` to resize frames to before feeding the
                 model. Also used as the post-crop resize target when ``bbox_df`` is
                 provided.

--- a/lightning_pose/data/video/pynvvc.py
+++ b/lightning_pose/data/video/pynvvc.py
@@ -2,14 +2,14 @@
 
 Import warning
 --------------
-Same discipline as ``lightning_pose.data.dali``: ``pynvvideocodec`` is an unconditional
+Same discipline as ``lightning_pose.data.video.dali``: ``pynvvideocodec`` is an unconditional
 but platform-gated dependency (Linux x86_64 only), so importing this module at the top
 level of any other module could raise ``ImportError``/``ModuleNotFoundError`` on other
 platforms. Always import from this module lazily, inside the function or method body
 that uses it::
 
     def my_function(...):
-        from lightning_pose.data.pynvvc import PreparePynvvc  # lazy
+        from lightning_pose.data.video.pynvvc import PreparePynvvc  # lazy
         ...
 
 The ``PyNvVideoCodec`` package itself is additionally deferred to inside
@@ -20,13 +20,13 @@ on Linux) -- the failure only surfaces when a decoder is actually constructed.
 
 Architecture overview
 ----------------------
-Mirrors ``lightning_pose.data.dali``'s two-phase construction: ``PreparePynvvc.__init__``
+Mirrors ``lightning_pose.data.video.dali``'s two-phase construction: ``PreparePynvvc.__init__``
 validates inputs and precomputes windowing parameters; calling the instance
 (``__call__``) builds and returns a ready-to-iterate ``LitPynvvcWrapper``.
 
 Predict-only, unlike ``PrepareDALI``: this backend never runs ``random_shuffle`` or the
 ``imgaug`` augmentation pipeline, since ``litpose predict`` already runs with both off.
-Training continues to go through DALI exclusively (``lightning_pose.data.dali``).
+Training continues to go through DALI exclusively (``lightning_pose.data.video.dali``).
 
 CUDA stream synchronization
 ----------------------------
@@ -119,7 +119,7 @@ class LitPynvvcWrapper:
     ``PyNvVideoCodec.SimpleDecoder`` per view instead of a DALI pipeline.
 
     Predict-only: no ``random_shuffle``, no ``imgaug``. See
-    ``lightning_pose.data.dali.LitDaliWrapper`` for the train-time DALI path, which
+    ``lightning_pose.data.video.dali.LitDaliWrapper`` for the train-time DALI path, which
     this class does not replicate.
     """
 
@@ -312,7 +312,7 @@ class LitPynvvcWrapper:
 class PreparePynvvc:
     """Factory for PyNvVideoCodec-backed inference dataloaders.
 
-    Predict-only counterpart to ``lightning_pose.data.dali.PrepareDALI`` -- only
+    Predict-only counterpart to ``lightning_pose.data.video.dali.PrepareDALI`` -- only
     needs the "predict" x {"base", "context"} combinations, since NVDEC inference
     never shuffles or augments. Construction is split the same way as ``PrepareDALI``:
     ``__init__`` validates inputs and precomputes windowing parameters; ``__call__``

--- a/lightning_pose/utils/inference_types.py
+++ b/lightning_pose/utils/inference_types.py
@@ -32,7 +32,7 @@ _ExportRuntime = Literal["onnx", "tensorrt"]
 # Video-reading backends accepted by predict_on_video_file(_multiview)'s reader=
 # kwarg / `litpose predict --reader`. Independent of _Runtime -- reader controls
 # video ingestion, _Runtime controls model execution.
-_Reader = Literal["dali", "pynvvc"]
+_Reader = Literal["dali", "pynvvc", "opencv"]
 
 # Weight precisions supported for ONNX export, accepted by Model.export(
 # onnx_precision=...) / `litpose export --onnx-precision`. Deliberately narrower

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -22,6 +22,7 @@ from omegaconf import DictConfig, ListConfig
 from lightning_pose.callbacks import JSONInferenceProgressTracker
 from lightning_pose.data.datamodules import BaseDataModule, UnlabeledDataModule
 from lightning_pose.data.utils import count_frames
+from lightning_pose.data.video.factory import build_video_reader
 
 if TYPE_CHECKING:
     from lightning_pose.api import Model
@@ -487,91 +488,20 @@ def predict_video(
         model.config.cfg.data.image_resize_dims.width,
     ]
 
-    # Decide which reader backend to use: explicit choice, or auto-select the best
-    # backend usable on this machine for this video -- pynvvc if it's actually usable
-    # (installed + this GPU/driver + this video decode successfully), else dali if
-    # it's installed (nvidia-dali-cuda110 is platform-gated to Linux x86_64, so it's
-    # simply absent on macOS/Windows/other architectures), else opencv, an
-    # unconditional cross-platform dependency and thus the guaranteed final rung.
-    # Probed against the first view's video since is_pynvvc_available/
-    # is_opencv_available need a real file. Deliberately placed here rather than in
-    # the CLI handler, so every caller (CLI, direct Model API/notebook use) gets the
-    # same fail-fast behavior and log line for free -- same rationale as the backend
-    # log line below.
+    # Resolve the reader backend and build its loader. Probed against the first
+    # view's video since availability checks need a real file. Deliberately done
+    # here rather than in the CLI handler, so every caller (CLI, direct Model
+    # API/notebook use) gets the same fail-fast behavior and log line for free.
     probe_video = video_file[0] if is_multiview else video_file
-    if reader is None:
-        from lightning_pose.data.video.pynvvc import is_pynvvc_available
-        if is_pynvvc_available(probe_video):
-            reader = "pynvvc"
-        else:
-            try:
-                import lightning_pose.data.video.dali  # noqa: F401  probe importability
-                reader = "dali"
-            except ImportError:
-                reader = "opencv"
-    elif reader == "dali":
-        try:
-            import lightning_pose.data.video.dali  # noqa: F401  probe importability
-        except ImportError as e:
-            raise RuntimeError(
-                "reader='dali' was requested but nvidia-dali isn't installed on this "
-                "machine (it's platform-gated to Linux x86_64, so it's simply absent on "
-                "macOS/Windows/other architectures). Pass reader='pynvvc'/'opencv' or "
-                "omit reader to auto-select."
-            ) from e
-    elif reader == "pynvvc":
-        from lightning_pose.data.video.pynvvc import is_pynvvc_available
-        if not is_pynvvc_available(probe_video):
-            raise RuntimeError(
-                "reader='pynvvc' was requested but PyNvVideoCodec can't decode "
-                f"{probe_video!r} on this machine (unsupported GPU generation, driver "
-                "too old, pynvvideocodec not installed, or an unsupported video "
-                "format). Pass reader='dali'/'opencv' or omit reader to auto-select."
-            )
-    elif reader == "opencv":
-        from lightning_pose.data.video.opencv import is_opencv_available
-        if not is_opencv_available(probe_video):
-            raise RuntimeError(
-                f"reader='opencv' was requested but OpenCV can't open {probe_video!r} "
-                "(corrupt file or unsupported codec/container). Pass a different "
-                "reader or omit reader to auto-select."
-            )
-    logger.info(f"predict_video: using '{reader}' reader backend")
-
-    if reader == "dali":
-        from lightning_pose.data.video.dali import PrepareDALI  # avoids cpu-only ImportError
-        vid_pred_class = PrepareDALI(
-            train_stage="predict",
-            model_type=model_type,
-            dali_config=model.config.cfg.dali,
-            # Important: This will be a list of lists for multiview.
-            # This will trigger dali to return multiview batches to predict_step.
-            filenames=filenames,
-            resize_dims=resize_dims,
-            bbox_df=bbox_df,
-        )
-    elif reader == "pynvvc":
-        from lightning_pose.data.video.pynvvc import (
-            PreparePynvvc,  # avoids ImportError on cpu-only installs
-        )
-        vid_pred_class = PreparePynvvc(
-            model_type=model_type,
-            dali_config=model.config.cfg.dali,
-            filenames=filenames,
-            resize_dims=resize_dims,
-            bbox_df=bbox_df,
-        )
-    else:  # opencv
-        from lightning_pose.data.video.opencv import PrepareOpenCV
-        vid_pred_class = PrepareOpenCV(
-            model_type=model_type,
-            dali_config=model.config.cfg.dali,
-            filenames=filenames,
-            resize_dims=resize_dims,
-            bbox_df=bbox_df,
-        )
-    # get loader
-    predict_loader = vid_pred_class()
+    predict_loader = build_video_reader(
+        reader=reader,
+        probe_video=probe_video,
+        model_type=model_type,
+        dali_config=model.config.cfg.dali,
+        filenames=filenames,
+        resize_dims=resize_dims,
+        bbox_df=bbox_df,
+    )
 
     # initialize prediction handler class
     pred_handler = PredictionHandler(

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -495,10 +495,10 @@ def predict_video(
     # free -- same rationale as the backend log line below.
     probe_video = video_file[0] if is_multiview else video_file
     if reader is None:
-        from lightning_pose.data.pynvvc import is_pynvvc_available
+        from lightning_pose.data.video.pynvvc import is_pynvvc_available
         reader = "pynvvc" if is_pynvvc_available(probe_video) else "dali"
     elif reader == "pynvvc":
-        from lightning_pose.data.pynvvc import is_pynvvc_available
+        from lightning_pose.data.video.pynvvc import is_pynvvc_available
         if not is_pynvvc_available(probe_video):
             raise RuntimeError(
                 "reader='pynvvc' was requested but PyNvVideoCodec can't decode "
@@ -509,7 +509,7 @@ def predict_video(
     logger.info(f"predict_video: using '{reader}' reader backend")
 
     if reader == "dali":
-        from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
+        from lightning_pose.data.video.dali import PrepareDALI  # avoids cpu-only ImportError
         vid_pred_class = PrepareDALI(
             train_stage="predict",
             model_type=model_type,
@@ -521,7 +521,7 @@ def predict_video(
             bbox_df=bbox_df,
         )
     else:  # pynvvc
-        from lightning_pose.data.pynvvc import (
+        from lightning_pose.data.video.pynvvc import (
             PreparePynvvc,  # avoids ImportError on cpu-only installs
         )
         vid_pred_class = PreparePynvvc(

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -430,10 +430,11 @@ def predict_video(
         bbox_file: (optional) path to a bbox CSV (columns x, y, h, w; one row per frame).
             when provided, DALI delivers full-resolution frames and the wrapper crops each
             frame to the bbox before resizing to the model's input dims. single-view only.
-        reader: (optional) which video-reading backend to use: "dali" or "pynvvc".
-            None (default) auto-selects pynvvc if it's usable on this machine for this
-            video, else falls back to dali. Independent of the model's runtime
-            (eager/onnx) and --compile -- this only controls video ingestion.
+        reader: (optional) which video-reading backend to use: "dali", "pynvvc", or
+            "opencv". None (default) auto-selects pynvvc if it's usable on this machine
+            for this video, else dali if it's installed, else opencv (the portable
+            fallback, always available). Independent of the model's runtime (eager/onnx)
+            and --compile -- this only controls video ingestion.
     """
 
     is_multiview = not isinstance(video_file, str)
@@ -486,17 +487,38 @@ def predict_video(
         model.config.cfg.data.image_resize_dims.width,
     ]
 
-    # Decide which reader backend to use: explicit choice, or auto-select pynvvc if
-    # it's actually usable (installed + this GPU/driver + this video decode
-    # successfully), else fall back to dali. Probed against the first view's video
-    # since is_pynvvc_available needs a real file to construct a trial decoder.
-    # Deliberately placed here rather than in the CLI handler, so every caller (CLI,
-    # direct Model API/notebook use) gets the same fail-fast behavior and log line for
-    # free -- same rationale as the backend log line below.
+    # Decide which reader backend to use: explicit choice, or auto-select the best
+    # backend usable on this machine for this video -- pynvvc if it's actually usable
+    # (installed + this GPU/driver + this video decode successfully), else dali if
+    # it's installed (nvidia-dali-cuda110 is platform-gated to Linux x86_64, so it's
+    # simply absent on macOS/Windows/other architectures), else opencv, an
+    # unconditional cross-platform dependency and thus the guaranteed final rung.
+    # Probed against the first view's video since is_pynvvc_available/
+    # is_opencv_available need a real file. Deliberately placed here rather than in
+    # the CLI handler, so every caller (CLI, direct Model API/notebook use) gets the
+    # same fail-fast behavior and log line for free -- same rationale as the backend
+    # log line below.
     probe_video = video_file[0] if is_multiview else video_file
     if reader is None:
         from lightning_pose.data.video.pynvvc import is_pynvvc_available
-        reader = "pynvvc" if is_pynvvc_available(probe_video) else "dali"
+        if is_pynvvc_available(probe_video):
+            reader = "pynvvc"
+        else:
+            try:
+                import lightning_pose.data.video.dali  # noqa: F401  probe importability
+                reader = "dali"
+            except ImportError:
+                reader = "opencv"
+    elif reader == "dali":
+        try:
+            import lightning_pose.data.video.dali  # noqa: F401  probe importability
+        except ImportError as e:
+            raise RuntimeError(
+                "reader='dali' was requested but nvidia-dali isn't installed on this "
+                "machine (it's platform-gated to Linux x86_64, so it's simply absent on "
+                "macOS/Windows/other architectures). Pass reader='pynvvc'/'opencv' or "
+                "omit reader to auto-select."
+            ) from e
     elif reader == "pynvvc":
         from lightning_pose.data.video.pynvvc import is_pynvvc_available
         if not is_pynvvc_available(probe_video):
@@ -504,7 +526,15 @@ def predict_video(
                 "reader='pynvvc' was requested but PyNvVideoCodec can't decode "
                 f"{probe_video!r} on this machine (unsupported GPU generation, driver "
                 "too old, pynvvideocodec not installed, or an unsupported video "
-                "format). Pass reader='dali' or omit reader to auto-select."
+                "format). Pass reader='dali'/'opencv' or omit reader to auto-select."
+            )
+    elif reader == "opencv":
+        from lightning_pose.data.video.opencv import is_opencv_available
+        if not is_opencv_available(probe_video):
+            raise RuntimeError(
+                f"reader='opencv' was requested but OpenCV can't open {probe_video!r} "
+                "(corrupt file or unsupported codec/container). Pass a different "
+                "reader or omit reader to auto-select."
             )
     logger.info(f"predict_video: using '{reader}' reader backend")
 
@@ -520,11 +550,20 @@ def predict_video(
             resize_dims=resize_dims,
             bbox_df=bbox_df,
         )
-    else:  # pynvvc
+    elif reader == "pynvvc":
         from lightning_pose.data.video.pynvvc import (
             PreparePynvvc,  # avoids ImportError on cpu-only installs
         )
         vid_pred_class = PreparePynvvc(
+            model_type=model_type,
+            dali_config=model.config.cfg.dali,
+            filenames=filenames,
+            resize_dims=resize_dims,
+            bbox_df=bbox_df,
+        )
+    else:  # opencv
+        from lightning_pose.data.video.opencv import PrepareOpenCV
+        vid_pred_class = PrepareOpenCV(
             model_type=model_type,
             dali_config=model.config.cfg.dali,
             filenames=filenames,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -527,7 +527,7 @@ def multiview_heatmap_data_module_combined_context(
 @pytest.fixture
 def video_dataloader(cfg, base_dataset, video_list):
     """Create a prediction dataloader for a new video."""
-    from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
+    from lightning_pose.data.video.dali import PrepareDALI  # avoids cpu-only ImportError
 
     # setup
     vid_pred_class = PrepareDALI(
@@ -554,7 +554,7 @@ def video_dataloader_multiview(
     video_list_multiview,
 ):
     """Create a prediction dataloader for a new video."""
-    from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
+    from lightning_pose.data.video.dali import PrepareDALI  # avoids cpu-only ImportError
 
     # setup
     vid_pred_class = PrepareDALI(

--- a/tests/data/video/test_dali.py
+++ b/tests/data/video/test_dali.py
@@ -11,9 +11,9 @@ import torch
 
 pytest.importorskip('nvidia.dali', reason='nvidia-dali not installed')
 
-from lightning_pose.data import dali as dali_module
-from lightning_pose.data.dali import LitDaliWrapper, PrepareDALI, video_pipe
 from lightning_pose.data.datatypes import UnlabeledBatchDict
+from lightning_pose.data.video import dali as dali_module
+from lightning_pose.data.video.dali import LitDaliWrapper, PrepareDALI, video_pipe
 
 
 class TestVideoPipe:
@@ -308,7 +308,7 @@ class TestPrepareDALI:
         )
         with (
             patch.object(vid_pred_class, '_get_dali_pipe', return_value=MagicMock()),
-            patch('lightning_pose.data.dali.LitDaliWrapper') as MockWrapper,
+            patch('lightning_pose.data.video.dali.LitDaliWrapper') as MockWrapper,
         ):
             vid_pred_class()
         call_kwargs = MockWrapper.call_args.kwargs

--- a/tests/data/video/test_factory.py
+++ b/tests/data/video/test_factory.py
@@ -8,6 +8,23 @@ import pytest
 from lightning_pose.data.video.factory import build_video_reader
 
 
+def _fake_dali_module(prepare_dali: MagicMock) -> MagicMock:
+    """A stand-in for the real lightning_pose.data.video.dali module.
+
+    Installed into sys.modules (rather than patching PrepareDALI via
+    unittest.mock.patch's dotted-path target) so these tests don't require
+    nvidia-dali to actually be importable in the test environment --
+    unittest.mock.patch('lightning_pose.data.video.dali.PrepareDALI', ...) has to
+    import the real module to resolve that target, which fails outright on a
+    machine without nvidia-dali installed (its own top-level import re-raises).
+    Mirrors the sys.modules-substitution trick test_pynvvc.py's TestIsPynvvcAvailable
+    already uses for PyNvVideoCodec, for the same reason.
+    """
+    fake_module = MagicMock()
+    fake_module.PrepareDALI = prepare_dali
+    return fake_module
+
+
 class TestBuildVideoReader:
     """Test the build_video_reader function.
 
@@ -39,9 +56,10 @@ class TestBuildVideoReader:
 
     def test_auto_select_falls_back_to_dali_when_pynvvc_unavailable(self, dali_config):
         mock_prep = MagicMock()
+        fake_module = {'lightning_pose.data.video.dali': _fake_dali_module(mock_prep)}
         with (
             patch('lightning_pose.data.video.pynvvc.is_pynvvc_available', return_value=False),
-            patch('lightning_pose.data.video.dali.PrepareDALI', mock_prep),
+            patch.dict(sys.modules, fake_module),
         ):
             build_video_reader(
                 None, '/fake/video.mp4', 'base', dali_config, ['/fake/video.mp4'], [64, 64], None,
@@ -74,7 +92,8 @@ class TestBuildVideoReader:
 
     def test_explicit_dali_succeeds_when_installed(self, dali_config):
         mock_prep = MagicMock()
-        with patch('lightning_pose.data.video.dali.PrepareDALI', mock_prep):
+        fake_module = {'lightning_pose.data.video.dali': _fake_dali_module(mock_prep)}
+        with patch.dict(sys.modules, fake_module):
             build_video_reader(
                 'dali', '/fake/video.mp4', 'base', dali_config,
                 ['/fake/video.mp4'], [64, 64], None,

--- a/tests/data/video/test_factory.py
+++ b/tests/data/video/test_factory.py
@@ -1,0 +1,142 @@
+"""Test the video reader factory (backend resolution + construction dispatch)."""
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from lightning_pose.data.video.factory import build_video_reader
+
+
+class TestBuildVideoReader:
+    """Test the build_video_reader function.
+
+    All tests mock at the boundary functions (is_pynvvc_available, is_opencv_available,
+    dali's own importability) and the Prepare* classes themselves, same discipline as
+    test_pynvvc.py's TestIsPynvvcAvailable -- deterministic regardless of what's
+    actually installed in the test environment, and no real decoder/GPU/file I/O.
+    """
+
+    @pytest.fixture
+    def dali_config(self):
+        return {
+            'base': {'predict': {'sequence_length': 8}},
+            'context': {'predict': {'sequence_length': 9}},
+        }
+
+    # -- auto-select (reader=None) --
+
+    def test_auto_select_picks_pynvvc_when_available(self, dali_config):
+        mock_prep = MagicMock()
+        with (
+            patch('lightning_pose.data.video.pynvvc.is_pynvvc_available', return_value=True),
+            patch('lightning_pose.data.video.pynvvc.PreparePynvvc', mock_prep),
+        ):
+            build_video_reader(
+                None, '/fake/video.mp4', 'base', dali_config, ['/fake/video.mp4'], [64, 64], None,
+            )
+        assert mock_prep.called
+
+    def test_auto_select_falls_back_to_dali_when_pynvvc_unavailable(self, dali_config):
+        mock_prep = MagicMock()
+        with (
+            patch('lightning_pose.data.video.pynvvc.is_pynvvc_available', return_value=False),
+            patch('lightning_pose.data.video.dali.PrepareDALI', mock_prep),
+        ):
+            build_video_reader(
+                None, '/fake/video.mp4', 'base', dali_config, ['/fake/video.mp4'], [64, 64], None,
+            )
+        assert mock_prep.called
+
+    def test_auto_select_falls_back_to_opencv_when_neither_available(self, dali_config):
+        """Simulates a machine with neither pynvvc usable nor dali installed at all
+        (e.g. macOS/Windows) -- opencv must still be reachable."""
+        mock_prep = MagicMock()
+        with (
+            patch('lightning_pose.data.video.pynvvc.is_pynvvc_available', return_value=False),
+            patch.dict(sys.modules, {'lightning_pose.data.video.dali': None}),
+            patch('lightning_pose.data.video.opencv.PrepareOpenCV', mock_prep),
+        ):
+            build_video_reader(
+                None, '/fake/video.mp4', 'base', dali_config, ['/fake/video.mp4'], [64, 64], None,
+            )
+        assert mock_prep.called
+
+    # -- explicit reader: validation + successful construction --
+
+    def test_explicit_dali_raises_when_uninstalled(self, dali_config):
+        with patch.dict(sys.modules, {'lightning_pose.data.video.dali': None}):
+            with pytest.raises(RuntimeError, match="reader='dali'"):
+                build_video_reader(
+                    'dali', '/fake/video.mp4', 'base', dali_config,
+                    ['/fake/video.mp4'], [64, 64], None,
+                )
+
+    def test_explicit_dali_succeeds_when_installed(self, dali_config):
+        mock_prep = MagicMock()
+        with patch('lightning_pose.data.video.dali.PrepareDALI', mock_prep):
+            build_video_reader(
+                'dali', '/fake/video.mp4', 'base', dali_config,
+                ['/fake/video.mp4'], [64, 64], None,
+            )
+        assert mock_prep.called
+
+    def test_explicit_pynvvc_raises_when_unavailable(self, dali_config):
+        with patch('lightning_pose.data.video.pynvvc.is_pynvvc_available', return_value=False):
+            with pytest.raises(RuntimeError, match="reader='pynvvc'"):
+                build_video_reader(
+                    'pynvvc', '/fake/video.mp4', 'base', dali_config,
+                    ['/fake/video.mp4'], [64, 64], None,
+                )
+
+    def test_explicit_pynvvc_succeeds_when_available(self, dali_config):
+        mock_prep = MagicMock()
+        with (
+            patch('lightning_pose.data.video.pynvvc.is_pynvvc_available', return_value=True),
+            patch('lightning_pose.data.video.pynvvc.PreparePynvvc', mock_prep),
+        ):
+            build_video_reader(
+                'pynvvc', '/fake/video.mp4', 'base', dali_config,
+                ['/fake/video.mp4'], [64, 64], None,
+            )
+        assert mock_prep.called
+
+    def test_explicit_opencv_raises_when_unusable(self, dali_config):
+        with patch('lightning_pose.data.video.opencv.is_opencv_available', return_value=False):
+            with pytest.raises(RuntimeError, match="reader='opencv'"):
+                build_video_reader(
+                    'opencv', '/fake/video.mp4', 'base', dali_config,
+                    ['/fake/video.mp4'], [64, 64], None,
+                )
+
+    def test_explicit_opencv_succeeds_when_usable(self, dali_config):
+        mock_prep = MagicMock()
+        with (
+            patch('lightning_pose.data.video.opencv.is_opencv_available', return_value=True),
+            patch('lightning_pose.data.video.opencv.PrepareOpenCV', mock_prep),
+        ):
+            build_video_reader(
+                'opencv', '/fake/video.mp4', 'base', dali_config,
+                ['/fake/video.mp4'], [64, 64], None,
+            )
+        assert mock_prep.called
+
+    # -- construction args forwarded unchanged --
+
+    def test_forwards_construction_args(self, dali_config):
+        bbox_df = pd.DataFrame({'x': [0], 'y': [0], 'h': [10], 'w': [10]})
+        mock_prep = MagicMock()
+        with (
+            patch('lightning_pose.data.video.opencv.is_opencv_available', return_value=True),
+            patch('lightning_pose.data.video.opencv.PrepareOpenCV', mock_prep),
+        ):
+            build_video_reader(
+                'opencv', '/fake/video.mp4', 'context', dali_config,
+                ['/fake/video.mp4'], [128, 128], bbox_df,
+            )
+        call_kwargs = mock_prep.call_args.kwargs
+        assert call_kwargs['model_type'] == 'context'
+        assert call_kwargs['dali_config'] is dali_config
+        assert call_kwargs['filenames'] == ['/fake/video.mp4']
+        assert call_kwargs['resize_dims'] == [128, 128]
+        assert call_kwargs['bbox_df'] is bbox_df

--- a/tests/data/video/test_opencv.py
+++ b/tests/data/video/test_opencv.py
@@ -1,0 +1,516 @@
+"""Test opencv dataloading functionality."""
+import os
+import shutil
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+import lightning_pose as lp
+from lightning_pose.data import _IMAGENET_MEAN, _IMAGENET_STD
+from lightning_pose.data.video import opencv as opencv_module
+from lightning_pose.data.video.opencv import (
+    LitOpenCVWrapper,
+    PrepareOpenCV,
+    is_opencv_available,
+)
+
+# real toy video used by the real-decode tests below -- opencv-python-headless is an
+# unconditional dependency (see module docstring), so unlike pynvvc's requires_pynvvc
+# gate, no skip marker is needed: these run on every CI runner, CPU included.
+_TOY_VIDEO = str(lp.LP_ROOT_PATH / "data" / "mirror-mouse-example" / "videos" / "test_vid.mp4")
+
+
+class TestIsOpenCVAvailable:
+    """Test the is_opencv_available function."""
+
+    def test_returns_true_for_real_video(self):
+        assert is_opencv_available(_TOY_VIDEO) is True
+
+    def test_returns_false_for_nonexistent_file(self):
+        assert is_opencv_available('/does/not/exist.mp4') is False
+
+    def test_returns_false_for_non_video_file(self, tmp_path):
+        bad_file = tmp_path / 'not_a_video.mp4'
+        bad_file.write_text('this is not video data')
+        assert is_opencv_available(str(bad_file)) is False
+
+
+class TestPrepareOpenCV:
+    """Test the PrepareOpenCV class."""
+
+    def test_single_view_raises_on_nonexistent_file(self, cfg, video_list):
+        with pytest.raises(FileNotFoundError):
+            PrepareOpenCV(
+                model_type='base',
+                filenames=[video_list[0] + '_bad-id.mp4'],
+                resize_dims=[256, 256],
+                dali_config=cfg.dali,
+            )
+
+    def test_single_view_raises_when_path_is_directory(self, cfg, video_list):
+        with pytest.raises(FileNotFoundError):
+            PrepareOpenCV(
+                model_type='base',
+                filenames=[os.path.dirname(video_list[0])],
+                resize_dims=[256, 256],
+                dali_config=cfg.dali,
+            )
+
+    def test_raises_on_more_than_one_video_per_view(self, cfg, video_list):
+        """opencv has no multi-session-batching concept, same as pynvvc."""
+        vid = video_list[0]
+        with pytest.raises(NotImplementedError, match='exactly one video per view'):
+            PrepareOpenCV(
+                model_type='base',
+                filenames=[[vid, vid]],
+                resize_dims=[256, 256],
+                dali_config=cfg.dali,
+            )
+
+    def test_multiview_raises_on_unequal_frame_counts(
+        self, cfg_multiview, video_list, tmp_path, monkeypatch,
+    ):
+        vid = video_list[0]
+        vid_copy = str(tmp_path / 'view1.mp4')
+        shutil.copy(vid, vid_copy)
+        monkeypatch.setattr(
+            opencv_module, 'count_frames', lambda p: {vid: 100, vid_copy: 90}[p],
+        )
+        with pytest.raises(ValueError, match='frame counts across views'):
+            PrepareOpenCV(
+                model_type='base',
+                filenames=[[vid], [vid_copy]],
+                resize_dims=[256, 256],
+                dali_config=cfg_multiview.dali,
+            )
+
+    def test_unknown_model_type_raises(self, cfg, video_list):
+        with pytest.raises(ValueError, match='unknown model_type'):
+            PrepareOpenCV(
+                model_type='bogus',  # type: ignore[arg-type]
+                filenames=video_list,
+                resize_dims=[256, 256],
+                dali_config=cfg.dali,
+            )
+
+    def test_num_iters_base(self, cfg, video_list, monkeypatch):
+        monkeypatch.setattr(opencv_module, 'count_frames', lambda p: 100)
+        cfg.dali.base.predict.sequence_length = 16
+        prep = PrepareOpenCV(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        assert prep.num_iters == 7  # ceil(100 / 16) = 7
+
+    def test_num_iters_context(self, cfg, video_list, monkeypatch):
+        monkeypatch.setattr(opencv_module, 'count_frames', lambda p: 100)
+        cfg.dali.context.predict.sequence_length = 9
+        prep = PrepareOpenCV(
+            model_type='context',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        # step = 9 - 4 = 5; ceil((100 - 9) / 5) + 1 = ceil(91 / 5) + 1 = 19 + 1 = 20
+        assert prep.num_iters == 20
+
+    def test_context_num_iters_raises_on_invalid_step(self, cfg, video_list, monkeypatch):
+        monkeypatch.setattr(opencv_module, 'count_frames', lambda p: 100)
+        cfg.dali.context.predict.sequence_length = 4  # step = 4 - 4 = 0
+        prep = PrepareOpenCV(
+            model_type='context',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        with pytest.raises(ValueError, match='step cannot be 0'):
+            _ = prep.num_iters
+
+    def test_bbox_df_sets_decode_resize_dims_none(self, cfg, video_list):
+        bbox_df = pd.DataFrame({'x': [0], 'y': [0], 'h': [10], 'w': [10]})
+        prep = PrepareOpenCV(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+            bbox_df=bbox_df,
+        )
+        assert prep._decode_resize_dims is None
+
+    def test_no_bbox_df_sets_decode_resize_dims_to_resize_dims(self, cfg, video_list):
+        prep = PrepareOpenCV(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        assert prep._decode_resize_dims == [256, 256]
+
+    def test_call_builds_wrapper_with_correct_params(self, cfg, video_list, monkeypatch):
+        """Integration check: PrepareOpenCV() actually produces a correctly-configured
+        LitOpenCVWrapper. Unlike pynvvc/dali, no mocking is needed here -- cv2.VideoCapture
+        against the real toy video is cheap and requires no proprietary package/hardware."""
+        prep = PrepareOpenCV(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[256, 256],
+            dali_config=cfg.dali,
+        )
+        wrapper = prep()
+        assert isinstance(wrapper, LitOpenCVWrapper)
+        assert wrapper.resize_dims == [256, 256]
+        assert wrapper.sequence_length == prep.sequence_length
+        assert wrapper.multiview is False
+        assert wrapper.num_iters == prep.num_iters
+
+
+class _FakeCapture:
+    """Minimal fake matching the cv2.VideoCapture.read() interface used by
+    LitOpenCVWrapper -- lets tests exercise the ring-buffer/padding logic without
+    depending on the real toy video's specific frame count or content."""
+
+    def __init__(self, frames: list[np.ndarray]) -> None:
+        self.frames = frames
+        self._idx = 0
+
+    def read(self) -> tuple[bool, np.ndarray | None]:
+        if self._idx >= len(self.frames):
+            return False, None
+        frame = self.frames[self._idx]
+        self._idx += 1
+        return True, frame
+
+
+def _make_fake_frames(n: int, h: int = 20, w: int = 24) -> list[np.ndarray]:
+    """HWC BGR uint8 frames, each filled with a distinct value so identity (not just
+    shape) can be checked -- e.g. that overlap frames across windows really are the
+    same physical frame, not just the same shape."""
+    return [np.full((h, w, 3), fill_value=i, dtype=np.uint8) for i in range(n)]
+
+
+class TestLitOpenCVWrapper:
+    """Test the LitOpenCVWrapper class.
+
+    All tests bypass __init__ (which needs real cv2.VideoCapture handles) via
+    object.__new__, same discipline as test_pynvvc.py's TestLitPynvvcWrapper --
+    swapping in _FakeCapture instances for self._caps.
+    """
+
+    @pytest.fixture
+    def bbox_df(self):
+        """Sample bbox DataFrame with 10 rows (same values as test_dali.py's fixture)."""
+        return pd.DataFrame({
+            'x': [10] * 10,
+            'y': [20] * 10,
+            'h': [50] * 10,
+            'w': [60] * 10,
+        })
+
+    def _make_wrapper(
+        self,
+        total_frames: int,
+        resize_dims: list[int] | None = None,
+        decode_resize_dims: list[int] | None = None,
+        sequence_length: int = 4,
+        do_context: bool = False,
+        multiview: bool = False,
+        bbox_df: pd.DataFrame | None = None,
+        frame_idx: int = 0,
+        num_views: int = 1,
+        frame_h: int = 100,
+        frame_w: int = 120,
+    ) -> LitOpenCVWrapper:
+        """Create a LitOpenCVWrapper without real cv2.VideoCapture handles."""
+        wrapper = object.__new__(LitOpenCVWrapper)
+        wrapper._caps = [  # type: ignore[assignment]
+            _FakeCapture(_make_fake_frames(total_frames, frame_h, frame_w))
+            for _ in range(num_views)
+        ]
+        wrapper._tail = [[] for _ in range(num_views)]
+        # resize_dims is always a concrete list on the real class (unlike
+        # decode_resize_dims, which is the actually-optional one) -- default to a
+        # harmless placeholder when a test doesn't care about its value.
+        wrapper.resize_dims = resize_dims if resize_dims is not None else [64, 64]
+        wrapper.decode_resize_dims = decode_resize_dims
+        wrapper.sequence_length = sequence_length
+        wrapper.step = sequence_length - 4 if do_context else sequence_length
+        wrapper.do_context = do_context
+        wrapper.num_iters = 1000  # overridden per-test where StopIteration timing matters
+        wrapper.multiview = multiview
+        wrapper.bbox_df = bbox_df
+        wrapper._iters_done = 0
+        wrapper._frame_idx = frame_idx
+        return wrapper
+
+    # -- _next_window --
+
+    def test_next_window_full_batch_no_padding(self):
+        wrapper = self._make_wrapper(total_frames=10, sequence_length=4)
+        window = wrapper._next_window(0)
+        assert window.shape == (4, 3, 100, 120)
+
+    def test_next_window_pads_last_partial_batch(self):
+        wrapper = self._make_wrapper(total_frames=6, sequence_length=4)
+        wrapper._next_window(0)  # consume frames 0-3
+        window = wrapper._next_window(0)  # only frames 4, 5 remain; need 2 padding frames
+        assert window.shape == (4, 3, 100, 120)
+        assert torch.equal(window[1], window[2])
+        assert torch.equal(window[2], window[3])
+        assert not torch.equal(window[0], window[1])
+
+    def test_next_window_fully_out_of_bounds_raises(self):
+        """Unlike pynvvc (which can re-fetch the last frame by index), opencv can't
+        seek backward once the capture is exhausted -- an empty window (tail empty,
+        capture exhausted) is a real invariant violation, not a case to pad through."""
+        wrapper = self._make_wrapper(total_frames=0, sequence_length=4)
+        with pytest.raises(RuntimeError, match='exhausted view 0'):
+            wrapper._next_window(0)
+
+    def test_next_window_context_caches_tail(self):
+        wrapper = self._make_wrapper(total_frames=20, sequence_length=5, do_context=True)
+        wrapper._next_window(0)
+        assert len(wrapper._tail[0]) == 4
+
+    def test_next_window_context_overlap_matches_previous_tail(self):
+        """The core correctness property of the ring-buffer design: window i's last 4
+        frames are byte-identical to window i+1's first 4 frames."""
+        wrapper = self._make_wrapper(total_frames=20, sequence_length=5, do_context=True)
+        w1 = wrapper._next_window(0)
+        w2 = wrapper._next_window(0)
+        assert torch.equal(w1[-4:], w2[:4])
+
+    def test_next_window_base_model_has_no_overlap(self):
+        wrapper = self._make_wrapper(total_frames=20, sequence_length=4, do_context=False)
+        w1 = wrapper._next_window(0)
+        w2 = wrapper._next_window(0)
+        assert not torch.equal(w1[-1], w2[0])
+        assert wrapper._tail[0] == []
+
+    def test_next_window_converts_bgr_to_rgb(self):
+        """frames are stored BGR (channel order [B, G, R] with distinct per-channel
+        values); _next_window must return RGB ([R, G, B])."""
+        wrapper = object.__new__(LitOpenCVWrapper)
+        bgr_frame = np.zeros((4, 4, 3), dtype=np.uint8)
+        bgr_frame[..., 0] = 10   # B
+        bgr_frame[..., 1] = 20   # G
+        bgr_frame[..., 2] = 30   # R
+        wrapper._caps = [_FakeCapture([bgr_frame])]  # type: ignore[assignment]
+        wrapper._tail = [[]]
+        wrapper.sequence_length = 1
+        wrapper.do_context = False
+
+        window = wrapper._next_window(0)  # (1, C, H, W)
+        assert window[0, 0].unique().item() == 30  # R channel first
+        assert window[0, 1].unique().item() == 20  # G channel second
+        assert window[0, 2].unique().item() == 10  # B channel last
+
+    # -- _resize_normalize --
+
+    def test_resize_normalize_no_resize_when_decode_resize_dims_none(self):
+        wrapper = self._make_wrapper(total_frames=5, decode_resize_dims=None)
+        frames = torch.randint(0, 256, (4, 3, 50, 60), dtype=torch.uint8).float()
+        out = wrapper._resize_normalize(frames)
+        assert out.shape == (4, 3, 50, 60)
+
+    def test_resize_normalize_resizes_when_decode_resize_dims_set(self):
+        wrapper = self._make_wrapper(total_frames=5, decode_resize_dims=[32, 32])
+        frames = torch.rand(4, 3, 50, 60) * 255
+        out = wrapper._resize_normalize(frames)
+        assert out.shape == (4, 3, 32, 32)
+
+    def test_resize_normalize_applies_imagenet_normalization(self):
+        """Exact-value check against the same formula/order of operations the method
+        itself uses, so this fails if the scale-then-normalize order ever changes."""
+        wrapper = self._make_wrapper(total_frames=5, decode_resize_dims=None)
+        frames = torch.full((1, 3, 4, 4), 127.5)
+        out = wrapper._resize_normalize(frames)
+        mean = torch.tensor(_IMAGENET_MEAN).view(1, 3, 1, 1)
+        std = torch.tensor(_IMAGENET_STD).view(1, 3, 1, 1)
+        expected = (127.5 / 255.0 - mean) / std
+        assert torch.allclose(out, expected.expand_as(out), atol=1e-5)
+
+    # -- __next__ --
+
+    def test_next_output_frames_shape_no_bbox(self):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, decode_resize_dims=[64, 64],
+        )
+        wrapper.num_iters = 1
+        batch = next(wrapper)
+        assert batch['frames'].shape == (4, 3, 64, 64)
+        assert batch['is_multiview'] is False
+        assert batch['bbox'].shape == (4, 4)
+
+    def test_next_bbox_crop_output_shape(self, bbox_df):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, resize_dims=[64, 64],
+            decode_resize_dims=None, bbox_df=bbox_df,
+        )
+        wrapper.num_iters = 1
+        batch = next(wrapper)
+        assert batch['frames'].shape == (4, 3, 64, 64)
+        assert batch['is_multiview'] is False
+
+    def test_next_advances_frame_idx_base(self, bbox_df):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, resize_dims=[64, 64],
+            decode_resize_dims=None, bbox_df=bbox_df, do_context=False,
+        )
+        wrapper.num_iters = 1
+        next(wrapper)
+        assert wrapper._frame_idx == 4
+
+    def test_next_advances_frame_idx_context(self, bbox_df):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=5, resize_dims=[64, 64],
+            decode_resize_dims=None, bbox_df=bbox_df, do_context=True,
+        )
+        wrapper.num_iters = 1
+        next(wrapper)
+        assert wrapper._frame_idx == 1  # step = seq_len - 4 = 1
+
+    def test_next_pads_bbox_rows_on_last_batch(self):
+        """Mirrors test_pynvvc.py's equivalent -- same padding logic, ported here."""
+        two_row_df = pd.DataFrame({
+            'x': [10, 20], 'y': [10, 20], 'h': [50, 60], 'w': [50, 60],
+        })
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, resize_dims=[64, 64],
+            decode_resize_dims=None, bbox_df=two_row_df, frame_idx=1,
+        )
+        wrapper.num_iters = 1
+        batch = next(wrapper)
+        assert batch['bbox'].shape == (4, 4)
+        expected_last = torch.tensor([20, 20, 60, 60], dtype=torch.float32)
+        for i in range(4):
+            assert torch.allclose(batch['bbox'][i], expected_last)
+
+    def test_next_stops_iteration_after_num_iters(self):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, decode_resize_dims=[32, 32],
+        )
+        wrapper.num_iters = 2
+        next(wrapper)
+        next(wrapper)
+        with pytest.raises(StopIteration):
+            next(wrapper)
+
+    def test_next_multiview_output_shape(self):
+        wrapper = self._make_wrapper(
+            total_frames=20, sequence_length=4, decode_resize_dims=[64, 64],
+            multiview=True, num_views=2,
+        )
+        wrapper.num_iters = 1
+        batch = next(wrapper)
+        assert batch['frames'].shape == (4, 2, 3, 64, 64)
+        assert batch['is_multiview'] is True
+        assert batch['bbox'].shape == (4, 2 * 4)
+        assert batch['transforms'].shape == (2, 1, 1)
+
+
+class TestOpenCVRealDecode:
+    """Real, unmocked cv2.VideoCapture decode tests against the real toy video.
+
+    Unlike pynvvc's TestPynvvcRealDecoder, none of this needs @pytest.mark.gpu --
+    opencv decode needs no GPU, so these run on the CPU CI workflow directly.
+    """
+
+    def test_single_view_base_real_decode(self, cfg, video_list):
+        """Base model predict loader yields correctly-shaped, finite batches from a real
+        decoder, exercising every batch including the padded final one."""
+        im_height, im_width = 64, 64
+        prep = PrepareOpenCV(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[im_height, im_width],
+            dali_config=cfg.dali,
+        )
+        loader = prep()
+        num_iters = prep.num_iters
+
+        batch_idx = -1
+        for batch in loader:
+            assert batch['frames'].shape == (
+                cfg.dali.base.predict.sequence_length, 3, im_height, im_width,
+            )
+            assert torch.isfinite(batch['frames']).all()
+            batch_idx += 1
+        assert batch_idx == num_iters - 1
+
+    def test_single_view_context_real_decode(self, cfg, video_list):
+        """Context model predict loader handles the overlapping-window step correctly
+        against a real decoder -- the trickiest path in this module, previously only
+        covered by mocks and the Part 3 scratch verification."""
+        im_height, im_width = 64, 64
+        prep = PrepareOpenCV(
+            model_type='context',
+            filenames=video_list,
+            resize_dims=[im_height, im_width],
+            dali_config=cfg.dali,
+        )
+        loader = prep()
+        num_iters = prep.num_iters
+
+        batch_idx = -1
+        for batch in loader:
+            assert batch['frames'].shape == (
+                cfg.dali.context.predict.sequence_length, 3, im_height, im_width,
+            )
+            batch_idx += 1
+        assert batch_idx == num_iters - 1
+
+    @pytest.mark.gpu
+    def test_matches_dali_decode(self, cfg, video_list):
+        """opencv's decode + resize + normalize output roughly matches DALI's on the
+        same real video -- catches a wrong color order, a wrong normalization
+        order/scale, or an off-by-one in the frame window that a shape-only check
+        would miss. GPU-marked because the DALI side of the comparison needs one, not
+        because opencv does.
+
+        See test_pynvvc.py's test_matches_dali_decode for why this asserts on the
+        mean deviation (loosely bounding the max as a backstop) rather than a strict
+        max-deviation threshold: two independent decode/resize paths legitimately
+        disagree at hard edges.
+        """
+        pytest.importorskip('nvidia.dali', reason='nvidia-dali not installed')
+        from lightning_pose.data.video.dali import PrepareDALI
+
+        im_height, im_width = 256, 256
+
+        opencv_prep = PrepareOpenCV(
+            model_type='base',
+            filenames=video_list,
+            resize_dims=[im_height, im_width],
+            dali_config=cfg.dali,
+        )
+        opencv_batch = next(iter(opencv_prep()))
+
+        dali_prep = PrepareDALI(
+            train_stage='predict',
+            model_type='base',
+            filenames=video_list,
+            dali_config=cfg.dali,
+            resize_dims=[im_height, im_width],
+        )
+        dali_batch = next(iter(dali_prep()))
+
+        opencv_frames = opencv_batch['frames'].cpu()
+        dali_frames = dali_batch['frames'].cpu()
+        assert opencv_frames.shape == dali_frames.shape
+        deviation = (opencv_frames - dali_frames).abs()
+        mean_deviation = deviation.mean().item()
+        assert mean_deviation < 0.05, (
+            f"opencv decode deviates from DALI decode by a mean of {mean_deviation:.4f} "
+            "(normalized units) -- check BGR->RGB color order and resize/normalize order "
+            "in LitOpenCVWrapper._resize_normalize"
+        )
+        max_deviation = deviation.max().item()
+        assert max_deviation < 3.0, (
+            f"opencv decode deviates from DALI decode by up to {max_deviation:.4f} "
+            "(normalized units) even after allowing for per-pixel edge disagreement -- "
+            "this is large enough to suggest a real decode bug, not resize-kernel noise"
+        )

--- a/tests/data/video/test_pynvvc.py
+++ b/tests/data/video/test_pynvvc.py
@@ -10,8 +10,8 @@ import torch
 
 import lightning_pose as lp
 from lightning_pose.data import _IMAGENET_MEAN, _IMAGENET_STD
-from lightning_pose.data import pynvvc as pynvvc_module
-from lightning_pose.data.pynvvc import LitPynvvcWrapper, PreparePynvvc, is_pynvvc_available
+from lightning_pose.data.video import pynvvc as pynvvc_module
+from lightning_pose.data.video.pynvvc import LitPynvvcWrapper, PreparePynvvc, is_pynvvc_available
 
 # real toy video used to gate the real-decoder tests below -- a plain `import
 # PyNvVideoCodec` succeeds regardless of GPU generation/driver age (see
@@ -561,7 +561,7 @@ class TestPynvvcRealDecoder:
         loosely, as a backstop against a real broken decode rather than a precision claim.
         """
         pytest.importorskip('nvidia.dali', reason='nvidia-dali not installed')
-        from lightning_pose.data.dali import PrepareDALI
+        from lightning_pose.data.video.dali import PrepareDALI
 
         im_height, im_width = 256, 256
 

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -119,7 +119,7 @@ class TestPredictVideoBboxFile:
 
         with (
             patch('lightning_pose.utils.predictions.count_frames', return_value=3),
-            patch('lightning_pose.data.dali.PrepareDALI', mock_dali),
+            patch('lightning_pose.data.video.dali.PrepareDALI', mock_dali),
             patch('lightning_pose.utils.predictions.pl.Trainer'),
             patch('lightning_pose.utils.predictions.PredictionHandler'),
         ):
@@ -140,7 +140,7 @@ class TestPredictVideoBboxFile:
         mock_dali = MagicMock()
 
         with (
-            patch('lightning_pose.data.dali.PrepareDALI', mock_dali),
+            patch('lightning_pose.data.video.dali.PrepareDALI', mock_dali),
             patch('lightning_pose.utils.predictions.pl.Trainer'),
             patch('lightning_pose.utils.predictions.PredictionHandler'),
         ):


### PR DESCRIPTION
# Add OpenCV video reader for portable, GPU-free prediction

## Summary

- Adds `opencv` as a third `--reader` backend for `litpose predict`/`Model.predict_on_video_file`, alongside DALI and PyNvVideoCodec. Decodes on CPU via `cv2.VideoCapture` — already an unconditional, cross-platform dependency — so it works on macOS, Windows, and non-NVIDIA/GPU-less machines, where the other two readers can't even be imported (`nvidia-dali-cuda110` is platform-gated to Linux x86_64; PyNvVideoCodec is Linux x86_64 + supported NVIDIA GPU/driver only).
- Reorganizes the existing two readers into a `lightning_pose/data/video/` subpackage with a documented contract for what a "video reader backend" must implement, so a future fourth backend doesn't require reverse-engineering the pattern.
- Extracts reader selection/construction out of `predict_video` into `data/video/factory.py::build_video_reader`, and fixes the auto-select fallback chain, which previously assumed DALI was always installed whenever PyNvVideoCodec wasn't usable — false on any platform without `nvidia-dali-cuda110`.

## Details

### Reorg → `lightning_pose/data/video/`

- `data/dali.py` → `data/video/dali.py`, `data/pynvvc.py` → `data/video/pynvvc.py`; all call sites and tests updated.
- `data/video/__init__.py` documents the package map. `data/video/factory.py` documents the reader contract and the "adding a new backend" recipe: two-phase `Prepare<Name>`/`Lit<Name>Wrapper` construction, an optional `is_<name>_available` probe, and when a backend needs lazy vs. eager imports.

### New backend: `data/video/opencv.py`

- `PrepareOpenCV`/`LitOpenCVWrapper`, mirroring `PreparePynvvc`/`LitPynvvcWrapper`, with one deliberate difference: sequential decode with a 4-frame ring buffer instead of indexed/seek-based reads. `cv2.VideoCapture`'s `CAP_PROP_POS_FRAMES` seeking isn't reliably frame-exact on VFR/B-frame containers, and context models need their overlapping windows' shared frames to be exactly identical — a seek-per-window implementation risks silently misaligning that overlap.
- `is_opencv_available()` for a clear error when `--reader opencv` is requested against an unreadable file.

### Reader selection: `data/video/factory.py::build_video_reader`

- Auto-select chain is now `pynvvc → dali (if installed) → opencv (unconditional)`.
- Explicit `--reader` requests are validated per backend and raise a clear `RuntimeError` instead of a deep traceback when unusable — now symmetric across all three (dali's own import failure is handled the same way as pynvvc/opencv's hardware/file checks).

### Docs

- `--reader` CLI help, `Model.predict_on_video_file(_multiview)` docstrings, and the inference-speed user guide updated for the 3-way choice and fallback chain.
- `docs/modules/lightning_pose.data.rst` gains `automodapi` entries for `video.dali`, `video.factory`, `video.opencv`, and `video.pynvvc` (the last was previously missing from docs — confirmed it imports cleanly without the proprietary `PyNvVideoCodec` package installed).
- Fixed a misleading `filenames` docstring on `PreparePynvvc`/`PrepareOpenCV.__init__` (claimed a bare string was accepted for single-view; it isn't).

## Test plan

- `tests/data/video/test_opencv.py` (33 tests): availability probe, constructor validation, `num_iters` arithmetic, ring-buffer/padding/context-overlap logic via a fake capture, BGR→RGB pixel-level conversion, and real-decode integration against the toy video for base and context models — plus a GPU-marked cross-check against DALI's decode output (mean/max deviation within tolerance).
- `tests/data/video/test_factory.py` (10 tests): all three auto-select fallback legs and explicit-reader validation/construction for all three backends, mocked at the boundary — no `Model`/`Trainer` needed.
- `pytest -m "not gpu"` passes on the full suite; GPU-marked tests (including the opencv-vs-DALI comparison) verified passing on real hardware.