### PR TITLE
fix: sync CUDA streams before ORT io_binding input binding

### DIFF
--- a/lightning_pose/api/model_runtime.py
+++ b/lightning_pose/api/model_runtime.py
@@ -233,9 +233,10 @@ def _build_onnx_forward(session: Any) -> Any:
     )
 
     def onnx_forward(images: torch.Tensor) -> torch.Tensor:
-        images = images.to(input_torch_dtype).contiguous()
         if cuda_available and images.is_cuda:
             torch.cuda.synchronize(images.device)
+        images = images.to(input_torch_dtype).contiguous()
+        if cuda_available and images.is_cuda:
             io_binding = session.io_binding()
             device_id = images.device.index or 0
             io_binding.bind_input(

--- a/lightning_pose/api/model_runtime.py
+++ b/lightning_pose/api/model_runtime.py
@@ -235,6 +235,7 @@ def _build_onnx_forward(session: Any) -> Any:
     def onnx_forward(images: torch.Tensor) -> torch.Tensor:
         images = images.to(input_torch_dtype).contiguous()
         if cuda_available and images.is_cuda:
+            torch.cuda.synchronize(images.device)
             io_binding = session.io_binding()
             device_id = images.device.index or 0
             io_binding.bind_input(


### PR DESCRIPTION
This fix was requested in PR #480 by @themattinthehatt 
@jjaw123 filed it as #483 ruling out the ORT memory leak fix, the repeated calls hypothesis and `CUDA_LAUNCH_BLOCKING=1` masking. This PR implements the follow up fix

Closes #483 

What was wrong?
In lightning_pose/api/model_runtime.py, onnx_forward binds the input frame buffer to ORT through a raw device pointer
```    io_binding.bind_input(
        name=input_name,
        device_type="cuda",
        device_id=device_id,
        element_type=input_np_dtype,
        shape=tuple(images.shape),
        buffer_ptr=images.data_ptr(),
    ) 
```
`bind_input(buffer_ptr=...)` is zero-copy: ORT is told to read from a GPU address but it is given no info about which stream produced the bytes at that address. The DALI DALIGenericIterator returns tensors whose producing work runs on DALI's internal CUDA stream while the ORT launches its kernels on its own stream. 

**Nothing in the current code maintains ordering between the two

Under load, ORT can start reading the frame buffer before DALI has finished writing it; the garbage input produces garbage heatmaps, and the first index op downstream trips a device-side assert
`RuntimeError: CUDA error: device-side assert triggered`
`IndexKernel.cu:113: operator(): Assertion '-sizes[i] <= index && index < sizes[i] && "index out of bounds"' failed.`

This matches the IndexKernel.cu failure reported in #483 and also explains why CUDA_LAUNCH_BLOCKING=1 masks it forcing everything onto a single timeline removes the cross-stream overlap

Fix:
Inserted a device-wide barrier before binding
```if cuda_available and images.is_cuda:
        torch.cuda.synchronize(images.device)
        io_binding = session.io_binding()
        ...
```
torch.cuda.synchronize() blocks the host until every stream on the device has drained -- including DALI's internal decode stream -- so the bytes at images.data_ptr() are guaranteed to be the final and fully-decoded frame before ORT reads them

I went with the device-wide barrier rather than the tighter alternatives (CUDA event recorded on DALI's stream or the user_compute_stream provider option) because those methods need reaching into DALI's stream handle from a layer that doesn't currently expose it. The sync is cheap relative to a multiview transformer forward pass and its essentially impossible to get wrong

Testing:
- python -c "import ast; ast.parse(open('lightning_pose/api/model_runtime.py','rb').read())" syntax check passes.
- from lightning_pose.api.model_runtime import _build_onnx_forward imports cleanly.

**Note: pytest tests/ on Windows currently fails to collect in conftest.py (ffmpeg filter_complex single-quoted args aren't escaped for cmd.exe), independent of this change; same behavior on main before this patch

Improvement that might be worth considering further on:

- `bind_output` currently allocates on GPU then copy_outputs_to_cpu() pulls to host and then the caller pushes back to device. Binding output directly into a pre-allocated PyTorch GPU tensor would remove a device to host-to-device roundtrip per forward. 