### PR TITLE
make sleap converter more robust

### DIFF
--- a/lightning_pose/converters/sleap.py
+++ b/lightning_pose/converters/sleap.py
@@ -19,6 +19,19 @@ from PIL import Image
 logger = logging.getLogger(__name__)
 
 
+def _decode_json_attr(raw: bytes | str) -> dict:
+    """Decode an h5py ``json`` attribute, which may come back as ``str`` or ``bytes``.
+
+    h5py returns ``numpy.bytes_`` for fixed-length HDF5 string attributes and native ``str``
+    for variable-length UTF-8 ones, depending on how the writer encoded them. Calling ``str()``
+    on the former yields its Python repr (e.g. ``"b'{...}'"``), not the decoded text, so bytes
+    must be decoded explicitly rather than passed through ``str()``.
+    """
+    if isinstance(raw, bytes):
+        return json.loads(raw.decode('utf-8'))
+    return json.loads(str(raw))
+
+
 def _extract_video_names(pkg_slp_file: Path) -> dict[str, str]:
     """Map each ``video<N>`` group in a ``.pkg.slp`` file to its source video filename."""
     video_names = {}
@@ -28,7 +41,7 @@ def _extract_video_names(pkg_slp_file: Path) -> dict[str, str]:
                 source_video_path = f'{video_group_name}/source_video'
                 if source_video_path in hdf_file:
                     source_video_ds = cast(h5py.Dataset, hdf_file[source_video_path])
-                    source_video_dict = json.loads(str(source_video_ds.attrs['json']))
+                    source_video_dict = _decode_json_attr(source_video_ds.attrs['json'])
                     video_names[video_group_name] = source_video_dict['backend']['filename']
     return video_names
 
@@ -130,7 +143,7 @@ def _extract_labels(pkg_slp_file: Path) -> pd.DataFrame | None:
 
             if data:
                 metadata_ds = cast(h5py.Dataset, hdf_file['metadata'])
-                metadata_dict = json.loads(str(metadata_ds.attrs['json']))
+                metadata_dict = _decode_json_attr(metadata_ds.attrs['json'])
                 keypoints = [node['name'] for node in metadata_dict['nodes']]
                 columns = pd.MultiIndex.from_product(
                     [['lightning_tracker'], keypoints, ['x', 'y']],

--- a/lightning_pose/converters/sleap.py
+++ b/lightning_pose/converters/sleap.py
@@ -19,7 +19,7 @@ from PIL import Image
 logger = logging.getLogger(__name__)
 
 
-def _decode_json_attr(raw: bytes | str) -> dict:
+def _decode_json_attr(raw: object) -> dict:
     """Decode an h5py ``json`` attribute, which may come back as ``str`` or ``bytes``.
 
     h5py returns ``numpy.bytes_`` for fixed-length HDF5 string attributes and native ``str``

--- a/tests/converters/test_sleap.py
+++ b/tests/converters/test_sleap.py
@@ -22,15 +22,29 @@ def _make_pkg_slp(
     keypoints=('nose', 'tail'),
     include_frames=True,
     include_labels=True,
+    json_attrs_as_bytes=False,
 ):
-    """Build a minimal single-video, single-instance .pkg.slp file for testing."""
+    """Build a minimal single-video, single-instance .pkg.slp file for testing.
+
+    Args:
+        json_attrs_as_bytes: some SLEAP export versions write ``json`` attributes using a
+            fixed-length HDF5 string dtype, which h5py reads back as ``numpy.bytes_`` rather
+            than ``str``. Set this to reproduce that shape.
+    """
+    def _set_json_attr(dataset, obj):
+        encoded = json.dumps(obj)
+        if json_attrs_as_bytes:
+            dataset.attrs.create('json', data=np.bytes_(encoded.encode('utf-8')))
+        else:
+            dataset.attrs['json'] = encoded
+
     png_bytes = io.BytesIO()
     Image.new('RGB', (2, 2)).save(png_bytes, format='PNG')
     png_array = np.frombuffer(png_bytes.getvalue(), dtype=np.uint8)
 
     with h5py.File(path, 'w') as f:
         source_video = f.create_dataset('video0/source_video', data=[0])
-        source_video.attrs['json'] = json.dumps({'backend': {'filename': video_filename}})
+        _set_json_attr(source_video, {'backend': {'filename': video_filename}})
         f.create_dataset('video0/frame_numbers', data=np.array([0], dtype='i8'))
 
         if include_frames:
@@ -57,9 +71,7 @@ def _make_pkg_slp(
             f.create_dataset('instances', data=np.array([(0, 0, 2)], dtype=instances_dtype))
 
             metadata = f.create_dataset('metadata', data=[0])
-            metadata.attrs['json'] = json.dumps(
-                {'nodes': [{'name': kp} for kp in keypoints]},
-            )
+            _set_json_attr(metadata, {'nodes': [{'name': kp} for kp in keypoints]})
 
 
 class TestExtractVideoNames:
@@ -124,6 +136,21 @@ class TestExtractLabels:
         assert df.loc[
             'labeled-data/vid1/img00000000.png', ('lightning_tracker', 'tail', 'y')
         ] == 40.0
+
+    def test_extracts_keypoints_with_bytes_json_attrs(self, tmp_path):
+        # regression test: some SLEAP export versions store the `json` attribute using a
+        # fixed-length HDF5 string dtype, which h5py reads back as numpy.bytes_ rather than
+        # str; str() on that value returns its repr (e.g. "b'{...}'") instead of decoding it
+        slp_file = tmp_path / 'project.pkg.slp'
+        _make_pkg_slp(slp_file, include_frames=False, json_attrs_as_bytes=True)
+
+        df = _extract_labels(slp_file)
+
+        assert df is not None
+        assert list(df.index) == ['labeled-data/vid1/img00000000.png']
+        assert df.loc[
+            'labeled-data/vid1/img00000000.png', ('lightning_tracker', 'nose', 'x')
+        ] == 10.0
 
     def test_no_instances_returns_none(self, tmp_path):
         slp_file = tmp_path / 'project.pkg.slp'


### PR DESCRIPTION
  Root cause: in `lightning_pose/converters/sleap.py`, `_extract_labels` and `_extract_video_names` both did
  `json.loads(str(dataset.attrs['json']))`. `h5py` returns HDF5 string attributes as either native str or
  `numpy.bytes_`, depending on how the writer encoded them — this varies across SLEAP export
  versions/tools. When the attribute comes back as bytes, `str(bytes_obj)` doesn't decode it; it returns
  the Python repr (`"b'{...}'"`), which isn't valid JSON.

  Fix: added a `_decode_json_attr` helper that decodes bytes explicitly (`.decode('utf-8')`) instead of
  relying on `str()`, used at both call sites. Added a regression test
  (`test_extracts_keypoints_with_bytes_json_attrs`) that builds a `.pkg.slp` fixture with bytes-typed json
  attrs to cover this shape going forward. All 11 tests in `tests/converters/test_sleap.py` pass.