### PR TITLE
fix bbox bug in pynvvc/opencv readers

### DIFF
--- a/lightning_pose/data/video/opencv.py
+++ b/lightning_pose/data/video/opencv.py
@@ -225,7 +225,11 @@ class LitOpenCVWrapper:
 
         if not self.multiview:
             frames = processed[0]
-            height, width = frames.shape[-2], frames.shape[-1]
+            # bbox reflects the true, pre-resize decoded frame size (not
+            # decode_resize_dims), so norm_to_frame correctly rescales model-space
+            # predictions back into the original video's pixel coordinates -- mirrors
+            # DALI's separate "frame_size" output, which is captured before fn.resize.
+            height, width = per_view_frames[0].shape[-2], per_view_frames[0].shape[-1]
 
             if self.bbox_df is not None:
                 assert self.resize_dims is not None  # required whenever bbox_df is set
@@ -258,12 +262,17 @@ class LitOpenCVWrapper:
 
         else:
             frames = torch.stack(processed, dim=1)  # (seq_len, num_views, C, H, W)
-            height, width = frames.shape[-2], frames.shape[-1]
             num_views = len(self._caps)
-            bbox_per_view = torch.tensor(
-                [0, 0, height, width], device=frames.device, dtype=torch.float32,
-            )
-            bbox = bbox_per_view.repeat(num_views).unsqueeze(0).repeat(frames.shape[0], 1)
+            # per-view pre-resize decoded frame size -- see single-view branch above
+            # for why this must come from per_view_frames, not the resized `frames`.
+            bbox_per_view = torch.cat([
+                torch.tensor(
+                    [0, 0, pv.shape[-2], pv.shape[-1]],
+                    device=frames.device, dtype=torch.float32,
+                )
+                for pv in per_view_frames
+            ])
+            bbox = bbox_per_view.unsqueeze(0).repeat(frames.shape[0], 1)
             transforms = torch.tensor([-1.0]).repeat(num_views, 1, 1)
             return MultiviewUnlabeledBatchDict(
                 frames=frames,

--- a/lightning_pose/data/video/pynvvc.py
+++ b/lightning_pose/data/video/pynvvc.py
@@ -289,7 +289,11 @@ class LitPynvvcWrapper:
 
         if not self.multiview:
             frames = processed[0]
-            height, width = frames.shape[-2], frames.shape[-1]
+            # bbox reflects the true, pre-resize decoded frame size (not
+            # decode_resize_dims), so norm_to_frame correctly rescales model-space
+            # predictions back into the original video's pixel coordinates -- mirrors
+            # DALI's separate "frame_size" output, which is captured before fn.resize.
+            height, width = per_view_frames[0].shape[-2], per_view_frames[0].shape[-1]
 
             if self.bbox_df is not None:
                 assert self.resize_dims is not None  # required whenever bbox_df is set
@@ -322,12 +326,17 @@ class LitPynvvcWrapper:
 
         else:
             frames = torch.stack(processed, dim=1)  # (seq_len, num_views, C, H, W)
-            height, width = frames.shape[-2], frames.shape[-1]
             num_views = len(self._decoders)
-            bbox_per_view = torch.tensor(
-                [0, 0, height, width], device=frames.device, dtype=torch.float32,
-            )
-            bbox = bbox_per_view.repeat(num_views).unsqueeze(0).repeat(frames.shape[0], 1)
+            # per-view pre-resize decoded frame size -- see single-view branch above
+            # for why this must come from per_view_frames, not the resized `frames`.
+            bbox_per_view = torch.cat([
+                torch.tensor(
+                    [0, 0, pv.shape[-2], pv.shape[-1]],
+                    device=frames.device, dtype=torch.float32,
+                )
+                for pv in per_view_frames
+            ])
+            bbox = bbox_per_view.unsqueeze(0).repeat(frames.shape[0], 1)
             transforms = torch.tensor([-1.0]).repeat(num_views, 1, 1)
             return MultiviewUnlabeledBatchDict(
                 frames=frames,

--- a/tests/data/video/test_opencv.py
+++ b/tests/data/video/test_opencv.py
@@ -344,6 +344,14 @@ class TestLitOpenCVWrapper:
         assert batch['frames'].shape == (4, 3, 64, 64)
         assert batch['is_multiview'] is False
         assert batch['bbox'].shape == (4, 4)
+        # bbox must carry the raw pre-resize decoded frame size (frame_h=100,
+        # frame_w=120 from _make_wrapper's default), not decode_resize_dims -- else
+        # model_to_frame_batch's norm_to_frame rescale becomes a no-op and predictions
+        # never get mapped out of resized-image pixel space back into the original
+        # video's coordinates.
+        expected_bbox = torch.tensor([0, 0, 100, 120], dtype=torch.float32)
+        for i in range(4):
+            assert torch.allclose(batch['bbox'][i], expected_bbox)
 
     def test_next_bbox_crop_output_shape(self, bbox_df):
         wrapper = self._make_wrapper(
@@ -410,6 +418,10 @@ class TestLitOpenCVWrapper:
         assert batch['is_multiview'] is True
         assert batch['bbox'].shape == (4, 2 * 4)
         assert batch['transforms'].shape == (2, 1, 1)
+        # same raw-vs-resized distinction as the single-view case above, repeated per view
+        expected_bbox = torch.tensor([0, 0, 100, 120, 0, 0, 100, 120], dtype=torch.float32)
+        for i in range(4):
+            assert torch.allclose(batch['bbox'][i], expected_bbox)
 
 
 class TestOpenCVRealDecode:

--- a/tests/data/video/test_pynvvc.py
+++ b/tests/data/video/test_pynvvc.py
@@ -419,6 +419,14 @@ class TestLitPynvvcWrapper:
         assert batch['frames'].shape == (4, 3, 64, 64)
         assert batch['is_multiview'] is False
         assert batch['bbox'].shape == (4, 4)
+        # bbox must carry the raw pre-resize decoded frame size (frame_h=100,
+        # frame_w=120 from _make_wrapper's default), not decode_resize_dims -- else
+        # model_to_frame_batch's norm_to_frame rescale becomes a no-op and predictions
+        # never get mapped out of resized-image pixel space back into the original
+        # video's coordinates.
+        expected_bbox = torch.tensor([0, 0, 100, 120], dtype=torch.float32)
+        for i in range(4):
+            assert torch.allclose(batch['bbox'][i], expected_bbox)
 
     def test_next_bbox_crop_output_shape(self, bbox_df):
         wrapper = self._make_wrapper(
@@ -492,6 +500,10 @@ class TestLitPynvvcWrapper:
         assert batch['is_multiview'] is True
         assert batch['bbox'].shape == (4, 2 * 4)
         assert batch['transforms'].shape == (2, 1, 1)
+        # same raw-vs-resized distinction as the single-view case above, repeated per view
+        expected_bbox = torch.tensor([0, 0, 100, 120, 0, 0, 100, 120], dtype=torch.float32)
+        for i in range(4):
+            assert torch.allclose(batch['bbox'][i], expected_bbox)
 
     def test_next_calls_cuda_stream_synchronize(self):
         """Regression guard for the documented 'safe but not optimal' CUDA sync fix


### PR DESCRIPTION
## Root cause
  
  In `lightning_pose/data/video/pynvvc.py` and `lightning_pose/data/video/opencv.py`, the non-bbox-crop
  branch of `__next__` computed the bbox field (used to map model predictions back to original video
  pixel coordinates) from the already-resized frame tensor:

```
  frames = processed[0]          # post _resize_normalize, i.e. resized to model input dims
  height, width = frames.shape[-2], frames.shape[-1]
  ...
  bbox = torch.tensor([0, 0, height, width], ...)
```

  Since `decode_resize_dims == resize_dims` (the model's input size) whenever no bbox_df is supplied,
  height/width ended up equal to the model input size rather than the true video frame size.
  Downstream, model_to_frame_batch (`lightning_pose/data/bboxes.py`) normalizes predictions by the
  model's dims and then rescales by bbox's height/width to land in frame-pixel space — with bbox
  wrongly equal to the model dims, that rescale is a no-op, so predictions stayed in resized-image
  pixel coordinates instead of being mapped back to the original video resolution. This affects any
  video whose native resolution differs from resize_dims (essentially all real usage).

  DALI never had this bug because it captures a separate frame_size output before its `fn.resize` op
  runs.

##  Fix

  Both readers now capture height/width from the raw decoded frame (per_view_frames, pre-resize)
  instead of the resized tensor, for both single-view and multiview branches — matching DALI's
  approach.
  
##  Verification

  Added regression assertions to `tests/data/video/test_pynvvc.py` and `tests/data/video/test_opencv.py`
  checking bbox equals the raw decoded frame size (100×120) rather than `decode_resize_dims` (64×64).
  Confirmed via git stash that these new assertions fail against the old code and pass against the fix.
  Full `tests/data/video/` suite (87 tests, non-GPU) passes.